### PR TITLE
feat: C_LeaveGame 테스트 코드 및 로그아웃/캐릭터변경 시스템 구현

### DIFF
--- a/DummyClientCS/Packet/ServerPacketHandler.cs
+++ b/DummyClientCS/Packet/ServerPacketHandler.cs
@@ -223,7 +223,16 @@ namespace Packet
 
         internal static void HANDLE_S_LeaveGame(PacketSession session, S_LeaveGame game)
         {
-            Console.WriteLine($"[S_LeaveGame] Game Has left.");
+            var success = game.Success;
+            var detail = game.Detail;
+            if (success)
+            {
+                Console.WriteLine($"[S_LeaveGame] Game Has left. detail : {detail}");
+            }
+            else
+            {
+                Console.WriteLine($"[S_LeaveGame Failed. detail : {detail}");
+            }
         }
 
         internal static void HANDLE_S_BroadcastMonsterDeath(PacketSession session, S_BroadcastMonsterDeath death)

--- a/DummyClientCS/Program.cs
+++ b/DummyClientCS/Program.cs
@@ -51,8 +51,12 @@ class Program
             Console.WriteLine("[i] 인벤토리 조회하기");
             Console.WriteLine("[u] 퀵슬롯 사용 (1~9)");
             Console.WriteLine("[o] 슬롯 지정 아이템 사용");
-            Console.WriteLine("\n===== 종료 로직 =====");
-            Console.WriteLine("[x] 룸에서 나가기");
+            Console.WriteLine("\n===== 종료 로직 테스트 =====");
+            Console.WriteLine("[x] 룸에서 나가기 (캐릭터 변경)");
+            Console.WriteLine("[l] 로그아웃 테스트 (JWT 인증 상태로 복귀)");
+            Console.WriteLine("[c] 캐릭터 변경 테스트");  
+            Console.WriteLine("[r] 룸 이동 테스트");
+            Console.WriteLine("[d] 연결 해제 테스트");
             Console.WriteLine("[z] 종료");
             Console.Write("선택: ");
 
@@ -297,9 +301,50 @@ class Program
                         Console.WriteLine("게임에 접속한 상태가 아닙니다!");
                         break;
                     }
-                    await SessionManager.Instance.SendForLeave();
+                    await SessionManager.Instance.SendLeaveForCharacterChange();
                     _isInGame = false;
-                    Console.WriteLine("룸에서 나갔습니다. 게임을 다시 시작하려면 8번을 눌러주세요.");
+                    Console.WriteLine("✅ 캐릭터 변경으로 룸에서 나갔습니다. 게임을 다시 시작하려면 8번을 눌러주세요.");
+                    break;
+                case "l":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("게임에 접속한 상태가 아닙니다!");
+                        break;
+                    }
+                    await SessionManager.Instance.SendLeaveForLogout();
+                    _isInGame = false;
+                    _isCharacterListLoaded = false;
+                    _isJwtVerified = false;
+                    Console.WriteLine("✅ 로그아웃 테스트 완료. JWT 인증 상태로 복귀했습니다. 다시 시작하려면 4번부터 진행하세요.");
+                    break;
+                case "c":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("게임에 접속한 상태가 아닙니다!");
+                        break;
+                    }
+                    await SessionManager.Instance.SendLeaveForCharacterChange();
+                    _isInGame = false;
+                    Console.WriteLine("✅ 캐릭터 변경 테스트 완료. 캐릭터 선택창으로 복귀했습니다. 게임을 다시 시작하려면 8번을 눌러주세요.");
+                    break;
+                case "r":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("게임에 접속한 상태가 아닙니다!");
+                        break;
+                    }
+                    await SessionManager.Instance.SendLeaveForRoomChange();
+                    Console.WriteLine("✅ 룸 이동 테스트 완료. (현재 미구현 상태)");
+                    break;
+                case "d":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("게임에 접속한 상태가 아닙니다!");
+                        break;
+                    }
+                    await SessionManager.Instance.SendLeaveForDisconnect();
+                    _isInGame = false;
+                    Console.WriteLine("✅ 연결 해제 테스트 완료. 디버그 로깅용입니다.");
                     break;
                 case "z":
                     Console.WriteLine("프로그램을 종료합니다.");

--- a/DummyClientCS/Protocol/Protocol.cs
+++ b/DummyClientCS/Protocol/Protocol.cs
@@ -41,92 +41,93 @@ namespace Google.Protobuf.Protocol {
             "YXBJZBgCIAEoBRIlCgdwbGF5ZXJzGAMgAygLMhQuUHJvdG9jb2wuUGxheWVy",
             "SW5mbyI+ChZTX0Jyb2FkY2FzdFBsYXllckVudGVyEiQKBnBsYXllchgBIAEo",
             "CzIULlByb3RvY29sLlBsYXllckluZm8iNQoLQ19MZWF2ZUdhbWUSJgoGcmVh",
-            "c29uGAEgASgOMhYuUHJvdG9jb2wuRUxlYXZlUmVhc29uIh4KC1NfTGVhdmVH",
-            "YW1lEg8KB3N1Y2Nlc3MYASABKAUiUgoWU19Ccm9hZGNhc3RQbGF5ZXJMZWF2",
-            "ZRIQCghwbGF5ZXJJZBgBIAEoBRImCgZyZWFzb24YAiABKA4yFi5Qcm90b2Nv",
-            "bC5FTGVhdmVSZWFzb24iQwoTQ19QbGF5ZXJNb3ZlUmVxdWVzdBIsCg1jbGlj",
-            "a1dvcmxkUG9zGAEgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8ivQEKEVNf",
-            "UGxheWVyTW92ZVJlcGx5EhAKCHBsYXllcklkGAEgASgFEhEKCWNsaWVudFNl",
-            "cRgCIAEoBRIlCgZyZXN1bHQYAyABKA4yFS5Qcm90b2NvbC5FTW92ZVJlc3Vs",
-            "dBIMCgR0aWNrGAQgASgFEiUKBm5ld1BvcxgFIAEoCzIVLlByb3RvY29sLlZl",
-            "Y3RvcjJJbmZvEicKCWRpcmVjdGlvbhgGIAEoDjIULlByb3RvY29sLkVEaXJl",
-            "Y3Rpb24iVAoVU19Ccm9hZGNhc3RQbGF5ZXJNb3ZlEgwKBHRpY2sYASABKAUS",
-            "LQoLcGxheWVyTW92ZXMYAiADKAsyGC5Qcm90b2NvbC5QbGF5ZXJNb3ZlSW5m",
-            "byI4ChFTX0NoYW5nZVJvb21CZWdpbhIUCgx0cmFuc2l0aW9uSWQYASABKAUS",
-            "DQoFbWFwSWQYAiABKAUiKQoRQ19DaGFuZ2VSb29tUmVhZHkSFAoMdHJhbnNp",
-            "dGlvbklkGAEgASgFImQKElNfQ2hhbmdlUm9vbUNvbW1pdBIUCgx0cmFuc2l0",
-            "aW9uSWQYASABKAUSDQoFbWFwSWQYAiABKAUSKQoJc25hcHNob3RzGAMgASgL",
-            "MhYuUHJvdG9jb2wuU19QbGF5ZXJMaXN0InMKDlNfU3Bhd25Nb25zdGVyEhEK",
-            "CW1vbnN0ZXJJZBgBIAEoBRIVCg1tb25zdGVyVHlwZUlkGAIgASgFEgkKAXgY",
-            "AyABKAUSCQoBeRgEIAEoBRIhCgNkaXIYBSABKA4yFC5Qcm90b2NvbC5FRGly",
-            "ZWN0aW9uIk8KEFNfRGVzcGF3bk1vbnN0ZXISEQoJbW9uc3RlcklkGAEgASgF",
-            "EigKBnJlYXNvbhgCIAEoDjIYLlByb3RvY29sLkVEZXNwYXduUmVhc29uImQK",
-            "FlNfQnJvYWRjYXN0TW9uc3Rlck1vdmUSEQoJbW9uc3RlcklkGAEgASgFEgkK",
-            "AXgYAiABKAUSCQoBeRgDIAEoBRIhCgNkaXIYBCABKA4yFC5Qcm90b2NvbC5F",
-            "RGlyZWN0aW9uIkAKGFNfQnJvYWRjYXN0TW9uc3RlckF0dGFjaxIRCgltb25z",
-            "dGVySWQYASABKAUSEQoJdGFyZ2V0UGlkGAIgASgFIiwKF1NfQnJvYWRjYXN0",
-            "TW9uc3RlckRlYXRoEhEKCW1vbnN0ZXJJZBgBIAEoBSIXChVDX1BsYXllckF0",
-            "dGFja1JlcXVlc3QiXgoXU19Ccm9hZGNhc3RQbGF5ZXJBdHRhY2sSEAoIcGxh",
-            "eWVySWQYASABKAUSEAoIdGFyZ2V0SWQYAiABKAUSDgoGZGFtYWdlGAMgASgF",
-            "Eg8KB2hwQWZ0ZXIYBCABKAUiFAoSQ19JbnZlbnRvcnlSZXF1ZXN0Ij4KEFNf",
-            "SW52ZW50b3J5UmVwbHkSKgoFc2xvdHMYASADKAsyGy5Qcm90b2NvbC5JbnZl",
-            "bnRvcnlTbG90SW5mbyIlChBDX0l0ZW1Vc2VSZXF1ZXN0EhEKCXNsb3RJbmRl",
-            "eBgBIAEoBSI3Cg5TX0l0ZW1Vc2VSZXBseRIPCgdzdWNjZXNzGAEgASgIEhQK",
-            "DGVycm9yTWVzc2FnZRgCIAEoCSJGChFTX0ludmVudG9yeVVwZGF0ZRIxCgxj",
-            "aGFuZ2VkU2xvdHMYASADKAsyGy5Qcm90b2NvbC5JbnZlbnRvcnlTbG90SW5m",
-            "byJICg9TX1N5c3RlbU1lc3NhZ2USDwoHbWVzc2FnZRgBIAEoCRIkCgR0eXBl",
-            "GAIgASgOMhYuUHJvdG9jb2wuRU1lc3NhZ2VUeXBlIiMKC1ZlY3RvcjJJbmZv",
-            "EgkKAXgYASABKAUSCQoBeRgCIAEoBSKZAQoOUGxheWVyTW92ZUluZm8SEAoI",
-            "cGxheWVySWQYASABKAUSJwoJZGlyZWN0aW9uGAIgASgOMhQuUHJvdG9jb2wu",
-            "RURpcmVjdGlvbhIlCgZuZXdQb3MYAyABKAsyFS5Qcm90b2NvbC5WZWN0b3Iy",
-            "SW5mbxIlCgZyZXN1bHQYBCABKA4yFS5Qcm90b2NvbC5FTW92ZVJlc3VsdCJ9",
-            "ChRDaGFyYWN0ZXJTdW1tYXJ5SW5mbxIQCgh1c2VybmFtZRgBIAEoCRINCgVs",
-            "ZXZlbBgCIAEoBRIhCgZnZW5kZXIYAyABKA4yES5Qcm90b2NvbC5FR2VuZGVy",
-            "EiEKBnJlZ2lvbhgEIAEoDjIRLlByb3RvY29sLkVSZWdpb24idwoKUGxheWVy",
-            "SW5mbxIKCgJpZBgBIAEoBRIQCgh1c2VybmFtZRgCIAEoCRIiCgNwb3MYAyAB",
-            "KAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxInCglkaXJlY3Rpb24YBCABKA4y",
-            "FC5Qcm90b2NvbC5FRGlyZWN0aW9uIloKEUludmVudG9yeVNsb3RJbmZvEhEK",
-            "CXNsb3RJbmRleBgBIAEoBRIOCgZpdGVtSWQYAiABKAUSDQoFY291bnQYAyAB",
-            "KAUSEwoLaXNRdWlja3Nsb3QYBCABKAgq8gYKBU1zZ0lkEhcKE0NfSldUX0xP",
-            "R0lOX1JFUVVFU1QQABIVChFTX0pXVF9MT0dJTl9SRVBMWRABEh4KGkNfQ1JF",
-            "QVRFX0NIQVJBQ1RFUl9SRVFVRVNUEAISHAoYU19DUkVBVEVfQ0hBUkFDVEVS",
-            "X1JFUExZEAMSHAoYQ19DSEFSQUNURVJfTElTVF9SRVFVRVNUEAQSGgoWU19D",
-            "SEFSQUNURVJfTElTVF9SRVBMWRAFEh4KGkNfREVMRVRFX0NIQVJBQ1RFUl9S",
-            "RVFVRVNUEAYSHAoYU19ERUxFVEVfQ0hBUkFDVEVSX1JFUExZEAcSEAoMQ19F",
-            "TlRFUl9HQU1FEAgSEAoMU19FTlRFUl9HQU1FEAkSEQoNU19QTEFZRVJfTElT",
-            "VBAKEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9FTlRFUhALEhAKDENfTEVBVkVf",
-            "R0FNRRAMEhAKDFNfTEVBVkVfR0FNRRANEhwKGFNfQlJPQURDQVNUX1BMQVlF",
-            "Ul9MRUFWRRAOEhkKFUNfUExBWUVSX01PVkVfUkVRVUVTVBAPEhcKE1NfUExB",
-            "WUVSX01PVkVfUkVQTFkQEBIbChdTX0JST0FEQ0FTVF9QTEFZRVJfTU9WRRAR",
-            "EhcKE1NfQ0hBTkdFX1JPT01fQkVHSU4QEhIXChNDX0NIQU5HRV9ST09NX1JF",
-            "QURZEBMSGAoUU19DSEFOR0VfUk9PTV9DT01NSVQQFBITCg9TX1NQQVdOX01P",
-            "TlNURVIQFRIVChFTX0RFU1BBV05fTU9OU1RFUhAWEhwKGFNfQlJPQURDQVNU",
-            "X01PTlNURVJfTU9WRRAXEh4KGlNfQlJPQURDQVNUX01PTlNURVJfQVRUQUNL",
-            "EBgSHQoZU19CUk9BRENBU1RfTU9OU1RFUl9ERUFUSBAZEhsKF0NfUExBWUVS",
-            "X0FUVEFDS19SRVFVRVNUEBoSHQoZU19CUk9BRENBU1RfUExBWUVSX0FUVEFD",
-            "SxAbEhcKE0NfSU5WRU5UT1JZX1JFUVVFU1QQHBIVChFTX0lOVkVOVE9SWV9S",
-            "RVBMWRAdEhYKEkNfSVRFTV9VU0VfUkVRVUVTVBAeEhQKEFNfSVRFTV9VU0Vf",
-            "UkVQTFkQHxIWChJTX0lOVkVOVE9SWV9VUERBVEUQIBIUChBTX1NZU1RFTV9N",
-            "RVNTQUdFECEqUwoMRUxvZ2luUmVzdWx0EgsKB1NVQ0NFU1MQABIRCg1JTlZB",
-            "TElEX1RPS0VOEAESEQoNVE9LRU5fRVhQSVJFRBACEhAKDFNFUlZFUl9FUlJP",
-            "UhADKj4KB0VHZW5kZXISDwoLR0VOREVSX05PTkUQABIPCgtHRU5ERVJfTUFM",
-            "RRABEhEKDUdFTkRFUl9GRU1BTEUQAio6CgdFUmVnaW9uEg8KC1JFR0lPTl9O",
-            "T05FEAASDQoJUkVHSU9OX0dPEAESDwoLUkVHSU9OX0JBQ0sQAipDCgpFRGly",
-            "ZWN0aW9uEgoKBkRJUl9VUBAAEgwKCERJUl9ET1dOEAESDAoIRElSX0xFRlQQ",
-            "AhINCglESVJfUklHSFQQAypgCgxFTGVhdmVSZWFzb24SEQoNTEVBVkVfVU5L",
-            "Tk9XThAAEhAKDExFQVZFX0xPR09VVBABEhUKEUxFQVZFX0NIQU5HRV9ST09N",
-            "EAISFAoQTEVBVkVfRElTQ09OTkVDVBADKl8KC0VNb3ZlUmVzdWx0EhAKDE1P",
-            "VkVfVU5LTk9XThAAEgsKB01PVkVfT0sQARIMCghNT1ZFX0RJUhACEhEKDU1P",
-            "VkVfQ09PTERPV04QAxIQCgxNT1ZFX0JMT0NLRUQQBCpJCgxFRW50ZXJSZWFz",
-            "b24SEQoNRU5URVJfVU5LTk9XThAAEg8KC0VOVEVSX0xPR0lOEAESFQoRRU5U",
-            "RVJfQ0hBTkdFX1JPT00QAio5Cg5FRGVzcGF3blJlYXNvbhITCg9ERVNQQVdO",
-            "X1VOS05PV04QABISCg5ERVNQQVdOX0tJTExFRBABKn4KCUVJdGVtVHlwZRIV",
-            "ChFJVEVNX1RZUEVfVU5LTk9XThAAEhgKFElURU1fVFlQRV9DT05TVU1BQkxF",
-            "EAESFwoTSVRFTV9UWVBFX0VRVUlQTUVOVBACEhMKD0lURU1fVFlQRV9RVUVT",
-            "VBADEhIKDklURU1fVFlQRV9NSVNDEAQqYQoMRU1lc3NhZ2VUeXBlEhAKDE1F",
-            "U1NBR0VfSU5GTxAAEhMKD01FU1NBR0VfV0FSTklORxABEhEKDU1FU1NBR0Vf",
-            "RVJST1IQAhIXChNNRVNTQUdFX0RST1BfRkFJTEVEEANCG6oCGEdvb2dsZS5Q",
-            "cm90b2J1Zi5Qcm90b2NvbGIGcHJvdG8z"));
+            "c29uGAEgASgOMhYuUHJvdG9jb2wuRUxlYXZlUmVhc29uIi4KC1NfTGVhdmVH",
+            "YW1lEg8KB3N1Y2Nlc3MYASABKAgSDgoGZGV0YWlsGAIgASgJIlIKFlNfQnJv",
+            "YWRjYXN0UGxheWVyTGVhdmUSEAoIcGxheWVySWQYASABKAUSJgoGcmVhc29u",
+            "GAIgASgOMhYuUHJvdG9jb2wuRUxlYXZlUmVhc29uIkMKE0NfUGxheWVyTW92",
+            "ZVJlcXVlc3QSLAoNY2xpY2tXb3JsZFBvcxgBIAEoCzIVLlByb3RvY29sLlZl",
+            "Y3RvcjJJbmZvIr0BChFTX1BsYXllck1vdmVSZXBseRIQCghwbGF5ZXJJZBgB",
+            "IAEoBRIRCgljbGllbnRTZXEYAiABKAUSJQoGcmVzdWx0GAMgASgOMhUuUHJv",
+            "dG9jb2wuRU1vdmVSZXN1bHQSDAoEdGljaxgEIAEoBRIlCgZuZXdQb3MYBSAB",
+            "KAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxInCglkaXJlY3Rpb24YBiABKA4y",
+            "FC5Qcm90b2NvbC5FRGlyZWN0aW9uIlQKFVNfQnJvYWRjYXN0UGxheWVyTW92",
+            "ZRIMCgR0aWNrGAEgASgFEi0KC3BsYXllck1vdmVzGAIgAygLMhguUHJvdG9j",
+            "b2wuUGxheWVyTW92ZUluZm8iOAoRU19DaGFuZ2VSb29tQmVnaW4SFAoMdHJh",
+            "bnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFIikKEUNfQ2hhbmdlUm9v",
+            "bVJlYWR5EhQKDHRyYW5zaXRpb25JZBgBIAEoBSJkChJTX0NoYW5nZVJvb21D",
+            "b21taXQSFAoMdHJhbnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFEikK",
+            "CXNuYXBzaG90cxgDIAEoCzIWLlByb3RvY29sLlNfUGxheWVyTGlzdCJzCg5T",
+            "X1NwYXduTW9uc3RlchIRCgltb25zdGVySWQYASABKAUSFQoNbW9uc3RlclR5",
+            "cGVJZBgCIAEoBRIJCgF4GAMgASgFEgkKAXkYBCABKAUSIQoDZGlyGAUgASgO",
+            "MhQuUHJvdG9jb2wuRURpcmVjdGlvbiJPChBTX0Rlc3Bhd25Nb25zdGVyEhEK",
+            "CW1vbnN0ZXJJZBgBIAEoBRIoCgZyZWFzb24YAiABKA4yGC5Qcm90b2NvbC5F",
+            "RGVzcGF3blJlYXNvbiJkChZTX0Jyb2FkY2FzdE1vbnN0ZXJNb3ZlEhEKCW1v",
+            "bnN0ZXJJZBgBIAEoBRIJCgF4GAIgASgFEgkKAXkYAyABKAUSIQoDZGlyGAQg",
+            "ASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiJAChhTX0Jyb2FkY2FzdE1vbnN0",
+            "ZXJBdHRhY2sSEQoJbW9uc3RlcklkGAEgASgFEhEKCXRhcmdldFBpZBgCIAEo",
+            "BSIsChdTX0Jyb2FkY2FzdE1vbnN0ZXJEZWF0aBIRCgltb25zdGVySWQYASAB",
+            "KAUiFwoVQ19QbGF5ZXJBdHRhY2tSZXF1ZXN0Il4KF1NfQnJvYWRjYXN0UGxh",
+            "eWVyQXR0YWNrEhAKCHBsYXllcklkGAEgASgFEhAKCHRhcmdldElkGAIgASgF",
+            "Eg4KBmRhbWFnZRgDIAEoBRIPCgdocEFmdGVyGAQgASgFIhQKEkNfSW52ZW50",
+            "b3J5UmVxdWVzdCI+ChBTX0ludmVudG9yeVJlcGx5EioKBXNsb3RzGAEgAygL",
+            "MhsuUHJvdG9jb2wuSW52ZW50b3J5U2xvdEluZm8iJQoQQ19JdGVtVXNlUmVx",
+            "dWVzdBIRCglzbG90SW5kZXgYASABKAUiNwoOU19JdGVtVXNlUmVwbHkSDwoH",
+            "c3VjY2VzcxgBIAEoCBIUCgxlcnJvck1lc3NhZ2UYAiABKAkiRgoRU19JbnZl",
+            "bnRvcnlVcGRhdGUSMQoMY2hhbmdlZFNsb3RzGAEgAygLMhsuUHJvdG9jb2wu",
+            "SW52ZW50b3J5U2xvdEluZm8iSAoPU19TeXN0ZW1NZXNzYWdlEg8KB21lc3Nh",
+            "Z2UYASABKAkSJAoEdHlwZRgCIAEoDjIWLlByb3RvY29sLkVNZXNzYWdlVHlw",
+            "ZSIjCgtWZWN0b3IySW5mbxIJCgF4GAEgASgFEgkKAXkYAiABKAUimQEKDlBs",
+            "YXllck1vdmVJbmZvEhAKCHBsYXllcklkGAEgASgFEicKCWRpcmVjdGlvbhgC",
+            "IAEoDjIULlByb3RvY29sLkVEaXJlY3Rpb24SJQoGbmV3UG9zGAMgASgLMhUu",
+            "UHJvdG9jb2wuVmVjdG9yMkluZm8SJQoGcmVzdWx0GAQgASgOMhUuUHJvdG9j",
+            "b2wuRU1vdmVSZXN1bHQifQoUQ2hhcmFjdGVyU3VtbWFyeUluZm8SEAoIdXNl",
+            "cm5hbWUYASABKAkSDQoFbGV2ZWwYAiABKAUSIQoGZ2VuZGVyGAMgASgOMhEu",
+            "UHJvdG9jb2wuRUdlbmRlchIhCgZyZWdpb24YBCABKA4yES5Qcm90b2NvbC5F",
+            "UmVnaW9uIncKClBsYXllckluZm8SCgoCaWQYASABKAUSEAoIdXNlcm5hbWUY",
+            "AiABKAkSIgoDcG9zGAMgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8SJwoJ",
+            "ZGlyZWN0aW9uGAQgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiJaChFJbnZl",
+            "bnRvcnlTbG90SW5mbxIRCglzbG90SW5kZXgYASABKAUSDgoGaXRlbUlkGAIg",
+            "ASgFEg0KBWNvdW50GAMgASgFEhMKC2lzUXVpY2tzbG90GAQgASgIKvIGCgVN",
+            "c2dJZBIXChNDX0pXVF9MT0dJTl9SRVFVRVNUEAASFQoRU19KV1RfTE9HSU5f",
+            "UkVQTFkQARIeChpDX0NSRUFURV9DSEFSQUNURVJfUkVRVUVTVBACEhwKGFNf",
+            "Q1JFQVRFX0NIQVJBQ1RFUl9SRVBMWRADEhwKGENfQ0hBUkFDVEVSX0xJU1Rf",
+            "UkVRVUVTVBAEEhoKFlNfQ0hBUkFDVEVSX0xJU1RfUkVQTFkQBRIeChpDX0RF",
+            "TEVURV9DSEFSQUNURVJfUkVRVUVTVBAGEhwKGFNfREVMRVRFX0NIQVJBQ1RF",
+            "Ul9SRVBMWRAHEhAKDENfRU5URVJfR0FNRRAIEhAKDFNfRU5URVJfR0FNRRAJ",
+            "EhEKDVNfUExBWUVSX0xJU1QQChIcChhTX0JST0FEQ0FTVF9QTEFZRVJfRU5U",
+            "RVIQCxIQCgxDX0xFQVZFX0dBTUUQDBIQCgxTX0xFQVZFX0dBTUUQDRIcChhT",
+            "X0JST0FEQ0FTVF9QTEFZRVJfTEVBVkUQDhIZChVDX1BMQVlFUl9NT1ZFX1JF",
+            "UVVFU1QQDxIXChNTX1BMQVlFUl9NT1ZFX1JFUExZEBASGwoXU19CUk9BRENB",
+            "U1RfUExBWUVSX01PVkUQERIXChNTX0NIQU5HRV9ST09NX0JFR0lOEBISFwoT",
+            "Q19DSEFOR0VfUk9PTV9SRUFEWRATEhgKFFNfQ0hBTkdFX1JPT01fQ09NTUlU",
+            "EBQSEwoPU19TUEFXTl9NT05TVEVSEBUSFQoRU19ERVNQQVdOX01PTlNURVIQ",
+            "FhIcChhTX0JST0FEQ0FTVF9NT05TVEVSX01PVkUQFxIeChpTX0JST0FEQ0FT",
+            "VF9NT05TVEVSX0FUVEFDSxAYEh0KGVNfQlJPQURDQVNUX01PTlNURVJfREVB",
+            "VEgQGRIbChdDX1BMQVlFUl9BVFRBQ0tfUkVRVUVTVBAaEh0KGVNfQlJPQURD",
+            "QVNUX1BMQVlFUl9BVFRBQ0sQGxIXChNDX0lOVkVOVE9SWV9SRVFVRVNUEBwS",
+            "FQoRU19JTlZFTlRPUllfUkVQTFkQHRIWChJDX0lURU1fVVNFX1JFUVVFU1QQ",
+            "HhIUChBTX0lURU1fVVNFX1JFUExZEB8SFgoSU19JTlZFTlRPUllfVVBEQVRF",
+            "ECASFAoQU19TWVNURU1fTUVTU0FHRRAhKlMKDEVMb2dpblJlc3VsdBILCgdT",
+            "VUNDRVNTEAASEQoNSU5WQUxJRF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQ",
+            "AhIQCgxTRVJWRVJfRVJST1IQAyo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05F",
+            "EAASDwoLR0VOREVSX01BTEUQARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJl",
+            "Z2lvbhIPCgtSRUdJT05fTk9ORRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lP",
+            "Tl9CQUNLEAIqQwoKRURpcmVjdGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9X",
+            "ThABEgwKCERJUl9MRUZUEAISDQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVh",
+            "c29uEhEKDUxFQVZFX1VOS05PV04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFM",
+            "RUFWRV9DSEFOR0VfUk9PTRACEhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQ",
+            "AxIUChBMRUFWRV9ESVNDT05ORUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9W",
+            "RV9VTktOT1dOEAASCwoHTU9WRV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9W",
+            "RV9DT09MRE9XThADEhAKDE1PVkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNv",
+            "bhIRCg1FTlRFUl9VTktOT1dOEAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRF",
+            "Ul9DSEFOR0VfUk9PTRACKjkKDkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05f",
+            "VU5LTk9XThAAEhIKDkRFU1BBV05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUK",
+            "EUlURU1fVFlQRV9VTktOT1dOEAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQ",
+            "ARIXChNJVEVNX1RZUEVfRVFVSVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNU",
+            "EAMSEgoOSVRFTV9UWVBFX01JU0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVT",
+            "U0FHRV9JTkZPEAASEwoPTUVTU0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9F",
+            "UlJPUhACEhcKE01FU1NBR0VfRFJPUF9GQUlMRUQQA0IbqgIYR29vZ2xlLlBy",
+            "b3RvYnVmLlByb3RvY29sYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -143,7 +144,7 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_PlayerList), global::Google.Protobuf.Protocol.S_PlayerList.Parser, new[]{ "MyPlayerId", "MapId", "Players" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerEnter), global::Google.Protobuf.Protocol.S_BroadcastPlayerEnter.Parser, new[]{ "Player" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_LeaveGame), global::Google.Protobuf.Protocol.C_LeaveGame.Parser, new[]{ "Reason" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_LeaveGame), global::Google.Protobuf.Protocol.S_LeaveGame.Parser, new[]{ "Success" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_LeaveGame), global::Google.Protobuf.Protocol.S_LeaveGame.Parser, new[]{ "Success", "Detail" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerLeave), global::Google.Protobuf.Protocol.S_BroadcastPlayerLeave.Parser, new[]{ "PlayerId", "Reason" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_PlayerMoveRequest), global::Google.Protobuf.Protocol.C_PlayerMoveRequest.Parser, new[]{ "ClickWorldPos" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_PlayerMoveReply), global::Google.Protobuf.Protocol.S_PlayerMoveReply.Parser, new[]{ "PlayerId", "ClientSeq", "Result", "Tick", "NewPos", "Direction" }, null, null, null, null),
@@ -241,7 +242,7 @@ namespace Google.Protobuf.Protocol {
   public enum ELeaveReason {
     [pbr::OriginalName("LEAVE_UNKNOWN")] LeaveUnknown = 0,
     /// <summary>
-    /// 게임종료
+    /// 로그아웃 -> Jwt 로그인 인증 상태로 (세션 초기화)
     /// </summary>
     [pbr::OriginalName("LEAVE_LOGOUT")] LeaveLogout = 1,
     /// <summary>
@@ -249,9 +250,13 @@ namespace Google.Protobuf.Protocol {
     /// </summary>
     [pbr::OriginalName("LEAVE_CHANGE_ROOM")] LeaveChangeRoom = 2,
     /// <summary>
+    /// 캐릭터 변경 -> 세션은 유지하고 캐릭터 선택으로 변경
+    /// </summary>
+    [pbr::OriginalName("LEAVE_CHANGE_CHARACTER")] LeaveChangeCharacter = 3,
+    /// <summary>
     /// 네트워크 끊김
     /// </summary>
-    [pbr::OriginalName("LEAVE_DISCONNECT")] LeaveDisconnect = 3,
+    [pbr::OriginalName("LEAVE_DISCONNECT")] LeaveDisconnect = 4,
   }
 
   public enum EMoveResult {
@@ -3015,6 +3020,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public S_LeaveGame(S_LeaveGame other) : this() {
       success_ = other.success_;
+      detail_ = other.detail_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -3026,13 +3032,25 @@ namespace Google.Protobuf.Protocol {
 
     /// <summary>Field number for the "success" field.</summary>
     public const int SuccessFieldNumber = 1;
-    private int success_;
+    private bool success_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Success {
+    public bool Success {
       get { return success_; }
       set {
         success_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "detail" field.</summary>
+    public const int DetailFieldNumber = 2;
+    private string detail_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Detail {
+      get { return detail_; }
+      set {
+        detail_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -3052,6 +3070,7 @@ namespace Google.Protobuf.Protocol {
         return true;
       }
       if (Success != other.Success) return false;
+      if (Detail != other.Detail) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -3059,7 +3078,8 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
-      if (Success != 0) hash ^= Success.GetHashCode();
+      if (Success != false) hash ^= Success.GetHashCode();
+      if (Detail.Length != 0) hash ^= Detail.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -3078,9 +3098,13 @@ namespace Google.Protobuf.Protocol {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (Success != 0) {
+      if (Success != false) {
         output.WriteRawTag(8);
-        output.WriteInt32(Success);
+        output.WriteBool(Success);
+      }
+      if (Detail.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Detail);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
@@ -3092,9 +3116,13 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Success != 0) {
+      if (Success != false) {
         output.WriteRawTag(8);
-        output.WriteInt32(Success);
+        output.WriteBool(Success);
+      }
+      if (Detail.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Detail);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
@@ -3106,8 +3134,11 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
-      if (Success != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Success);
+      if (Success != false) {
+        size += 1 + 1;
+      }
+      if (Detail.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Detail);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -3121,8 +3152,11 @@ namespace Google.Protobuf.Protocol {
       if (other == null) {
         return;
       }
-      if (other.Success != 0) {
+      if (other.Success != false) {
         Success = other.Success;
+      }
+      if (other.Detail.Length != 0) {
+        Detail = other.Detail;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -3140,7 +3174,11 @@ namespace Google.Protobuf.Protocol {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 8: {
-            Success = input.ReadInt32();
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            Detail = input.ReadString();
             break;
           }
         }
@@ -3159,7 +3197,11 @@ namespace Google.Protobuf.Protocol {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
           case 8: {
-            Success = input.ReadInt32();
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            Detail = input.ReadString();
             break;
           }
         }

--- a/DummyClientCS/SessionManager.cs
+++ b/DummyClientCS/SessionManager.cs
@@ -164,11 +164,54 @@ namespace DummyClientCS
                 {
                     var pkt = new Google.Protobuf.Protocol.C_LeaveGame
                     {
-                        Reason = 0
+                        Reason = Google.Protobuf.Protocol.ELeaveReason.LeaveChangeCharacter // 기본값: 캐릭터 변경
                     };
                     session.Send(ServerPacketManager.MakeSendBuffer(pkt));
                 }
             }
+        }
+
+        // 다양한 종료 사유별 테스트 메소드들
+        public async Task SendLeaveGameWithReason(Google.Protobuf.Protocol.ELeaveReason reason)
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_LeaveGame
+                    {
+                        Reason = reason
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.WriteLine($"📤 C_LeaveGame 패킷 전송됨 - 사유: {reason}");
+                }
+            }
+        }
+
+        // 로그아웃 (JWT 인증 상태로 복귀)
+        public async Task SendLeaveForLogout()
+        {
+            await SendLeaveGameWithReason(Google.Protobuf.Protocol.ELeaveReason.LeaveLogout);
+        }
+
+        // 캐릭터 변경 (캐릭터 선택창으로 복귀) 
+        public async Task SendLeaveForCharacterChange()
+        {
+            await SendLeaveGameWithReason(Google.Protobuf.Protocol.ELeaveReason.LeaveChangeCharacter);
+        }
+
+        // 룸 이동
+        public async Task SendLeaveForRoomChange()
+        {
+            await SendLeaveGameWithReason(Google.Protobuf.Protocol.ELeaveReason.LeaveChangeRoom);
+        }
+
+        // 연결 해제
+        public async Task SendLeaveForDisconnect()
+        {
+            await SendLeaveGameWithReason(Google.Protobuf.Protocol.ELeaveReason.LeaveDisconnect);
         }
 
         public async Task SendForEachAttack()

--- a/GameServer/ClientPacketHandler.cpp
+++ b/GameServer/ClientPacketHandler.cpp
@@ -40,6 +40,8 @@ bool Handle_C_JwtLoginRequest(PacketSessionRef& session, Protocol::C_JwtLoginReq
 		auto fut = AccountRepository::UpsertAccountAsync(userId);
 	}
 
+	gameSession->SetState(GameSession::State::InGame);
+
 	Protocol::S_JwtLoginReply replyPkt;
 	replyPkt.set_result(eLoginResult);
 	auto sendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
@@ -246,14 +248,27 @@ bool Handle_C_LeaveGame(PacketSessionRef& session, Protocol::C_LeaveGame& pkt)
 
 	RoomRef room = player->GetRoom();
 
-	room->DoAsync(&Room::Leave, player);
-	
-	player->SaveInventoryToDB(); // DB에 인벤토리 저장
-
-	GConsoleLogger->WriteStdOut(Color::GREEN, L"[C_LeaveGame]: Client가 Room에서 나감 \n");
+	bool result = false;
+	string detail = "";
+	switch (pkt.reason())
+	{
+		case Protocol::ELeaveReason::LEAVE_LOGOUT:
+			result = gameSession->Logout(OUT detail); 
+			break;
+		case Protocol::ELeaveReason::LEAVE_CHANGE_CHARACTER:
+			result = gameSession->CharacterSelect(OUT detail);
+			break; 
+		case Protocol::ELeaveReason::LEAVE_CHANGE_ROOM:// 클라가 직접 요청을 보낼때 이 항목은 사용하지 않음
+			break;
+		case Protocol::ELeaveReason::LEAVE_DISCONNECT: // 클라가 직접 요청을 보낼때 이 항목은 사용하지 않음
+		default:
+			GConsoleLogger->WriteStdOut(Color::GREEN, L"Change Room and disconnect is not used in C_LeaveGame"); 
+			break;
+	}
 	
 	Protocol::S_LeaveGame leaveGamePkt;
-	leaveGamePkt.set_success(true);
+	leaveGamePkt.set_success(result);
+	leaveGamePkt.set_detail(detail);
 	auto sendBuffer = ClientPacketHandler::MakeSendBuffer(leaveGamePkt);
 	session->Send(sendBuffer);
 	return true;

--- a/GameServer/GameSession.cpp
+++ b/GameServer/GameSession.cpp
@@ -14,17 +14,11 @@ void GameSession::OnDisconnected()
 {
 	if (GetState() == State::InRoom && _currentPlayer)
 	{
-		CharacterRepository::CharacterStat stat;
-		_currentPlayer->GetCharacterStat(stat);
-		CharacterRepository::UpdateCharacterStatsAsync(stat); // 연결종료 시, Stats 저장
-		_currentPlayer->SaveInventoryToDB(); // 연결 종료시, DB 저장
-		
 		RoomRef room = _currentPlayer->GetRoom();
-		room->DoAsync(&Room::Leave, _currentPlayer);
+		room->DoAsync(&Room::Leave, _currentPlayer); // 여기서 데이터 저장
 	}
-	_gameSessionContainer->Remove(static_pointer_cast<GameSession>(shared_from_this()));
 
-	// 여기서 룸 Leave 체크
+	_gameSessionContainer->Remove(static_pointer_cast<GameSession>(shared_from_this()));
 
 	SetState(State::Disconnected);
 }
@@ -43,4 +37,67 @@ void GameSession::OnRecvPacket(BYTE* buffer, int32 len)
 void GameSession::OnSend(int32 len)
 {
 
+}
+
+bool GameSession::Logout(OUT std::string& detailOut)
+{
+	// 현재 상태 확인, InRoom 또는 InGame 상태에서만 리셋 가능
+	auto currentState = GetState();
+	if (currentState != State::InGame && currentState != State::InRoom)
+	{
+		GConsoleLogger->WriteStdOut(Color::RED, L"[WARNING] ResetSession: 잘못된 상태 - %d\n", (int)GetState());
+		detailOut = "InRoom or InGame 상태가 아니므로 로그아웃 불가능";
+		return false;
+	}
+
+	// 현재 플레이어가 있다면 데이터 저장 및 룸에서 제거
+	if (_currentPlayer != nullptr)
+	{
+		// 룸에서 플레이어 제거
+		RoomRef room = _currentPlayer->GetRoom();
+		if (room != nullptr)
+		{
+			room->DoAsync(&Room::Leave, _currentPlayer); // 여기서 데이터 저장
+		}
+	}
+
+	// Jwt 인증 전 상태로 만들기
+	SetState(State::Connected);
+
+	_players.clear();
+	_currentPlayer = nullptr;
+	_account = nullptr;
+
+	GConsoleLogger->WriteStdOut(Color::GREEN, L"[INFO] GameSession Reset 완료 - JWT 로그인 창으로 복귀\n");
+	detailOut = "Logout 성공";
+
+	return true;
+}
+
+bool GameSession::CharacterSelect(OUT std::string& detailOut)
+{
+	// 룸 일때만 가능
+	auto currentState = GetState();
+	if (currentState != State::InRoom)
+	{
+		GConsoleLogger->WriteStdOut(Color::RED, L"[WARNING] ResetSession: 잘못된 상태 - %d\n", (int)GetState());
+		detailOut = "InRoom 상태가 아니므로 캐릭터 선택창 이동 불가능";
+	}
+
+	// 현재 플레이어가 있다면 데이터 저장 및 룸에서 제거
+	if (_currentPlayer != nullptr)
+	{
+		// 룸에서 플레이어 제거
+		RoomRef room = _currentPlayer->GetRoom();
+		if (room != nullptr)
+		{
+			room->DoAsync(&Room::Leave, _currentPlayer); // 여기서 데이터 저장
+		}
+	}
+
+	SetState(State::InGame); // 캐릭터 선택을 해야하는 상태로 만들기
+	_currentPlayer = nullptr; 
+	detailOut = "Character Select 성공!";
+
+	return true;
 }

--- a/GameServer/GameSession.h
+++ b/GameServer/GameSession.h
@@ -21,6 +21,12 @@ public:
 	virtual void OnDisconnected() override;
 	virtual void OnRecvPacket(BYTE* buffer, int32 len) override;
 	virtual void OnSend(int32 len) override;
+public:
+	// make to JWT Login State
+	bool Logout(OUT std::string& detailOut);
+
+	// make to character Select
+	bool CharacterSelect(OUT std::string& detailOut);
 
 private:
 	GameSessionContainerRef _gameSessionContainer;

--- a/GameServer/Player.cpp
+++ b/GameServer/Player.cpp
@@ -29,6 +29,16 @@ void Player::LoadCharacterStat(const CharacterRepository::CharacterStat& stat)
 	SetExp(stat.exp);
 }
 
+std::future<void> Player::SaveCharacterToDB()
+{
+	GConsoleLogger->WriteStdOut(Color::YELLOW, L"SaveCharacterToDB 실행");
+	CharacterRepository::CharacterStat stat;
+	GetCharacterStat(stat);
+	CharacterRepository::UpdateCharacterStatsAsync(stat); // 연결종료 시, Stats 저장
+	auto fut = SaveInventoryToDB(); // 연결 종료시, DB 저장
+	return fut;
+}
+
 std::future<void> Player::LoadInventoryFromDB()
 {
 	int characterId = static_cast<int>(playerId);

--- a/GameServer/Player.h
+++ b/GameServer/Player.h
@@ -152,6 +152,7 @@ private:
 public:
 	void GetCharacterStat(CharacterRepository::CharacterStat& outStat) const;
 	void LoadCharacterStat(const CharacterRepository::CharacterStat& stat);
+	std::future<void> SaveCharacterToDB();
 
 /*---------------------------------
 	Player Room Transitioning Data

--- a/GameServer/Protocol.pb.cc
+++ b/GameServer/Protocol.pb.cc
@@ -196,7 +196,8 @@ struct C_LeaveGameDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 C_LeaveGameDefaultTypeInternal _C_LeaveGame_default_instance_;
 PROTOBUF_CONSTEXPR S_LeaveGame::S_LeaveGame(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.success_)*/0
+    /*decltype(_impl_.detail_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.success_)*/false
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct S_LeaveGameDefaultTypeInternal {
   PROTOBUF_CONSTEXPR S_LeaveGameDefaultTypeInternal()
@@ -674,6 +675,7 @@ const uint32_t TableStruct_Protocol_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::Protocol::S_LeaveGame, _impl_.success_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_LeaveGame, _impl_.detail_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::Protocol::S_BroadcastPlayerLeave, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -900,31 +902,31 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 82, -1, -1, sizeof(::Protocol::S_BroadcastPlayerEnter)},
   { 89, -1, -1, sizeof(::Protocol::C_LeaveGame)},
   { 96, -1, -1, sizeof(::Protocol::S_LeaveGame)},
-  { 103, -1, -1, sizeof(::Protocol::S_BroadcastPlayerLeave)},
-  { 111, -1, -1, sizeof(::Protocol::C_PlayerMoveRequest)},
-  { 118, -1, -1, sizeof(::Protocol::S_PlayerMoveReply)},
-  { 130, -1, -1, sizeof(::Protocol::S_BroadcastPlayerMove)},
-  { 138, -1, -1, sizeof(::Protocol::S_ChangeRoomBegin)},
-  { 146, -1, -1, sizeof(::Protocol::C_ChangeRoomReady)},
-  { 153, -1, -1, sizeof(::Protocol::S_ChangeRoomCommit)},
-  { 162, -1, -1, sizeof(::Protocol::S_SpawnMonster)},
-  { 173, -1, -1, sizeof(::Protocol::S_DespawnMonster)},
-  { 181, -1, -1, sizeof(::Protocol::S_BroadcastMonsterMove)},
-  { 191, -1, -1, sizeof(::Protocol::S_BroadcastMonsterAttack)},
-  { 199, -1, -1, sizeof(::Protocol::S_BroadcastMonsterDeath)},
-  { 206, -1, -1, sizeof(::Protocol::C_PlayerAttackRequest)},
-  { 212, -1, -1, sizeof(::Protocol::S_BroadcastPlayerAttack)},
-  { 222, -1, -1, sizeof(::Protocol::C_InventoryRequest)},
-  { 228, -1, -1, sizeof(::Protocol::S_InventoryReply)},
-  { 235, -1, -1, sizeof(::Protocol::C_ItemUseRequest)},
-  { 242, -1, -1, sizeof(::Protocol::S_ItemUseReply)},
-  { 250, -1, -1, sizeof(::Protocol::S_InventoryUpdate)},
-  { 257, -1, -1, sizeof(::Protocol::S_SystemMessage)},
-  { 265, -1, -1, sizeof(::Protocol::Vector2Info)},
-  { 273, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
-  { 283, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
-  { 293, -1, -1, sizeof(::Protocol::PlayerInfo)},
-  { 303, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
+  { 104, -1, -1, sizeof(::Protocol::S_BroadcastPlayerLeave)},
+  { 112, -1, -1, sizeof(::Protocol::C_PlayerMoveRequest)},
+  { 119, -1, -1, sizeof(::Protocol::S_PlayerMoveReply)},
+  { 131, -1, -1, sizeof(::Protocol::S_BroadcastPlayerMove)},
+  { 139, -1, -1, sizeof(::Protocol::S_ChangeRoomBegin)},
+  { 147, -1, -1, sizeof(::Protocol::C_ChangeRoomReady)},
+  { 154, -1, -1, sizeof(::Protocol::S_ChangeRoomCommit)},
+  { 163, -1, -1, sizeof(::Protocol::S_SpawnMonster)},
+  { 174, -1, -1, sizeof(::Protocol::S_DespawnMonster)},
+  { 182, -1, -1, sizeof(::Protocol::S_BroadcastMonsterMove)},
+  { 192, -1, -1, sizeof(::Protocol::S_BroadcastMonsterAttack)},
+  { 200, -1, -1, sizeof(::Protocol::S_BroadcastMonsterDeath)},
+  { 207, -1, -1, sizeof(::Protocol::C_PlayerAttackRequest)},
+  { 213, -1, -1, sizeof(::Protocol::S_BroadcastPlayerAttack)},
+  { 223, -1, -1, sizeof(::Protocol::C_InventoryRequest)},
+  { 229, -1, -1, sizeof(::Protocol::S_InventoryReply)},
+  { 236, -1, -1, sizeof(::Protocol::C_ItemUseRequest)},
+  { 243, -1, -1, sizeof(::Protocol::S_ItemUseReply)},
+  { 251, -1, -1, sizeof(::Protocol::S_InventoryUpdate)},
+  { 258, -1, -1, sizeof(::Protocol::S_SystemMessage)},
+  { 266, -1, -1, sizeof(::Protocol::Vector2Info)},
+  { 274, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
+  { 284, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
+  { 294, -1, -1, sizeof(::Protocol::PlayerInfo)},
+  { 304, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -989,107 +991,108 @@ const char descriptor_table_protodef_Protocol_2eproto[] PROTOBUF_SECTION_VARIABL
   "\022%\n\007players\030\003 \003(\0132\024.Protocol.PlayerInfo\""
   ">\n\026S_BroadcastPlayerEnter\022$\n\006player\030\001 \001("
   "\0132\024.Protocol.PlayerInfo\"5\n\013C_LeaveGame\022&"
-  "\n\006reason\030\001 \001(\0162\026.Protocol.ELeaveReason\"\036"
-  "\n\013S_LeaveGame\022\017\n\007success\030\001 \001(\005\"R\n\026S_Broa"
-  "dcastPlayerLeave\022\020\n\010playerId\030\001 \001(\005\022&\n\006re"
-  "ason\030\002 \001(\0162\026.Protocol.ELeaveReason\"C\n\023C_"
-  "PlayerMoveRequest\022,\n\rclickWorldPos\030\001 \001(\013"
-  "2\025.Protocol.Vector2Info\"\275\001\n\021S_PlayerMove"
-  "Reply\022\020\n\010playerId\030\001 \001(\005\022\021\n\tclientSeq\030\002 \001"
-  "(\005\022%\n\006result\030\003 \001(\0162\025.Protocol.EMoveResul"
-  "t\022\014\n\004tick\030\004 \001(\005\022%\n\006newPos\030\005 \001(\0132\025.Protoc"
-  "ol.Vector2Info\022\'\n\tdirection\030\006 \001(\0162\024.Prot"
-  "ocol.EDirection\"T\n\025S_BroadcastPlayerMove"
-  "\022\014\n\004tick\030\001 \001(\005\022-\n\013playerMoves\030\002 \003(\0132\030.Pr"
-  "otocol.PlayerMoveInfo\"8\n\021S_ChangeRoomBeg"
-  "in\022\024\n\014transitionId\030\001 \001(\005\022\r\n\005mapId\030\002 \001(\005\""
-  ")\n\021C_ChangeRoomReady\022\024\n\014transitionId\030\001 \001"
-  "(\005\"d\n\022S_ChangeRoomCommit\022\024\n\014transitionId"
-  "\030\001 \001(\005\022\r\n\005mapId\030\002 \001(\005\022)\n\tsnapshots\030\003 \001(\013"
-  "2\026.Protocol.S_PlayerList\"s\n\016S_SpawnMonst"
-  "er\022\021\n\tmonsterId\030\001 \001(\005\022\025\n\rmonsterTypeId\030\002"
-  " \001(\005\022\t\n\001x\030\003 \001(\005\022\t\n\001y\030\004 \001(\005\022!\n\003dir\030\005 \001(\0162"
-  "\024.Protocol.EDirection\"O\n\020S_DespawnMonste"
-  "r\022\021\n\tmonsterId\030\001 \001(\005\022(\n\006reason\030\002 \001(\0162\030.P"
-  "rotocol.EDespawnReason\"d\n\026S_BroadcastMon"
-  "sterMove\022\021\n\tmonsterId\030\001 \001(\005\022\t\n\001x\030\002 \001(\005\022\t"
-  "\n\001y\030\003 \001(\005\022!\n\003dir\030\004 \001(\0162\024.Protocol.EDirec"
-  "tion\"@\n\030S_BroadcastMonsterAttack\022\021\n\tmons"
-  "terId\030\001 \001(\005\022\021\n\ttargetPid\030\002 \001(\005\",\n\027S_Broa"
-  "dcastMonsterDeath\022\021\n\tmonsterId\030\001 \001(\005\"\027\n\025"
-  "C_PlayerAttackRequest\"^\n\027S_BroadcastPlay"
-  "erAttack\022\020\n\010playerId\030\001 \001(\005\022\020\n\010targetId\030\002"
-  " \001(\005\022\016\n\006damage\030\003 \001(\005\022\017\n\007hpAfter\030\004 \001(\005\"\024\n"
-  "\022C_InventoryRequest\">\n\020S_InventoryReply\022"
-  "*\n\005slots\030\001 \003(\0132\033.Protocol.InventorySlotI"
-  "nfo\"%\n\020C_ItemUseRequest\022\021\n\tslotIndex\030\001 \001"
-  "(\005\"7\n\016S_ItemUseReply\022\017\n\007success\030\001 \001(\010\022\024\n"
-  "\014errorMessage\030\002 \001(\t\"F\n\021S_InventoryUpdate"
-  "\0221\n\014changedSlots\030\001 \003(\0132\033.Protocol.Invent"
-  "orySlotInfo\"H\n\017S_SystemMessage\022\017\n\007messag"
-  "e\030\001 \001(\t\022$\n\004type\030\002 \001(\0162\026.Protocol.EMessag"
-  "eType\"#\n\013Vector2Info\022\t\n\001x\030\001 \001(\005\022\t\n\001y\030\002 \001"
-  "(\005\"\231\001\n\016PlayerMoveInfo\022\020\n\010playerId\030\001 \001(\005\022"
-  "\'\n\tdirection\030\002 \001(\0162\024.Protocol.EDirection"
-  "\022%\n\006newPos\030\003 \001(\0132\025.Protocol.Vector2Info\022"
-  "%\n\006result\030\004 \001(\0162\025.Protocol.EMoveResult\"}"
-  "\n\024CharacterSummaryInfo\022\020\n\010username\030\001 \001(\t"
-  "\022\r\n\005level\030\002 \001(\005\022!\n\006gender\030\003 \001(\0162\021.Protoc"
-  "ol.EGender\022!\n\006region\030\004 \001(\0162\021.Protocol.ER"
-  "egion\"w\n\nPlayerInfo\022\n\n\002id\030\001 \001(\005\022\020\n\010usern"
-  "ame\030\002 \001(\t\022\"\n\003pos\030\003 \001(\0132\025.Protocol.Vector"
-  "2Info\022\'\n\tdirection\030\004 \001(\0162\024.Protocol.EDir"
-  "ection\"Z\n\021InventorySlotInfo\022\021\n\tslotIndex"
-  "\030\001 \001(\005\022\016\n\006itemId\030\002 \001(\005\022\r\n\005count\030\003 \001(\005\022\023\n"
-  "\013isQuickslot\030\004 \001(\010*\362\006\n\005MsgId\022\027\n\023C_JWT_LO"
-  "GIN_REQUEST\020\000\022\025\n\021S_JWT_LOGIN_REPLY\020\001\022\036\n\032"
-  "C_CREATE_CHARACTER_REQUEST\020\002\022\034\n\030S_CREATE"
-  "_CHARACTER_REPLY\020\003\022\034\n\030C_CHARACTER_LIST_R"
-  "EQUEST\020\004\022\032\n\026S_CHARACTER_LIST_REPLY\020\005\022\036\n\032"
-  "C_DELETE_CHARACTER_REQUEST\020\006\022\034\n\030S_DELETE"
-  "_CHARACTER_REPLY\020\007\022\020\n\014C_ENTER_GAME\020\010\022\020\n\014"
-  "S_ENTER_GAME\020\t\022\021\n\rS_PLAYER_LIST\020\n\022\034\n\030S_B"
-  "ROADCAST_PLAYER_ENTER\020\013\022\020\n\014C_LEAVE_GAME\020"
-  "\014\022\020\n\014S_LEAVE_GAME\020\r\022\034\n\030S_BROADCAST_PLAYE"
-  "R_LEAVE\020\016\022\031\n\025C_PLAYER_MOVE_REQUEST\020\017\022\027\n\023"
-  "S_PLAYER_MOVE_REPLY\020\020\022\033\n\027S_BROADCAST_PLA"
-  "YER_MOVE\020\021\022\027\n\023S_CHANGE_ROOM_BEGIN\020\022\022\027\n\023C"
-  "_CHANGE_ROOM_READY\020\023\022\030\n\024S_CHANGE_ROOM_CO"
-  "MMIT\020\024\022\023\n\017S_SPAWN_MONSTER\020\025\022\025\n\021S_DESPAWN"
-  "_MONSTER\020\026\022\034\n\030S_BROADCAST_MONSTER_MOVE\020\027"
-  "\022\036\n\032S_BROADCAST_MONSTER_ATTACK\020\030\022\035\n\031S_BR"
-  "OADCAST_MONSTER_DEATH\020\031\022\033\n\027C_PLAYER_ATTA"
-  "CK_REQUEST\020\032\022\035\n\031S_BROADCAST_PLAYER_ATTAC"
-  "K\020\033\022\027\n\023C_INVENTORY_REQUEST\020\034\022\025\n\021S_INVENT"
-  "ORY_REPLY\020\035\022\026\n\022C_ITEM_USE_REQUEST\020\036\022\024\n\020S"
-  "_ITEM_USE_REPLY\020\037\022\026\n\022S_INVENTORY_UPDATE\020"
-  " \022\024\n\020S_SYSTEM_MESSAGE\020!*S\n\014ELoginResult\022"
-  "\013\n\007SUCCESS\020\000\022\021\n\rINVALID_TOKEN\020\001\022\021\n\rTOKEN"
-  "_EXPIRED\020\002\022\020\n\014SERVER_ERROR\020\003*>\n\007EGender\022"
-  "\017\n\013GENDER_NONE\020\000\022\017\n\013GENDER_MALE\020\001\022\021\n\rGEN"
-  "DER_FEMALE\020\002*:\n\007ERegion\022\017\n\013REGION_NONE\020\000"
-  "\022\r\n\tREGION_GO\020\001\022\017\n\013REGION_BACK\020\002*C\n\nEDir"
-  "ection\022\n\n\006DIR_UP\020\000\022\014\n\010DIR_DOWN\020\001\022\014\n\010DIR_"
-  "LEFT\020\002\022\r\n\tDIR_RIGHT\020\003*`\n\014ELeaveReason\022\021\n"
-  "\rLEAVE_UNKNOWN\020\000\022\020\n\014LEAVE_LOGOUT\020\001\022\025\n\021LE"
-  "AVE_CHANGE_ROOM\020\002\022\024\n\020LEAVE_DISCONNECT\020\003*"
-  "_\n\013EMoveResult\022\020\n\014MOVE_UNKNOWN\020\000\022\013\n\007MOVE"
-  "_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_COOLDOWN\020\003\022\020"
-  "\n\014MOVE_BLOCKED\020\004*I\n\014EEnterReason\022\021\n\rENTE"
-  "R_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022\025\n\021ENTER_CH"
-  "ANGE_ROOM\020\002*9\n\016EDespawnReason\022\023\n\017DESPAWN"
-  "_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020\001*~\n\tEItemT"
-  "ype\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n\024ITEM_TYPE_"
-  "CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQUIPMENT\020\002\022\023\n"
-  "\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TYPE_MISC\020\004*a"
-  "\n\014EMessageType\022\020\n\014MESSAGE_INFO\020\000\022\023\n\017MESS"
-  "AGE_WARNING\020\001\022\021\n\rMESSAGE_ERROR\020\002\022\027\n\023MESS"
-  "AGE_DROP_FAILED\020\003B\033\252\002\030Google.Protobuf.Pr"
-  "otocolb\006proto3"
+  "\n\006reason\030\001 \001(\0162\026.Protocol.ELeaveReason\"."
+  "\n\013S_LeaveGame\022\017\n\007success\030\001 \001(\010\022\016\n\006detail"
+  "\030\002 \001(\t\"R\n\026S_BroadcastPlayerLeave\022\020\n\010play"
+  "erId\030\001 \001(\005\022&\n\006reason\030\002 \001(\0162\026.Protocol.EL"
+  "eaveReason\"C\n\023C_PlayerMoveRequest\022,\n\rcli"
+  "ckWorldPos\030\001 \001(\0132\025.Protocol.Vector2Info\""
+  "\275\001\n\021S_PlayerMoveReply\022\020\n\010playerId\030\001 \001(\005\022"
+  "\021\n\tclientSeq\030\002 \001(\005\022%\n\006result\030\003 \001(\0162\025.Pro"
+  "tocol.EMoveResult\022\014\n\004tick\030\004 \001(\005\022%\n\006newPo"
+  "s\030\005 \001(\0132\025.Protocol.Vector2Info\022\'\n\tdirect"
+  "ion\030\006 \001(\0162\024.Protocol.EDirection\"T\n\025S_Bro"
+  "adcastPlayerMove\022\014\n\004tick\030\001 \001(\005\022-\n\013player"
+  "Moves\030\002 \003(\0132\030.Protocol.PlayerMoveInfo\"8\n"
+  "\021S_ChangeRoomBegin\022\024\n\014transitionId\030\001 \001(\005"
+  "\022\r\n\005mapId\030\002 \001(\005\")\n\021C_ChangeRoomReady\022\024\n\014"
+  "transitionId\030\001 \001(\005\"d\n\022S_ChangeRoomCommit"
+  "\022\024\n\014transitionId\030\001 \001(\005\022\r\n\005mapId\030\002 \001(\005\022)\n"
+  "\tsnapshots\030\003 \001(\0132\026.Protocol.S_PlayerList"
+  "\"s\n\016S_SpawnMonster\022\021\n\tmonsterId\030\001 \001(\005\022\025\n"
+  "\rmonsterTypeId\030\002 \001(\005\022\t\n\001x\030\003 \001(\005\022\t\n\001y\030\004 \001"
+  "(\005\022!\n\003dir\030\005 \001(\0162\024.Protocol.EDirection\"O\n"
+  "\020S_DespawnMonster\022\021\n\tmonsterId\030\001 \001(\005\022(\n\006"
+  "reason\030\002 \001(\0162\030.Protocol.EDespawnReason\"d"
+  "\n\026S_BroadcastMonsterMove\022\021\n\tmonsterId\030\001 "
+  "\001(\005\022\t\n\001x\030\002 \001(\005\022\t\n\001y\030\003 \001(\005\022!\n\003dir\030\004 \001(\0162\024"
+  ".Protocol.EDirection\"@\n\030S_BroadcastMonst"
+  "erAttack\022\021\n\tmonsterId\030\001 \001(\005\022\021\n\ttargetPid"
+  "\030\002 \001(\005\",\n\027S_BroadcastMonsterDeath\022\021\n\tmon"
+  "sterId\030\001 \001(\005\"\027\n\025C_PlayerAttackRequest\"^\n"
+  "\027S_BroadcastPlayerAttack\022\020\n\010playerId\030\001 \001"
+  "(\005\022\020\n\010targetId\030\002 \001(\005\022\016\n\006damage\030\003 \001(\005\022\017\n\007"
+  "hpAfter\030\004 \001(\005\"\024\n\022C_InventoryRequest\">\n\020S"
+  "_InventoryReply\022*\n\005slots\030\001 \003(\0132\033.Protoco"
+  "l.InventorySlotInfo\"%\n\020C_ItemUseRequest\022"
+  "\021\n\tslotIndex\030\001 \001(\005\"7\n\016S_ItemUseReply\022\017\n\007"
+  "success\030\001 \001(\010\022\024\n\014errorMessage\030\002 \001(\t\"F\n\021S"
+  "_InventoryUpdate\0221\n\014changedSlots\030\001 \003(\0132\033"
+  ".Protocol.InventorySlotInfo\"H\n\017S_SystemM"
+  "essage\022\017\n\007message\030\001 \001(\t\022$\n\004type\030\002 \001(\0162\026."
+  "Protocol.EMessageType\"#\n\013Vector2Info\022\t\n\001"
+  "x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\"\231\001\n\016PlayerMoveInfo\022\020\n"
+  "\010playerId\030\001 \001(\005\022\'\n\tdirection\030\002 \001(\0162\024.Pro"
+  "tocol.EDirection\022%\n\006newPos\030\003 \001(\0132\025.Proto"
+  "col.Vector2Info\022%\n\006result\030\004 \001(\0162\025.Protoc"
+  "ol.EMoveResult\"}\n\024CharacterSummaryInfo\022\020"
+  "\n\010username\030\001 \001(\t\022\r\n\005level\030\002 \001(\005\022!\n\006gende"
+  "r\030\003 \001(\0162\021.Protocol.EGender\022!\n\006region\030\004 \001"
+  "(\0162\021.Protocol.ERegion\"w\n\nPlayerInfo\022\n\n\002i"
+  "d\030\001 \001(\005\022\020\n\010username\030\002 \001(\t\022\"\n\003pos\030\003 \001(\0132\025"
+  ".Protocol.Vector2Info\022\'\n\tdirection\030\004 \001(\016"
+  "2\024.Protocol.EDirection\"Z\n\021InventorySlotI"
+  "nfo\022\021\n\tslotIndex\030\001 \001(\005\022\016\n\006itemId\030\002 \001(\005\022\r"
+  "\n\005count\030\003 \001(\005\022\023\n\013isQuickslot\030\004 \001(\010*\362\006\n\005M"
+  "sgId\022\027\n\023C_JWT_LOGIN_REQUEST\020\000\022\025\n\021S_JWT_L"
+  "OGIN_REPLY\020\001\022\036\n\032C_CREATE_CHARACTER_REQUE"
+  "ST\020\002\022\034\n\030S_CREATE_CHARACTER_REPLY\020\003\022\034\n\030C_"
+  "CHARACTER_LIST_REQUEST\020\004\022\032\n\026S_CHARACTER_"
+  "LIST_REPLY\020\005\022\036\n\032C_DELETE_CHARACTER_REQUE"
+  "ST\020\006\022\034\n\030S_DELETE_CHARACTER_REPLY\020\007\022\020\n\014C_"
+  "ENTER_GAME\020\010\022\020\n\014S_ENTER_GAME\020\t\022\021\n\rS_PLAY"
+  "ER_LIST\020\n\022\034\n\030S_BROADCAST_PLAYER_ENTER\020\013\022"
+  "\020\n\014C_LEAVE_GAME\020\014\022\020\n\014S_LEAVE_GAME\020\r\022\034\n\030S"
+  "_BROADCAST_PLAYER_LEAVE\020\016\022\031\n\025C_PLAYER_MO"
+  "VE_REQUEST\020\017\022\027\n\023S_PLAYER_MOVE_REPLY\020\020\022\033\n"
+  "\027S_BROADCAST_PLAYER_MOVE\020\021\022\027\n\023S_CHANGE_R"
+  "OOM_BEGIN\020\022\022\027\n\023C_CHANGE_ROOM_READY\020\023\022\030\n\024"
+  "S_CHANGE_ROOM_COMMIT\020\024\022\023\n\017S_SPAWN_MONSTE"
+  "R\020\025\022\025\n\021S_DESPAWN_MONSTER\020\026\022\034\n\030S_BROADCAS"
+  "T_MONSTER_MOVE\020\027\022\036\n\032S_BROADCAST_MONSTER_"
+  "ATTACK\020\030\022\035\n\031S_BROADCAST_MONSTER_DEATH\020\031\022"
+  "\033\n\027C_PLAYER_ATTACK_REQUEST\020\032\022\035\n\031S_BROADC"
+  "AST_PLAYER_ATTACK\020\033\022\027\n\023C_INVENTORY_REQUE"
+  "ST\020\034\022\025\n\021S_INVENTORY_REPLY\020\035\022\026\n\022C_ITEM_US"
+  "E_REQUEST\020\036\022\024\n\020S_ITEM_USE_REPLY\020\037\022\026\n\022S_I"
+  "NVENTORY_UPDATE\020 \022\024\n\020S_SYSTEM_MESSAGE\020!*"
+  "S\n\014ELoginResult\022\013\n\007SUCCESS\020\000\022\021\n\rINVALID_"
+  "TOKEN\020\001\022\021\n\rTOKEN_EXPIRED\020\002\022\020\n\014SERVER_ERR"
+  "OR\020\003*>\n\007EGender\022\017\n\013GENDER_NONE\020\000\022\017\n\013GEND"
+  "ER_MALE\020\001\022\021\n\rGENDER_FEMALE\020\002*:\n\007ERegion\022"
+  "\017\n\013REGION_NONE\020\000\022\r\n\tREGION_GO\020\001\022\017\n\013REGIO"
+  "N_BACK\020\002*C\n\nEDirection\022\n\n\006DIR_UP\020\000\022\014\n\010DI"
+  "R_DOWN\020\001\022\014\n\010DIR_LEFT\020\002\022\r\n\tDIR_RIGHT\020\003*|\n"
+  "\014ELeaveReason\022\021\n\rLEAVE_UNKNOWN\020\000\022\020\n\014LEAV"
+  "E_LOGOUT\020\001\022\025\n\021LEAVE_CHANGE_ROOM\020\002\022\032\n\026LEA"
+  "VE_CHANGE_CHARACTER\020\003\022\024\n\020LEAVE_DISCONNEC"
+  "T\020\004*_\n\013EMoveResult\022\020\n\014MOVE_UNKNOWN\020\000\022\013\n\007"
+  "MOVE_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_COOLDOWN"
+  "\020\003\022\020\n\014MOVE_BLOCKED\020\004*I\n\014EEnterReason\022\021\n\r"
+  "ENTER_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022\025\n\021ENTE"
+  "R_CHANGE_ROOM\020\002*9\n\016EDespawnReason\022\023\n\017DES"
+  "PAWN_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020\001*~\n\tEI"
+  "temType\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n\024ITEM_T"
+  "YPE_CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQUIPMENT\020"
+  "\002\022\023\n\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TYPE_MISC"
+  "\020\004*a\n\014EMessageType\022\020\n\014MESSAGE_INFO\020\000\022\023\n\017"
+  "MESSAGE_WARNING\020\001\022\021\n\rMESSAGE_ERROR\020\002\022\027\n\023"
+  "MESSAGE_DROP_FAILED\020\003B\033\252\002\030Google.Protobu"
+  "f.Protocolb\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_Protocol_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_Protocol_2eproto = {
-    false, false, 4614, descriptor_table_protodef_Protocol_2eproto,
+    false, false, 4658, descriptor_table_protodef_Protocol_2eproto,
     "Protocol.proto",
     &descriptor_table_Protocol_2eproto_once, nullptr, 0, 39,
     schemas, file_default_instances, TableStruct_Protocol_2eproto::offsets,
@@ -1221,6 +1224,7 @@ bool ELeaveReason_IsValid(int value) {
     case 1:
     case 2:
     case 3:
+    case 4:
       return true;
     default:
       return false;
@@ -3814,10 +3818,19 @@ S_LeaveGame::S_LeaveGame(const S_LeaveGame& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   S_LeaveGame* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.success_){}
+      decltype(_impl_.detail_){}
+    , decltype(_impl_.success_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.detail_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.detail_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_detail().empty()) {
+    _this->_impl_.detail_.Set(from._internal_detail(), 
+      _this->GetArenaForAllocation());
+  }
   _this->_impl_.success_ = from._impl_.success_;
   // @@protoc_insertion_point(copy_constructor:Protocol.S_LeaveGame)
 }
@@ -3827,9 +3840,14 @@ inline void S_LeaveGame::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.success_){0}
+      decltype(_impl_.detail_){}
+    , decltype(_impl_.success_){false}
     , /*decltype(_impl_._cached_size_)*/{}
   };
+  _impl_.detail_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.detail_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
 S_LeaveGame::~S_LeaveGame() {
@@ -3843,6 +3861,7 @@ S_LeaveGame::~S_LeaveGame() {
 
 inline void S_LeaveGame::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.detail_.Destroy();
 }
 
 void S_LeaveGame::SetCachedSize(int size) const {
@@ -3855,7 +3874,8 @@ void S_LeaveGame::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  _impl_.success_ = 0;
+  _impl_.detail_.ClearToEmpty();
+  _impl_.success_ = false;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -3865,11 +3885,21 @@ const char* S_LeaveGame::_InternalParse(const char* ptr, ::_pbi::ParseContext* c
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // int32 success = 1;
+      // bool success = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
-          _impl_.success_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          _impl_.success_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // string detail = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_detail();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "Protocol.S_LeaveGame.detail"));
         } else
           goto handle_unusual;
         continue;
@@ -3902,10 +3932,20 @@ uint8_t* S_LeaveGame::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // int32 success = 1;
+  // bool success = 1;
   if (this->_internal_success() != 0) {
     target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteInt32ToArray(1, this->_internal_success(), target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(1, this->_internal_success(), target);
+  }
+
+  // string detail = 2;
+  if (!this->_internal_detail().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_detail().data(), static_cast<int>(this->_internal_detail().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "Protocol.S_LeaveGame.detail");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_detail(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -3924,9 +3964,16 @@ size_t S_LeaveGame::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // int32 success = 1;
+  // string detail = 2;
+  if (!this->_internal_detail().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_detail());
+  }
+
+  // bool success = 1;
   if (this->_internal_success() != 0) {
-    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_success());
+    total_size += 1 + 1;
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
@@ -3947,6 +3994,9 @@ void S_LeaveGame::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PR
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (!from._internal_detail().empty()) {
+    _this->_internal_set_detail(from._internal_detail());
+  }
   if (from._internal_success() != 0) {
     _this->_internal_set_success(from._internal_success());
   }
@@ -3966,7 +4016,13 @@ bool S_LeaveGame::IsInitialized() const {
 
 void S_LeaveGame::InternalSwap(S_LeaveGame* other) {
   using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.detail_, lhs_arena,
+      &other->_impl_.detail_, rhs_arena
+  );
   swap(_impl_.success_, other->_impl_.success_);
 }
 

--- a/GameServer/Protocol.pb.h
+++ b/GameServer/Protocol.pb.h
@@ -375,7 +375,8 @@ enum ELeaveReason : int {
   LEAVE_UNKNOWN = 0,
   LEAVE_LOGOUT = 1,
   LEAVE_CHANGE_ROOM = 2,
-  LEAVE_DISCONNECT = 3,
+  LEAVE_CHANGE_CHARACTER = 3,
+  LEAVE_DISCONNECT = 4,
   ELeaveReason_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
   ELeaveReason_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
 };
@@ -2662,15 +2663,30 @@ class S_LeaveGame final :
   // accessors -------------------------------------------------------
 
   enum : int {
+    kDetailFieldNumber = 2,
     kSuccessFieldNumber = 1,
   };
-  // int32 success = 1;
-  void clear_success();
-  int32_t success() const;
-  void set_success(int32_t value);
+  // string detail = 2;
+  void clear_detail();
+  const std::string& detail() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_detail(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_detail();
+  PROTOBUF_NODISCARD std::string* release_detail();
+  void set_allocated_detail(std::string* detail);
   private:
-  int32_t _internal_success() const;
-  void _internal_set_success(int32_t value);
+  const std::string& _internal_detail() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_detail(const std::string& value);
+  std::string* _internal_mutable_detail();
+  public:
+
+  // bool success = 1;
+  void clear_success();
+  bool success() const;
+  void set_success(bool value);
+  private:
+  bool _internal_success() const;
+  void _internal_set_success(bool value);
   public:
 
   // @@protoc_insertion_point(class_scope:Protocol.S_LeaveGame)
@@ -2681,7 +2697,8 @@ class S_LeaveGame final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    int32_t success_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr detail_;
+    bool success_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -7479,24 +7496,74 @@ inline void C_LeaveGame::set_reason(::Protocol::ELeaveReason value) {
 
 // S_LeaveGame
 
-// int32 success = 1;
+// bool success = 1;
 inline void S_LeaveGame::clear_success() {
-  _impl_.success_ = 0;
+  _impl_.success_ = false;
 }
-inline int32_t S_LeaveGame::_internal_success() const {
+inline bool S_LeaveGame::_internal_success() const {
   return _impl_.success_;
 }
-inline int32_t S_LeaveGame::success() const {
+inline bool S_LeaveGame::success() const {
   // @@protoc_insertion_point(field_get:Protocol.S_LeaveGame.success)
   return _internal_success();
 }
-inline void S_LeaveGame::_internal_set_success(int32_t value) {
+inline void S_LeaveGame::_internal_set_success(bool value) {
   
   _impl_.success_ = value;
 }
-inline void S_LeaveGame::set_success(int32_t value) {
+inline void S_LeaveGame::set_success(bool value) {
   _internal_set_success(value);
   // @@protoc_insertion_point(field_set:Protocol.S_LeaveGame.success)
+}
+
+// string detail = 2;
+inline void S_LeaveGame::clear_detail() {
+  _impl_.detail_.ClearToEmpty();
+}
+inline const std::string& S_LeaveGame::detail() const {
+  // @@protoc_insertion_point(field_get:Protocol.S_LeaveGame.detail)
+  return _internal_detail();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void S_LeaveGame::set_detail(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.detail_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:Protocol.S_LeaveGame.detail)
+}
+inline std::string* S_LeaveGame::mutable_detail() {
+  std::string* _s = _internal_mutable_detail();
+  // @@protoc_insertion_point(field_mutable:Protocol.S_LeaveGame.detail)
+  return _s;
+}
+inline const std::string& S_LeaveGame::_internal_detail() const {
+  return _impl_.detail_.Get();
+}
+inline void S_LeaveGame::_internal_set_detail(const std::string& value) {
+  
+  _impl_.detail_.Set(value, GetArenaForAllocation());
+}
+inline std::string* S_LeaveGame::_internal_mutable_detail() {
+  
+  return _impl_.detail_.Mutable(GetArenaForAllocation());
+}
+inline std::string* S_LeaveGame::release_detail() {
+  // @@protoc_insertion_point(field_release:Protocol.S_LeaveGame.detail)
+  return _impl_.detail_.Release();
+}
+inline void S_LeaveGame::set_allocated_detail(std::string* detail) {
+  if (detail != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.detail_.SetAllocated(detail, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.detail_.IsDefault()) {
+    _impl_.detail_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:Protocol.S_LeaveGame.detail)
 }
 
 // -------------------------------------------------------------------

--- a/GameServer/Room.cpp
+++ b/GameServer/Room.cpp
@@ -35,9 +35,7 @@ void Room::SaveAllActivePlayers()
     // Active 구현을 해야하지만 일단은 모든 플레이어 대상으로
     for (auto& [pid, p] : _players)
     {
-        CharacterRepository::CharacterStat stat;  // 스택에 한 번만 생성
-        p->GetCharacterStat(stat);  // 복사 없이 직접 할당
-        CharacterRepository::UpdateCharacterStatsAsync(stat); // const& 전달
+        p->SaveCharacterToDB();
     }
 
     DoTimer(_cfg.periodicSaveTicksMs, &Room::SaveAllActivePlayers);
@@ -160,6 +158,10 @@ void Room::Enter(PlayerRef p)
 
 void Room::Leave(PlayerRef p)
 {
+    // 데이터 저장
+    auto fut = p->SaveCharacterToDB();
+    fut.get();
+
     RemovePlayerInternal(p->playerId, "Leave");
     GConsoleLogger->WriteStdOut(Color::GREEN, L"Room에서 Leave 퇴장\n");
 	OnLeave(p); // 여기서 모두에게 BroadCasting?
@@ -473,9 +475,7 @@ void Room::ChangeRoomReady(const PlayerRef& p, const Protocol::C_ChangeRoomReady
             *commit.mutable_snapshots() = dst->BuildPlayerListSnapshot(p, /*includeSelf=*/true);
             
             // DB에 저장
-            CharacterRepository::CharacterStat stat;  // 스택에 한 번만 생성
-            p->GetCharacterStat(stat);  // 복사 없이 직접 할당
-            CharacterRepository::UpdateCharacterStatsAsync(stat); // const& 전달
+            p->SaveCharacterToDB();
 
             if (auto s = p->ownerSession.lock())
             {

--- a/Protocol/Protocol.proto
+++ b/Protocol/Protocol.proto
@@ -128,7 +128,8 @@ message C_LeaveGame
 // (11)
 message S_LeaveGame
 {
-	int32 success = 1;
+	bool success = 1;
+	string detail = 2;
 }
 
 // (12)
@@ -292,9 +293,10 @@ enum EDirection
 enum ELeaveReason
 {
 	LEAVE_UNKNOWN = 0;
-	LEAVE_LOGOUT = 1; // 게임종료
+	LEAVE_LOGOUT = 1; // 로그아웃 -> Jwt 로그인 인증 상태로 (세션 초기화)
 	LEAVE_CHANGE_ROOM = 2; // 룸 이동
-	LEAVE_DISCONNECT = 3; // 네트워크 끊김
+	LEAVE_CHANGE_CHARACTER = 3; // 캐릭터 변경 -> 세션은 유지하고 캐릭터 선택으로 변경
+	LEAVE_DISCONNECT = 4; // 네트워크 끊김
 }
 
 enum EMoveResult

--- a/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
+++ b/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
@@ -41,92 +41,93 @@ namespace Google.Protobuf.Protocol {
             "YXBJZBgCIAEoBRIlCgdwbGF5ZXJzGAMgAygLMhQuUHJvdG9jb2wuUGxheWVy",
             "SW5mbyI+ChZTX0Jyb2FkY2FzdFBsYXllckVudGVyEiQKBnBsYXllchgBIAEo",
             "CzIULlByb3RvY29sLlBsYXllckluZm8iNQoLQ19MZWF2ZUdhbWUSJgoGcmVh",
-            "c29uGAEgASgOMhYuUHJvdG9jb2wuRUxlYXZlUmVhc29uIh4KC1NfTGVhdmVH",
-            "YW1lEg8KB3N1Y2Nlc3MYASABKAUiUgoWU19Ccm9hZGNhc3RQbGF5ZXJMZWF2",
-            "ZRIQCghwbGF5ZXJJZBgBIAEoBRImCgZyZWFzb24YAiABKA4yFi5Qcm90b2Nv",
-            "bC5FTGVhdmVSZWFzb24iQwoTQ19QbGF5ZXJNb3ZlUmVxdWVzdBIsCg1jbGlj",
-            "a1dvcmxkUG9zGAEgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8ivQEKEVNf",
-            "UGxheWVyTW92ZVJlcGx5EhAKCHBsYXllcklkGAEgASgFEhEKCWNsaWVudFNl",
-            "cRgCIAEoBRIlCgZyZXN1bHQYAyABKA4yFS5Qcm90b2NvbC5FTW92ZVJlc3Vs",
-            "dBIMCgR0aWNrGAQgASgFEiUKBm5ld1BvcxgFIAEoCzIVLlByb3RvY29sLlZl",
-            "Y3RvcjJJbmZvEicKCWRpcmVjdGlvbhgGIAEoDjIULlByb3RvY29sLkVEaXJl",
-            "Y3Rpb24iVAoVU19Ccm9hZGNhc3RQbGF5ZXJNb3ZlEgwKBHRpY2sYASABKAUS",
-            "LQoLcGxheWVyTW92ZXMYAiADKAsyGC5Qcm90b2NvbC5QbGF5ZXJNb3ZlSW5m",
-            "byI4ChFTX0NoYW5nZVJvb21CZWdpbhIUCgx0cmFuc2l0aW9uSWQYASABKAUS",
-            "DQoFbWFwSWQYAiABKAUiKQoRQ19DaGFuZ2VSb29tUmVhZHkSFAoMdHJhbnNp",
-            "dGlvbklkGAEgASgFImQKElNfQ2hhbmdlUm9vbUNvbW1pdBIUCgx0cmFuc2l0",
-            "aW9uSWQYASABKAUSDQoFbWFwSWQYAiABKAUSKQoJc25hcHNob3RzGAMgASgL",
-            "MhYuUHJvdG9jb2wuU19QbGF5ZXJMaXN0InMKDlNfU3Bhd25Nb25zdGVyEhEK",
-            "CW1vbnN0ZXJJZBgBIAEoBRIVCg1tb25zdGVyVHlwZUlkGAIgASgFEgkKAXgY",
-            "AyABKAUSCQoBeRgEIAEoBRIhCgNkaXIYBSABKA4yFC5Qcm90b2NvbC5FRGly",
-            "ZWN0aW9uIk8KEFNfRGVzcGF3bk1vbnN0ZXISEQoJbW9uc3RlcklkGAEgASgF",
-            "EigKBnJlYXNvbhgCIAEoDjIYLlByb3RvY29sLkVEZXNwYXduUmVhc29uImQK",
-            "FlNfQnJvYWRjYXN0TW9uc3Rlck1vdmUSEQoJbW9uc3RlcklkGAEgASgFEgkK",
-            "AXgYAiABKAUSCQoBeRgDIAEoBRIhCgNkaXIYBCABKA4yFC5Qcm90b2NvbC5F",
-            "RGlyZWN0aW9uIkAKGFNfQnJvYWRjYXN0TW9uc3RlckF0dGFjaxIRCgltb25z",
-            "dGVySWQYASABKAUSEQoJdGFyZ2V0UGlkGAIgASgFIiwKF1NfQnJvYWRjYXN0",
-            "TW9uc3RlckRlYXRoEhEKCW1vbnN0ZXJJZBgBIAEoBSIXChVDX1BsYXllckF0",
-            "dGFja1JlcXVlc3QiXgoXU19Ccm9hZGNhc3RQbGF5ZXJBdHRhY2sSEAoIcGxh",
-            "eWVySWQYASABKAUSEAoIdGFyZ2V0SWQYAiABKAUSDgoGZGFtYWdlGAMgASgF",
-            "Eg8KB2hwQWZ0ZXIYBCABKAUiFAoSQ19JbnZlbnRvcnlSZXF1ZXN0Ij4KEFNf",
-            "SW52ZW50b3J5UmVwbHkSKgoFc2xvdHMYASADKAsyGy5Qcm90b2NvbC5JbnZl",
-            "bnRvcnlTbG90SW5mbyIlChBDX0l0ZW1Vc2VSZXF1ZXN0EhEKCXNsb3RJbmRl",
-            "eBgBIAEoBSI3Cg5TX0l0ZW1Vc2VSZXBseRIPCgdzdWNjZXNzGAEgASgIEhQK",
-            "DGVycm9yTWVzc2FnZRgCIAEoCSJGChFTX0ludmVudG9yeVVwZGF0ZRIxCgxj",
-            "aGFuZ2VkU2xvdHMYASADKAsyGy5Qcm90b2NvbC5JbnZlbnRvcnlTbG90SW5m",
-            "byJICg9TX1N5c3RlbU1lc3NhZ2USDwoHbWVzc2FnZRgBIAEoCRIkCgR0eXBl",
-            "GAIgASgOMhYuUHJvdG9jb2wuRU1lc3NhZ2VUeXBlIiMKC1ZlY3RvcjJJbmZv",
-            "EgkKAXgYASABKAUSCQoBeRgCIAEoBSKZAQoOUGxheWVyTW92ZUluZm8SEAoI",
-            "cGxheWVySWQYASABKAUSJwoJZGlyZWN0aW9uGAIgASgOMhQuUHJvdG9jb2wu",
-            "RURpcmVjdGlvbhIlCgZuZXdQb3MYAyABKAsyFS5Qcm90b2NvbC5WZWN0b3Iy",
-            "SW5mbxIlCgZyZXN1bHQYBCABKA4yFS5Qcm90b2NvbC5FTW92ZVJlc3VsdCJ9",
-            "ChRDaGFyYWN0ZXJTdW1tYXJ5SW5mbxIQCgh1c2VybmFtZRgBIAEoCRINCgVs",
-            "ZXZlbBgCIAEoBRIhCgZnZW5kZXIYAyABKA4yES5Qcm90b2NvbC5FR2VuZGVy",
-            "EiEKBnJlZ2lvbhgEIAEoDjIRLlByb3RvY29sLkVSZWdpb24idwoKUGxheWVy",
-            "SW5mbxIKCgJpZBgBIAEoBRIQCgh1c2VybmFtZRgCIAEoCRIiCgNwb3MYAyAB",
-            "KAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxInCglkaXJlY3Rpb24YBCABKA4y",
-            "FC5Qcm90b2NvbC5FRGlyZWN0aW9uIloKEUludmVudG9yeVNsb3RJbmZvEhEK",
-            "CXNsb3RJbmRleBgBIAEoBRIOCgZpdGVtSWQYAiABKAUSDQoFY291bnQYAyAB",
-            "KAUSEwoLaXNRdWlja3Nsb3QYBCABKAgq8gYKBU1zZ0lkEhcKE0NfSldUX0xP",
-            "R0lOX1JFUVVFU1QQABIVChFTX0pXVF9MT0dJTl9SRVBMWRABEh4KGkNfQ1JF",
-            "QVRFX0NIQVJBQ1RFUl9SRVFVRVNUEAISHAoYU19DUkVBVEVfQ0hBUkFDVEVS",
-            "X1JFUExZEAMSHAoYQ19DSEFSQUNURVJfTElTVF9SRVFVRVNUEAQSGgoWU19D",
-            "SEFSQUNURVJfTElTVF9SRVBMWRAFEh4KGkNfREVMRVRFX0NIQVJBQ1RFUl9S",
-            "RVFVRVNUEAYSHAoYU19ERUxFVEVfQ0hBUkFDVEVSX1JFUExZEAcSEAoMQ19F",
-            "TlRFUl9HQU1FEAgSEAoMU19FTlRFUl9HQU1FEAkSEQoNU19QTEFZRVJfTElT",
-            "VBAKEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9FTlRFUhALEhAKDENfTEVBVkVf",
-            "R0FNRRAMEhAKDFNfTEVBVkVfR0FNRRANEhwKGFNfQlJPQURDQVNUX1BMQVlF",
-            "Ul9MRUFWRRAOEhkKFUNfUExBWUVSX01PVkVfUkVRVUVTVBAPEhcKE1NfUExB",
-            "WUVSX01PVkVfUkVQTFkQEBIbChdTX0JST0FEQ0FTVF9QTEFZRVJfTU9WRRAR",
-            "EhcKE1NfQ0hBTkdFX1JPT01fQkVHSU4QEhIXChNDX0NIQU5HRV9ST09NX1JF",
-            "QURZEBMSGAoUU19DSEFOR0VfUk9PTV9DT01NSVQQFBITCg9TX1NQQVdOX01P",
-            "TlNURVIQFRIVChFTX0RFU1BBV05fTU9OU1RFUhAWEhwKGFNfQlJPQURDQVNU",
-            "X01PTlNURVJfTU9WRRAXEh4KGlNfQlJPQURDQVNUX01PTlNURVJfQVRUQUNL",
-            "EBgSHQoZU19CUk9BRENBU1RfTU9OU1RFUl9ERUFUSBAZEhsKF0NfUExBWUVS",
-            "X0FUVEFDS19SRVFVRVNUEBoSHQoZU19CUk9BRENBU1RfUExBWUVSX0FUVEFD",
-            "SxAbEhcKE0NfSU5WRU5UT1JZX1JFUVVFU1QQHBIVChFTX0lOVkVOVE9SWV9S",
-            "RVBMWRAdEhYKEkNfSVRFTV9VU0VfUkVRVUVTVBAeEhQKEFNfSVRFTV9VU0Vf",
-            "UkVQTFkQHxIWChJTX0lOVkVOVE9SWV9VUERBVEUQIBIUChBTX1NZU1RFTV9N",
-            "RVNTQUdFECEqUwoMRUxvZ2luUmVzdWx0EgsKB1NVQ0NFU1MQABIRCg1JTlZB",
-            "TElEX1RPS0VOEAESEQoNVE9LRU5fRVhQSVJFRBACEhAKDFNFUlZFUl9FUlJP",
-            "UhADKj4KB0VHZW5kZXISDwoLR0VOREVSX05PTkUQABIPCgtHRU5ERVJfTUFM",
-            "RRABEhEKDUdFTkRFUl9GRU1BTEUQAio6CgdFUmVnaW9uEg8KC1JFR0lPTl9O",
-            "T05FEAASDQoJUkVHSU9OX0dPEAESDwoLUkVHSU9OX0JBQ0sQAipDCgpFRGly",
-            "ZWN0aW9uEgoKBkRJUl9VUBAAEgwKCERJUl9ET1dOEAESDAoIRElSX0xFRlQQ",
-            "AhINCglESVJfUklHSFQQAypgCgxFTGVhdmVSZWFzb24SEQoNTEVBVkVfVU5L",
-            "Tk9XThAAEhAKDExFQVZFX0xPR09VVBABEhUKEUxFQVZFX0NIQU5HRV9ST09N",
-            "EAISFAoQTEVBVkVfRElTQ09OTkVDVBADKl8KC0VNb3ZlUmVzdWx0EhAKDE1P",
-            "VkVfVU5LTk9XThAAEgsKB01PVkVfT0sQARIMCghNT1ZFX0RJUhACEhEKDU1P",
-            "VkVfQ09PTERPV04QAxIQCgxNT1ZFX0JMT0NLRUQQBCpJCgxFRW50ZXJSZWFz",
-            "b24SEQoNRU5URVJfVU5LTk9XThAAEg8KC0VOVEVSX0xPR0lOEAESFQoRRU5U",
-            "RVJfQ0hBTkdFX1JPT00QAio5Cg5FRGVzcGF3blJlYXNvbhITCg9ERVNQQVdO",
-            "X1VOS05PV04QABISCg5ERVNQQVdOX0tJTExFRBABKn4KCUVJdGVtVHlwZRIV",
-            "ChFJVEVNX1RZUEVfVU5LTk9XThAAEhgKFElURU1fVFlQRV9DT05TVU1BQkxF",
-            "EAESFwoTSVRFTV9UWVBFX0VRVUlQTUVOVBACEhMKD0lURU1fVFlQRV9RVUVT",
-            "VBADEhIKDklURU1fVFlQRV9NSVNDEAQqYQoMRU1lc3NhZ2VUeXBlEhAKDE1F",
-            "U1NBR0VfSU5GTxAAEhMKD01FU1NBR0VfV0FSTklORxABEhEKDU1FU1NBR0Vf",
-            "RVJST1IQAhIXChNNRVNTQUdFX0RST1BfRkFJTEVEEANCG6oCGEdvb2dsZS5Q",
-            "cm90b2J1Zi5Qcm90b2NvbGIGcHJvdG8z"));
+            "c29uGAEgASgOMhYuUHJvdG9jb2wuRUxlYXZlUmVhc29uIi4KC1NfTGVhdmVH",
+            "YW1lEg8KB3N1Y2Nlc3MYASABKAgSDgoGZGV0YWlsGAIgASgJIlIKFlNfQnJv",
+            "YWRjYXN0UGxheWVyTGVhdmUSEAoIcGxheWVySWQYASABKAUSJgoGcmVhc29u",
+            "GAIgASgOMhYuUHJvdG9jb2wuRUxlYXZlUmVhc29uIkMKE0NfUGxheWVyTW92",
+            "ZVJlcXVlc3QSLAoNY2xpY2tXb3JsZFBvcxgBIAEoCzIVLlByb3RvY29sLlZl",
+            "Y3RvcjJJbmZvIr0BChFTX1BsYXllck1vdmVSZXBseRIQCghwbGF5ZXJJZBgB",
+            "IAEoBRIRCgljbGllbnRTZXEYAiABKAUSJQoGcmVzdWx0GAMgASgOMhUuUHJv",
+            "dG9jb2wuRU1vdmVSZXN1bHQSDAoEdGljaxgEIAEoBRIlCgZuZXdQb3MYBSAB",
+            "KAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxInCglkaXJlY3Rpb24YBiABKA4y",
+            "FC5Qcm90b2NvbC5FRGlyZWN0aW9uIlQKFVNfQnJvYWRjYXN0UGxheWVyTW92",
+            "ZRIMCgR0aWNrGAEgASgFEi0KC3BsYXllck1vdmVzGAIgAygLMhguUHJvdG9j",
+            "b2wuUGxheWVyTW92ZUluZm8iOAoRU19DaGFuZ2VSb29tQmVnaW4SFAoMdHJh",
+            "bnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFIikKEUNfQ2hhbmdlUm9v",
+            "bVJlYWR5EhQKDHRyYW5zaXRpb25JZBgBIAEoBSJkChJTX0NoYW5nZVJvb21D",
+            "b21taXQSFAoMdHJhbnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFEikK",
+            "CXNuYXBzaG90cxgDIAEoCzIWLlByb3RvY29sLlNfUGxheWVyTGlzdCJzCg5T",
+            "X1NwYXduTW9uc3RlchIRCgltb25zdGVySWQYASABKAUSFQoNbW9uc3RlclR5",
+            "cGVJZBgCIAEoBRIJCgF4GAMgASgFEgkKAXkYBCABKAUSIQoDZGlyGAUgASgO",
+            "MhQuUHJvdG9jb2wuRURpcmVjdGlvbiJPChBTX0Rlc3Bhd25Nb25zdGVyEhEK",
+            "CW1vbnN0ZXJJZBgBIAEoBRIoCgZyZWFzb24YAiABKA4yGC5Qcm90b2NvbC5F",
+            "RGVzcGF3blJlYXNvbiJkChZTX0Jyb2FkY2FzdE1vbnN0ZXJNb3ZlEhEKCW1v",
+            "bnN0ZXJJZBgBIAEoBRIJCgF4GAIgASgFEgkKAXkYAyABKAUSIQoDZGlyGAQg",
+            "ASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiJAChhTX0Jyb2FkY2FzdE1vbnN0",
+            "ZXJBdHRhY2sSEQoJbW9uc3RlcklkGAEgASgFEhEKCXRhcmdldFBpZBgCIAEo",
+            "BSIsChdTX0Jyb2FkY2FzdE1vbnN0ZXJEZWF0aBIRCgltb25zdGVySWQYASAB",
+            "KAUiFwoVQ19QbGF5ZXJBdHRhY2tSZXF1ZXN0Il4KF1NfQnJvYWRjYXN0UGxh",
+            "eWVyQXR0YWNrEhAKCHBsYXllcklkGAEgASgFEhAKCHRhcmdldElkGAIgASgF",
+            "Eg4KBmRhbWFnZRgDIAEoBRIPCgdocEFmdGVyGAQgASgFIhQKEkNfSW52ZW50",
+            "b3J5UmVxdWVzdCI+ChBTX0ludmVudG9yeVJlcGx5EioKBXNsb3RzGAEgAygL",
+            "MhsuUHJvdG9jb2wuSW52ZW50b3J5U2xvdEluZm8iJQoQQ19JdGVtVXNlUmVx",
+            "dWVzdBIRCglzbG90SW5kZXgYASABKAUiNwoOU19JdGVtVXNlUmVwbHkSDwoH",
+            "c3VjY2VzcxgBIAEoCBIUCgxlcnJvck1lc3NhZ2UYAiABKAkiRgoRU19JbnZl",
+            "bnRvcnlVcGRhdGUSMQoMY2hhbmdlZFNsb3RzGAEgAygLMhsuUHJvdG9jb2wu",
+            "SW52ZW50b3J5U2xvdEluZm8iSAoPU19TeXN0ZW1NZXNzYWdlEg8KB21lc3Nh",
+            "Z2UYASABKAkSJAoEdHlwZRgCIAEoDjIWLlByb3RvY29sLkVNZXNzYWdlVHlw",
+            "ZSIjCgtWZWN0b3IySW5mbxIJCgF4GAEgASgFEgkKAXkYAiABKAUimQEKDlBs",
+            "YXllck1vdmVJbmZvEhAKCHBsYXllcklkGAEgASgFEicKCWRpcmVjdGlvbhgC",
+            "IAEoDjIULlByb3RvY29sLkVEaXJlY3Rpb24SJQoGbmV3UG9zGAMgASgLMhUu",
+            "UHJvdG9jb2wuVmVjdG9yMkluZm8SJQoGcmVzdWx0GAQgASgOMhUuUHJvdG9j",
+            "b2wuRU1vdmVSZXN1bHQifQoUQ2hhcmFjdGVyU3VtbWFyeUluZm8SEAoIdXNl",
+            "cm5hbWUYASABKAkSDQoFbGV2ZWwYAiABKAUSIQoGZ2VuZGVyGAMgASgOMhEu",
+            "UHJvdG9jb2wuRUdlbmRlchIhCgZyZWdpb24YBCABKA4yES5Qcm90b2NvbC5F",
+            "UmVnaW9uIncKClBsYXllckluZm8SCgoCaWQYASABKAUSEAoIdXNlcm5hbWUY",
+            "AiABKAkSIgoDcG9zGAMgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8SJwoJ",
+            "ZGlyZWN0aW9uGAQgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiJaChFJbnZl",
+            "bnRvcnlTbG90SW5mbxIRCglzbG90SW5kZXgYASABKAUSDgoGaXRlbUlkGAIg",
+            "ASgFEg0KBWNvdW50GAMgASgFEhMKC2lzUXVpY2tzbG90GAQgASgIKvIGCgVN",
+            "c2dJZBIXChNDX0pXVF9MT0dJTl9SRVFVRVNUEAASFQoRU19KV1RfTE9HSU5f",
+            "UkVQTFkQARIeChpDX0NSRUFURV9DSEFSQUNURVJfUkVRVUVTVBACEhwKGFNf",
+            "Q1JFQVRFX0NIQVJBQ1RFUl9SRVBMWRADEhwKGENfQ0hBUkFDVEVSX0xJU1Rf",
+            "UkVRVUVTVBAEEhoKFlNfQ0hBUkFDVEVSX0xJU1RfUkVQTFkQBRIeChpDX0RF",
+            "TEVURV9DSEFSQUNURVJfUkVRVUVTVBAGEhwKGFNfREVMRVRFX0NIQVJBQ1RF",
+            "Ul9SRVBMWRAHEhAKDENfRU5URVJfR0FNRRAIEhAKDFNfRU5URVJfR0FNRRAJ",
+            "EhEKDVNfUExBWUVSX0xJU1QQChIcChhTX0JST0FEQ0FTVF9QTEFZRVJfRU5U",
+            "RVIQCxIQCgxDX0xFQVZFX0dBTUUQDBIQCgxTX0xFQVZFX0dBTUUQDRIcChhT",
+            "X0JST0FEQ0FTVF9QTEFZRVJfTEVBVkUQDhIZChVDX1BMQVlFUl9NT1ZFX1JF",
+            "UVVFU1QQDxIXChNTX1BMQVlFUl9NT1ZFX1JFUExZEBASGwoXU19CUk9BRENB",
+            "U1RfUExBWUVSX01PVkUQERIXChNTX0NIQU5HRV9ST09NX0JFR0lOEBISFwoT",
+            "Q19DSEFOR0VfUk9PTV9SRUFEWRATEhgKFFNfQ0hBTkdFX1JPT01fQ09NTUlU",
+            "EBQSEwoPU19TUEFXTl9NT05TVEVSEBUSFQoRU19ERVNQQVdOX01PTlNURVIQ",
+            "FhIcChhTX0JST0FEQ0FTVF9NT05TVEVSX01PVkUQFxIeChpTX0JST0FEQ0FT",
+            "VF9NT05TVEVSX0FUVEFDSxAYEh0KGVNfQlJPQURDQVNUX01PTlNURVJfREVB",
+            "VEgQGRIbChdDX1BMQVlFUl9BVFRBQ0tfUkVRVUVTVBAaEh0KGVNfQlJPQURD",
+            "QVNUX1BMQVlFUl9BVFRBQ0sQGxIXChNDX0lOVkVOVE9SWV9SRVFVRVNUEBwS",
+            "FQoRU19JTlZFTlRPUllfUkVQTFkQHRIWChJDX0lURU1fVVNFX1JFUVVFU1QQ",
+            "HhIUChBTX0lURU1fVVNFX1JFUExZEB8SFgoSU19JTlZFTlRPUllfVVBEQVRF",
+            "ECASFAoQU19TWVNURU1fTUVTU0FHRRAhKlMKDEVMb2dpblJlc3VsdBILCgdT",
+            "VUNDRVNTEAASEQoNSU5WQUxJRF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQ",
+            "AhIQCgxTRVJWRVJfRVJST1IQAyo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05F",
+            "EAASDwoLR0VOREVSX01BTEUQARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJl",
+            "Z2lvbhIPCgtSRUdJT05fTk9ORRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lP",
+            "Tl9CQUNLEAIqQwoKRURpcmVjdGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9X",
+            "ThABEgwKCERJUl9MRUZUEAISDQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVh",
+            "c29uEhEKDUxFQVZFX1VOS05PV04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFM",
+            "RUFWRV9DSEFOR0VfUk9PTRACEhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQ",
+            "AxIUChBMRUFWRV9ESVNDT05ORUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9W",
+            "RV9VTktOT1dOEAASCwoHTU9WRV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9W",
+            "RV9DT09MRE9XThADEhAKDE1PVkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNv",
+            "bhIRCg1FTlRFUl9VTktOT1dOEAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRF",
+            "Ul9DSEFOR0VfUk9PTRACKjkKDkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05f",
+            "VU5LTk9XThAAEhIKDkRFU1BBV05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUK",
+            "EUlURU1fVFlQRV9VTktOT1dOEAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQ",
+            "ARIXChNJVEVNX1RZUEVfRVFVSVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNU",
+            "EAMSEgoOSVRFTV9UWVBFX01JU0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVT",
+            "U0FHRV9JTkZPEAASEwoPTUVTU0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9F",
+            "UlJPUhACEhcKE01FU1NBR0VfRFJPUF9GQUlMRUQQA0IbqgIYR29vZ2xlLlBy",
+            "b3RvYnVmLlByb3RvY29sYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -143,7 +144,7 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_PlayerList), global::Google.Protobuf.Protocol.S_PlayerList.Parser, new[]{ "MyPlayerId", "MapId", "Players" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerEnter), global::Google.Protobuf.Protocol.S_BroadcastPlayerEnter.Parser, new[]{ "Player" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_LeaveGame), global::Google.Protobuf.Protocol.C_LeaveGame.Parser, new[]{ "Reason" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_LeaveGame), global::Google.Protobuf.Protocol.S_LeaveGame.Parser, new[]{ "Success" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_LeaveGame), global::Google.Protobuf.Protocol.S_LeaveGame.Parser, new[]{ "Success", "Detail" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerLeave), global::Google.Protobuf.Protocol.S_BroadcastPlayerLeave.Parser, new[]{ "PlayerId", "Reason" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_PlayerMoveRequest), global::Google.Protobuf.Protocol.C_PlayerMoveRequest.Parser, new[]{ "ClickWorldPos" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_PlayerMoveReply), global::Google.Protobuf.Protocol.S_PlayerMoveReply.Parser, new[]{ "PlayerId", "ClientSeq", "Result", "Tick", "NewPos", "Direction" }, null, null, null, null),
@@ -241,7 +242,7 @@ namespace Google.Protobuf.Protocol {
   public enum ELeaveReason {
     [pbr::OriginalName("LEAVE_UNKNOWN")] LeaveUnknown = 0,
     /// <summary>
-    /// 게임종료
+    /// 로그아웃 -> Jwt 로그인 인증 상태로 (세션 초기화)
     /// </summary>
     [pbr::OriginalName("LEAVE_LOGOUT")] LeaveLogout = 1,
     /// <summary>
@@ -249,9 +250,13 @@ namespace Google.Protobuf.Protocol {
     /// </summary>
     [pbr::OriginalName("LEAVE_CHANGE_ROOM")] LeaveChangeRoom = 2,
     /// <summary>
+    /// 캐릭터 변경 -> 세션은 유지하고 캐릭터 선택으로 변경
+    /// </summary>
+    [pbr::OriginalName("LEAVE_CHANGE_CHARACTER")] LeaveChangeCharacter = 3,
+    /// <summary>
     /// 네트워크 끊김
     /// </summary>
-    [pbr::OriginalName("LEAVE_DISCONNECT")] LeaveDisconnect = 3,
+    [pbr::OriginalName("LEAVE_DISCONNECT")] LeaveDisconnect = 4,
   }
 
   public enum EMoveResult {
@@ -3015,6 +3020,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public S_LeaveGame(S_LeaveGame other) : this() {
       success_ = other.success_;
+      detail_ = other.detail_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -3026,13 +3032,25 @@ namespace Google.Protobuf.Protocol {
 
     /// <summary>Field number for the "success" field.</summary>
     public const int SuccessFieldNumber = 1;
-    private int success_;
+    private bool success_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Success {
+    public bool Success {
       get { return success_; }
       set {
         success_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "detail" field.</summary>
+    public const int DetailFieldNumber = 2;
+    private string detail_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Detail {
+      get { return detail_; }
+      set {
+        detail_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
       }
     }
 
@@ -3052,6 +3070,7 @@ namespace Google.Protobuf.Protocol {
         return true;
       }
       if (Success != other.Success) return false;
+      if (Detail != other.Detail) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -3059,7 +3078,8 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
-      if (Success != 0) hash ^= Success.GetHashCode();
+      if (Success != false) hash ^= Success.GetHashCode();
+      if (Detail.Length != 0) hash ^= Detail.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -3078,9 +3098,13 @@ namespace Google.Protobuf.Protocol {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (Success != 0) {
+      if (Success != false) {
         output.WriteRawTag(8);
-        output.WriteInt32(Success);
+        output.WriteBool(Success);
+      }
+      if (Detail.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Detail);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
@@ -3092,9 +3116,13 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (Success != 0) {
+      if (Success != false) {
         output.WriteRawTag(8);
-        output.WriteInt32(Success);
+        output.WriteBool(Success);
+      }
+      if (Detail.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Detail);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
@@ -3106,8 +3134,11 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
-      if (Success != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Success);
+      if (Success != false) {
+        size += 1 + 1;
+      }
+      if (Detail.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Detail);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -3121,8 +3152,11 @@ namespace Google.Protobuf.Protocol {
       if (other == null) {
         return;
       }
-      if (other.Success != 0) {
+      if (other.Success != false) {
         Success = other.Success;
+      }
+      if (other.Detail.Length != 0) {
+        Detail = other.Detail;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -3140,7 +3174,11 @@ namespace Google.Protobuf.Protocol {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
           case 8: {
-            Success = input.ReadInt32();
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            Detail = input.ReadString();
             break;
           }
         }
@@ -3159,7 +3197,11 @@ namespace Google.Protobuf.Protocol {
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
           case 8: {
-            Success = input.ReadInt32();
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            Detail = input.ReadString();
             break;
           }
         }


### PR DESCRIPTION
- DummyClientCS에 다양한 ELeaveReason별 테스트 메뉴 추가 (l,c,r,d,x)
- SessionManager에 종료 사유별 테스트 메소드들 구현
- GameSession에 Logout/CharacterSelect 메소드 구현으로 세션 상태 관리
- ClientPacketHandler에 C_LeaveGame switch-case 로직 추가
- Protocol.proto에 S_LeaveGame detail 필드 추가 및 ELeaveReason 확장
- 로그아웃 시 JWT 인증상태 복귀, 캐릭터 변경 시 캐릭터선택창 복귀 기능
- 상태별 유효성 검증 로직 및 데이터 저장 처리