### PR TITLE
fix: 몬스터 스폰 프로토콜 구조 개선 및 룸 이동시 몬스터 스폰 버그 해결

### DIFF
--- a/DummyClientCS/Packet/ServerPacketHandler.cs
+++ b/DummyClientCS/Packet/ServerPacketHandler.cs
@@ -204,21 +204,6 @@ namespace Packet
             Console.WriteLine($">>> 씬 전환: '{newSceneName}' 로딩 중...");
             Console.WriteLine($">>> 새로운 맵 환경 및 UI 초기화 완료");
             
-            // 새로운 룸의 플레이어 정보 처리
-            if (commit.Snapshots != null)
-            {
-                var snapshots = commit.Snapshots;
-                NetDebug.MyPlayerId = snapshots.MyPlayerId;
-                Console.WriteLine($"내 플레이어 ID: {snapshots.MyPlayerId}");
-                Console.WriteLine($"새로운 룸의 본인 포함 다른 플레이어 수: {snapshots.Players.Count}");
-                
-                foreach (var player in snapshots.Players)
-                {
-                    var pos = NetDebug.PosToStr(player.Pos);
-                    var dir = NetDebug.DirToStr(player.Direction);
-                    Console.WriteLine($"  - 플레이어ID: {player.Id}, 이름: {player.Username}, 위치: {pos}, 방향: {dir}");
-                }
-            }
         }
 
         internal static void HANDLE_S_LeaveGame(PacketSession session, S_LeaveGame game)
@@ -352,7 +337,7 @@ namespace Packet
             Console.WriteLine($"MapId : {list.MapId} ");
             foreach(MonsterInfo monster in list.Monsters)
             {
-                Console.WriteLine($"[S_MonsterList] Id:{monster.MonsterId} Pos:({monster.Pos.X}, {monster.Pos.Y}), Dir:{monster.Direction}");
+                Console.WriteLine($"[S_MonsterList] Id:{monster.MonsterId} TypeId:{monster.MonsterTypeId} Pos:({monster.Pos.X}, {monster.Pos.Y}), Dir:{monster.Direction}");
             }
         }
     }

--- a/DummyClientCS/Protocol/Protocol.cs
+++ b/DummyClientCS/Protocol/Protocol.cs
@@ -54,85 +54,83 @@ namespace Google.Protobuf.Protocol {
             "ZRIMCgR0aWNrGAEgASgFEi0KC3BsYXllck1vdmVzGAIgAygLMhguUHJvdG9j",
             "b2wuUGxheWVyTW92ZUluZm8iOAoRU19DaGFuZ2VSb29tQmVnaW4SFAoMdHJh",
             "bnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFIikKEUNfQ2hhbmdlUm9v",
-            "bVJlYWR5EhQKDHRyYW5zaXRpb25JZBgBIAEoBSJkChJTX0NoYW5nZVJvb21D",
-            "b21taXQSFAoMdHJhbnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFEikK",
-            "CXNuYXBzaG90cxgDIAEoCzIWLlByb3RvY29sLlNfUGxheWVyTGlzdCJzCg5T",
-            "X1NwYXduTW9uc3RlchIRCgltb25zdGVySWQYASABKAUSFQoNbW9uc3RlclR5",
-            "cGVJZBgCIAEoBRIJCgF4GAMgASgFEgkKAXkYBCABKAUSIQoDZGlyGAUgASgO",
-            "MhQuUHJvdG9jb2wuRURpcmVjdGlvbiJPChBTX0Rlc3Bhd25Nb25zdGVyEhEK",
-            "CW1vbnN0ZXJJZBgBIAEoBRIoCgZyZWFzb24YAiABKA4yGC5Qcm90b2NvbC5F",
-            "RGVzcGF3blJlYXNvbiJkChZTX0Jyb2FkY2FzdE1vbnN0ZXJNb3ZlEhEKCW1v",
-            "bnN0ZXJJZBgBIAEoBRIJCgF4GAIgASgFEgkKAXkYAyABKAUSIQoDZGlyGAQg",
-            "ASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiJAChhTX0Jyb2FkY2FzdE1vbnN0",
-            "ZXJBdHRhY2sSEQoJbW9uc3RlcklkGAEgASgFEhEKCXRhcmdldFBpZBgCIAEo",
-            "BSIsChdTX0Jyb2FkY2FzdE1vbnN0ZXJEZWF0aBIRCgltb25zdGVySWQYASAB",
-            "KAUiFwoVQ19QbGF5ZXJBdHRhY2tSZXF1ZXN0Il4KF1NfQnJvYWRjYXN0UGxh",
-            "eWVyQXR0YWNrEhAKCHBsYXllcklkGAEgASgFEhAKCHRhcmdldElkGAIgASgF",
-            "Eg4KBmRhbWFnZRgDIAEoBRIPCgdocEFmdGVyGAQgASgFIhQKEkNfSW52ZW50",
-            "b3J5UmVxdWVzdCI+ChBTX0ludmVudG9yeVJlcGx5EioKBXNsb3RzGAEgAygL",
-            "MhsuUHJvdG9jb2wuSW52ZW50b3J5U2xvdEluZm8iJQoQQ19JdGVtVXNlUmVx",
-            "dWVzdBIRCglzbG90SW5kZXgYASABKAUiNwoOU19JdGVtVXNlUmVwbHkSDwoH",
-            "c3VjY2VzcxgBIAEoCBIUCgxlcnJvck1lc3NhZ2UYAiABKAkiRgoRU19JbnZl",
-            "bnRvcnlVcGRhdGUSMQoMY2hhbmdlZFNsb3RzGAEgAygLMhsuUHJvdG9jb2wu",
-            "SW52ZW50b3J5U2xvdEluZm8iSAoPU19TeXN0ZW1NZXNzYWdlEg8KB21lc3Nh",
-            "Z2UYASABKAkSJAoEdHlwZRgCIAEoDjIWLlByb3RvY29sLkVNZXNzYWdlVHlw",
-            "ZSJHCg1TX01vbnN0ZXJMaXN0Eg0KBW1hcElkGAEgASgFEicKCG1vbnN0ZXJz",
-            "GAIgAygLMhUuUHJvdG9jb2wuTW9uc3RlckluZm8iIwoLVmVjdG9yMkluZm8S",
-            "CQoBeBgBIAEoBRIJCgF5GAIgASgFIpkBCg5QbGF5ZXJNb3ZlSW5mbxIQCghw",
-            "bGF5ZXJJZBgBIAEoBRInCglkaXJlY3Rpb24YAiABKA4yFC5Qcm90b2NvbC5F",
-            "RGlyZWN0aW9uEiUKBm5ld1BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3RvcjJJ",
-            "bmZvEiUKBnJlc3VsdBgEIAEoDjIVLlByb3RvY29sLkVNb3ZlUmVzdWx0In0K",
-            "FENoYXJhY3RlclN1bW1hcnlJbmZvEhAKCHVzZXJuYW1lGAEgASgJEg0KBWxl",
-            "dmVsGAIgASgFEiEKBmdlbmRlchgDIAEoDjIRLlByb3RvY29sLkVHZW5kZXIS",
-            "IQoGcmVnaW9uGAQgASgOMhEuUHJvdG9jb2wuRVJlZ2lvbiJ3CgpQbGF5ZXJJ",
-            "bmZvEgoKAmlkGAEgASgFEhAKCHVzZXJuYW1lGAIgASgJEiIKA3BvcxgDIAEo",
-            "CzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIU",
-            "LlByb3RvY29sLkVEaXJlY3Rpb24iWgoRSW52ZW50b3J5U2xvdEluZm8SEQoJ",
-            "c2xvdEluZGV4GAEgASgFEg4KBml0ZW1JZBgCIAEoBRINCgVjb3VudBgDIAEo",
-            "BRITCgtpc1F1aWNrc2xvdBgEIAEoCCJtCgtNb25zdGVySW5mbxIRCgltb25z",
-            "dGVySWQYASABKAUSIgoDcG9zGAIgASgLMhUuUHJvdG9jb2wuVmVjdG9yMklu",
-            "Zm8SJwoJZGlyZWN0aW9uGAMgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiqG",
-            "BwoFTXNnSWQSFwoTQ19KV1RfTE9HSU5fUkVRVUVTVBAAEhUKEVNfSldUX0xP",
-            "R0lOX1JFUExZEAESHgoaQ19DUkVBVEVfQ0hBUkFDVEVSX1JFUVVFU1QQAhIc",
-            "ChhTX0NSRUFURV9DSEFSQUNURVJfUkVQTFkQAxIcChhDX0NIQVJBQ1RFUl9M",
-            "SVNUX1JFUVVFU1QQBBIaChZTX0NIQVJBQ1RFUl9MSVNUX1JFUExZEAUSHgoa",
-            "Q19ERUxFVEVfQ0hBUkFDVEVSX1JFUVVFU1QQBhIcChhTX0RFTEVURV9DSEFS",
-            "QUNURVJfUkVQTFkQBxIQCgxDX0VOVEVSX0dBTUUQCBIQCgxTX0VOVEVSX0dB",
-            "TUUQCRIRCg1TX1BMQVlFUl9MSVNUEAoSHAoYU19CUk9BRENBU1RfUExBWUVS",
-            "X0VOVEVSEAsSEAoMQ19MRUFWRV9HQU1FEAwSEAoMU19MRUFWRV9HQU1FEA0S",
-            "HAoYU19CUk9BRENBU1RfUExBWUVSX0xFQVZFEA4SGQoVQ19QTEFZRVJfTU9W",
-            "RV9SRVFVRVNUEA8SFwoTU19QTEFZRVJfTU9WRV9SRVBMWRAQEhsKF1NfQlJP",
-            "QURDQVNUX1BMQVlFUl9NT1ZFEBESFwoTU19DSEFOR0VfUk9PTV9CRUdJThAS",
-            "EhcKE0NfQ0hBTkdFX1JPT01fUkVBRFkQExIYChRTX0NIQU5HRV9ST09NX0NP",
-            "TU1JVBAUEhMKD1NfU1BBV05fTU9OU1RFUhAVEhUKEVNfREVTUEFXTl9NT05T",
-            "VEVSEBYSHAoYU19CUk9BRENBU1RfTU9OU1RFUl9NT1ZFEBcSHgoaU19CUk9B",
-            "RENBU1RfTU9OU1RFUl9BVFRBQ0sQGBIdChlTX0JST0FEQ0FTVF9NT05TVEVS",
-            "X0RFQVRIEBkSGwoXQ19QTEFZRVJfQVRUQUNLX1JFUVVFU1QQGhIdChlTX0JS",
-            "T0FEQ0FTVF9QTEFZRVJfQVRUQUNLEBsSFwoTQ19JTlZFTlRPUllfUkVRVUVT",
-            "VBAcEhUKEVNfSU5WRU5UT1JZX1JFUExZEB0SFgoSQ19JVEVNX1VTRV9SRVFV",
-            "RVNUEB4SFAoQU19JVEVNX1VTRV9SRVBMWRAfEhYKElNfSU5WRU5UT1JZX1VQ",
-            "REFURRAgEhQKEFNfU1lTVEVNX01FU1NBR0UQIRISCg5TX01PTlNURVJfTElT",
-            "VBAiKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAASEQoNSU5WQUxJRF9U",
-            "T0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJWRVJfRVJST1IQAyo+",
-            "CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VOREVSX01BTEUQARIR",
-            "Cg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtSRUdJT05fTk9ORRAA",
-            "Eg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIqQwoKRURpcmVjdGlv",
-            "bhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJUl9MRUZUEAISDQoJ",
-            "RElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxFQVZFX1VOS05PV04Q",
-            "ABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFOR0VfUk9PTRACEhoK",
-            "FkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFWRV9ESVNDT05ORUNU",
-            "EAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dOEAASCwoHTU9WRV9P",
-            "SxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9XThADEhAKDE1PVkVf",
-            "QkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRFUl9VTktOT1dOEAAS",
-            "DwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0VfUk9PTRACKjkKDkVE",
-            "ZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAAEhIKDkRFU1BBV05f",
-            "S0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQRV9VTktOT1dOEAAS",
-            "GAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVNX1RZUEVfRVFVSVBN",
-            "RU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRFTV9UWVBFX01JU0MQ",
-            "BCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZPEAASEwoPTUVTU0FH",
-            "RV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcKE01FU1NBR0VfRFJP",
-            "UF9GQUlMRUQQA0IbqgIYR29vZ2xlLlByb3RvYnVmLlByb3RvY29sYgZwcm90",
-            "bzM="));
+            "bVJlYWR5EhQKDHRyYW5zaXRpb25JZBgBIAEoBSI5ChJTX0NoYW5nZVJvb21D",
+            "b21taXQSFAoMdHJhbnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFIjgK",
+            "DlNfU3Bhd25Nb25zdGVyEiYKB21vbnN0ZXIYASABKAsyFS5Qcm90b2NvbC5N",
+            "b25zdGVySW5mbyJPChBTX0Rlc3Bhd25Nb25zdGVyEhEKCW1vbnN0ZXJJZBgB",
+            "IAEoBRIoCgZyZWFzb24YAiABKA4yGC5Qcm90b2NvbC5FRGVzcGF3blJlYXNv",
+            "biJkChZTX0Jyb2FkY2FzdE1vbnN0ZXJNb3ZlEhEKCW1vbnN0ZXJJZBgBIAEo",
+            "BRIJCgF4GAIgASgFEgkKAXkYAyABKAUSIQoDZGlyGAQgASgOMhQuUHJvdG9j",
+            "b2wuRURpcmVjdGlvbiJAChhTX0Jyb2FkY2FzdE1vbnN0ZXJBdHRhY2sSEQoJ",
+            "bW9uc3RlcklkGAEgASgFEhEKCXRhcmdldFBpZBgCIAEoBSIsChdTX0Jyb2Fk",
+            "Y2FzdE1vbnN0ZXJEZWF0aBIRCgltb25zdGVySWQYASABKAUiFwoVQ19QbGF5",
+            "ZXJBdHRhY2tSZXF1ZXN0Il4KF1NfQnJvYWRjYXN0UGxheWVyQXR0YWNrEhAK",
+            "CHBsYXllcklkGAEgASgFEhAKCHRhcmdldElkGAIgASgFEg4KBmRhbWFnZRgD",
+            "IAEoBRIPCgdocEFmdGVyGAQgASgFIhQKEkNfSW52ZW50b3J5UmVxdWVzdCI+",
+            "ChBTX0ludmVudG9yeVJlcGx5EioKBXNsb3RzGAEgAygLMhsuUHJvdG9jb2wu",
+            "SW52ZW50b3J5U2xvdEluZm8iJQoQQ19JdGVtVXNlUmVxdWVzdBIRCglzbG90",
+            "SW5kZXgYASABKAUiNwoOU19JdGVtVXNlUmVwbHkSDwoHc3VjY2VzcxgBIAEo",
+            "CBIUCgxlcnJvck1lc3NhZ2UYAiABKAkiRgoRU19JbnZlbnRvcnlVcGRhdGUS",
+            "MQoMY2hhbmdlZFNsb3RzGAEgAygLMhsuUHJvdG9jb2wuSW52ZW50b3J5U2xv",
+            "dEluZm8iSAoPU19TeXN0ZW1NZXNzYWdlEg8KB21lc3NhZ2UYASABKAkSJAoE",
+            "dHlwZRgCIAEoDjIWLlByb3RvY29sLkVNZXNzYWdlVHlwZSJHCg1TX01vbnN0",
+            "ZXJMaXN0Eg0KBW1hcElkGAEgASgFEicKCG1vbnN0ZXJzGAIgAygLMhUuUHJv",
+            "dG9jb2wuTW9uc3RlckluZm8iIwoLVmVjdG9yMkluZm8SCQoBeBgBIAEoBRIJ",
+            "CgF5GAIgASgFIpkBCg5QbGF5ZXJNb3ZlSW5mbxIQCghwbGF5ZXJJZBgBIAEo",
+            "BRInCglkaXJlY3Rpb24YAiABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9uEiUK",
+            "Bm5ld1BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEiUKBnJlc3Vs",
+            "dBgEIAEoDjIVLlByb3RvY29sLkVNb3ZlUmVzdWx0In0KFENoYXJhY3RlclN1",
+            "bW1hcnlJbmZvEhAKCHVzZXJuYW1lGAEgASgJEg0KBWxldmVsGAIgASgFEiEK",
+            "BmdlbmRlchgDIAEoDjIRLlByb3RvY29sLkVHZW5kZXISIQoGcmVnaW9uGAQg",
+            "ASgOMhEuUHJvdG9jb2wuRVJlZ2lvbiJ3CgpQbGF5ZXJJbmZvEgoKAmlkGAEg",
+            "ASgFEhAKCHVzZXJuYW1lGAIgASgJEiIKA3BvcxgDIAEoCzIVLlByb3RvY29s",
+            "LlZlY3RvcjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVE",
+            "aXJlY3Rpb24iWgoRSW52ZW50b3J5U2xvdEluZm8SEQoJc2xvdEluZGV4GAEg",
+            "ASgFEg4KBml0ZW1JZBgCIAEoBRINCgVjb3VudBgDIAEoBRITCgtpc1F1aWNr",
+            "c2xvdBgEIAEoCCKEAQoLTW9uc3RlckluZm8SEQoJbW9uc3RlcklkGAEgASgF",
+            "EhUKDW1vbnN0ZXJUeXBlSWQYAiABKAUSIgoDcG9zGAMgASgLMhUuUHJvdG9j",
+            "b2wuVmVjdG9yMkluZm8SJwoJZGlyZWN0aW9uGAQgASgOMhQuUHJvdG9jb2wu",
+            "RURpcmVjdGlvbiqGBwoFTXNnSWQSFwoTQ19KV1RfTE9HSU5fUkVRVUVTVBAA",
+            "EhUKEVNfSldUX0xPR0lOX1JFUExZEAESHgoaQ19DUkVBVEVfQ0hBUkFDVEVS",
+            "X1JFUVVFU1QQAhIcChhTX0NSRUFURV9DSEFSQUNURVJfUkVQTFkQAxIcChhD",
+            "X0NIQVJBQ1RFUl9MSVNUX1JFUVVFU1QQBBIaChZTX0NIQVJBQ1RFUl9MSVNU",
+            "X1JFUExZEAUSHgoaQ19ERUxFVEVfQ0hBUkFDVEVSX1JFUVVFU1QQBhIcChhT",
+            "X0RFTEVURV9DSEFSQUNURVJfUkVQTFkQBxIQCgxDX0VOVEVSX0dBTUUQCBIQ",
+            "CgxTX0VOVEVSX0dBTUUQCRIRCg1TX1BMQVlFUl9MSVNUEAoSHAoYU19CUk9B",
+            "RENBU1RfUExBWUVSX0VOVEVSEAsSEAoMQ19MRUFWRV9HQU1FEAwSEAoMU19M",
+            "RUFWRV9HQU1FEA0SHAoYU19CUk9BRENBU1RfUExBWUVSX0xFQVZFEA4SGQoV",
+            "Q19QTEFZRVJfTU9WRV9SRVFVRVNUEA8SFwoTU19QTEFZRVJfTU9WRV9SRVBM",
+            "WRAQEhsKF1NfQlJPQURDQVNUX1BMQVlFUl9NT1ZFEBESFwoTU19DSEFOR0Vf",
+            "Uk9PTV9CRUdJThASEhcKE0NfQ0hBTkdFX1JPT01fUkVBRFkQExIYChRTX0NI",
+            "QU5HRV9ST09NX0NPTU1JVBAUEhMKD1NfU1BBV05fTU9OU1RFUhAVEhUKEVNf",
+            "REVTUEFXTl9NT05TVEVSEBYSHAoYU19CUk9BRENBU1RfTU9OU1RFUl9NT1ZF",
+            "EBcSHgoaU19CUk9BRENBU1RfTU9OU1RFUl9BVFRBQ0sQGBIdChlTX0JST0FE",
+            "Q0FTVF9NT05TVEVSX0RFQVRIEBkSGwoXQ19QTEFZRVJfQVRUQUNLX1JFUVVF",
+            "U1QQGhIdChlTX0JST0FEQ0FTVF9QTEFZRVJfQVRUQUNLEBsSFwoTQ19JTlZF",
+            "TlRPUllfUkVRVUVTVBAcEhUKEVNfSU5WRU5UT1JZX1JFUExZEB0SFgoSQ19J",
+            "VEVNX1VTRV9SRVFVRVNUEB4SFAoQU19JVEVNX1VTRV9SRVBMWRAfEhYKElNf",
+            "SU5WRU5UT1JZX1VQREFURRAgEhQKEFNfU1lTVEVNX01FU1NBR0UQIRISCg5T",
+            "X01PTlNURVJfTElTVBAiKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAAS",
+            "EQoNSU5WQUxJRF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJW",
+            "RVJfRVJST1IQAyo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VO",
+            "REVSX01BTEUQARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtS",
+            "RUdJT05fTk9ORRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIq",
+            "QwoKRURpcmVjdGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJ",
+            "Ul9MRUZUEAISDQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxF",
+            "QVZFX1VOS05PV04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFO",
+            "R0VfUk9PTRACEhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFW",
+            "RV9ESVNDT05ORUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dO",
+            "EAASCwoHTU9WRV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9X",
+            "ThADEhAKDE1PVkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRF",
+            "Ul9VTktOT1dOEAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0Vf",
+            "Uk9PTRACKjkKDkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAA",
+            "EhIKDkRFU1BBV05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQ",
+            "RV9VTktOT1dOEAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVN",
+            "X1RZUEVfRVFVSVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRF",
+            "TV9UWVBFX01JU0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZP",
+            "EAASEwoPTUVTU0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcK",
+            "E01FU1NBR0VfRFJPUF9GQUlMRUQQA0IbqgIYR29vZ2xlLlByb3RvYnVmLlBy",
+            "b3RvY29sYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -156,8 +154,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerMove), global::Google.Protobuf.Protocol.S_BroadcastPlayerMove.Parser, new[]{ "Tick", "PlayerMoves" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_ChangeRoomBegin), global::Google.Protobuf.Protocol.S_ChangeRoomBegin.Parser, new[]{ "TransitionId", "MapId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_ChangeRoomReady), global::Google.Protobuf.Protocol.C_ChangeRoomReady.Parser, new[]{ "TransitionId" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_ChangeRoomCommit), global::Google.Protobuf.Protocol.S_ChangeRoomCommit.Parser, new[]{ "TransitionId", "MapId", "Snapshots" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_SpawnMonster), global::Google.Protobuf.Protocol.S_SpawnMonster.Parser, new[]{ "MonsterId", "MonsterTypeId", "X", "Y", "Dir" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_ChangeRoomCommit), global::Google.Protobuf.Protocol.S_ChangeRoomCommit.Parser, new[]{ "TransitionId", "MapId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_SpawnMonster), global::Google.Protobuf.Protocol.S_SpawnMonster.Parser, new[]{ "Monster" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_DespawnMonster), global::Google.Protobuf.Protocol.S_DespawnMonster.Parser, new[]{ "MonsterId", "Reason" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastMonsterMove), global::Google.Protobuf.Protocol.S_BroadcastMonsterMove.Parser, new[]{ "MonsterId", "X", "Y", "Dir" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastMonsterAttack), global::Google.Protobuf.Protocol.S_BroadcastMonsterAttack.Parser, new[]{ "MonsterId", "TargetPid" }, null, null, null, null),
@@ -176,7 +174,7 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.CharacterSummaryInfo), global::Google.Protobuf.Protocol.CharacterSummaryInfo.Parser, new[]{ "Username", "Level", "Gender", "Region" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerInfo), global::Google.Protobuf.Protocol.PlayerInfo.Parser, new[]{ "Id", "Username", "Pos", "Direction" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.InventorySlotInfo), global::Google.Protobuf.Protocol.InventorySlotInfo.Parser, new[]{ "SlotIndex", "ItemId", "Count", "IsQuickslot" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.MonsterInfo), global::Google.Protobuf.Protocol.MonsterInfo.Parser, new[]{ "MonsterId", "Pos", "Direction" }, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.MonsterInfo), global::Google.Protobuf.Protocol.MonsterInfo.Parser, new[]{ "MonsterId", "MonsterTypeId", "Pos", "Direction" }, null, null, null, null)
           }));
     }
     #endregion
@@ -4716,7 +4714,6 @@ namespace Google.Protobuf.Protocol {
     public S_ChangeRoomCommit(S_ChangeRoomCommit other) : this() {
       transitionId_ = other.transitionId_;
       mapId_ = other.mapId_;
-      snapshots_ = other.snapshots_ != null ? other.snapshots_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -4741,27 +4738,15 @@ namespace Google.Protobuf.Protocol {
     /// <summary>Field number for the "mapId" field.</summary>
     public const int MapIdFieldNumber = 2;
     private int mapId_;
+    /// <summary>
+    /// Snapshot은 OnEnter에서 PlayerList보내는것으로 대신함
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int MapId {
       get { return mapId_; }
       set {
         mapId_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "snapshots" field.</summary>
-    public const int SnapshotsFieldNumber = 3;
-    private global::Google.Protobuf.Protocol.S_PlayerList snapshots_;
-    /// <summary>
-    /// 들어오자마자 월드 동기화
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Google.Protobuf.Protocol.S_PlayerList Snapshots {
-      get { return snapshots_; }
-      set {
-        snapshots_ = value;
       }
     }
 
@@ -4782,7 +4767,6 @@ namespace Google.Protobuf.Protocol {
       }
       if (TransitionId != other.TransitionId) return false;
       if (MapId != other.MapId) return false;
-      if (!object.Equals(Snapshots, other.Snapshots)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -4792,7 +4776,6 @@ namespace Google.Protobuf.Protocol {
       int hash = 1;
       if (TransitionId != 0) hash ^= TransitionId.GetHashCode();
       if (MapId != 0) hash ^= MapId.GetHashCode();
-      if (snapshots_ != null) hash ^= Snapshots.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -4819,10 +4802,6 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(16);
         output.WriteInt32(MapId);
       }
-      if (snapshots_ != null) {
-        output.WriteRawTag(26);
-        output.WriteMessage(Snapshots);
-      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -4841,10 +4820,6 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(16);
         output.WriteInt32(MapId);
       }
-      if (snapshots_ != null) {
-        output.WriteRawTag(26);
-        output.WriteMessage(Snapshots);
-      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -4860,9 +4835,6 @@ namespace Google.Protobuf.Protocol {
       }
       if (MapId != 0) {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(MapId);
-      }
-      if (snapshots_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Snapshots);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -4881,12 +4853,6 @@ namespace Google.Protobuf.Protocol {
       }
       if (other.MapId != 0) {
         MapId = other.MapId;
-      }
-      if (other.snapshots_ != null) {
-        if (snapshots_ == null) {
-          Snapshots = new global::Google.Protobuf.Protocol.S_PlayerList();
-        }
-        Snapshots.MergeFrom(other.Snapshots);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -4911,13 +4877,6 @@ namespace Google.Protobuf.Protocol {
             MapId = input.ReadInt32();
             break;
           }
-          case 26: {
-            if (snapshots_ == null) {
-              Snapshots = new global::Google.Protobuf.Protocol.S_PlayerList();
-            }
-            input.ReadMessage(Snapshots);
-            break;
-          }
         }
       }
     #endif
@@ -4939,13 +4898,6 @@ namespace Google.Protobuf.Protocol {
           }
           case 16: {
             MapId = input.ReadInt32();
-            break;
-          }
-          case 26: {
-            if (snapshots_ == null) {
-              Snapshots = new global::Google.Protobuf.Protocol.S_PlayerList();
-            }
-            input.ReadMessage(Snapshots);
             break;
           }
         }
@@ -4992,11 +4944,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public S_SpawnMonster(S_SpawnMonster other) : this() {
-      monsterId_ = other.monsterId_;
-      monsterTypeId_ = other.monsterTypeId_;
-      x_ = other.x_;
-      y_ = other.y_;
-      dir_ = other.dir_;
+      monster_ = other.monster_ != null ? other.monster_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -5006,78 +4954,15 @@ namespace Google.Protobuf.Protocol {
       return new S_SpawnMonster(this);
     }
 
-    /// <summary>Field number for the "monsterId" field.</summary>
-    public const int MonsterIdFieldNumber = 1;
-    private int monsterId_;
-    /// <summary>
-    /// Entity Unique id
-    /// </summary>
+    /// <summary>Field number for the "monster" field.</summary>
+    public const int MonsterFieldNumber = 1;
+    private global::Google.Protobuf.Protocol.MonsterInfo monster_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int MonsterId {
-      get { return monsterId_; }
+    public global::Google.Protobuf.Protocol.MonsterInfo Monster {
+      get { return monster_; }
       set {
-        monsterId_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "monsterTypeId" field.</summary>
-    public const int MonsterTypeIdFieldNumber = 2;
-    private int monsterTypeId_;
-    /// <summary>
-    /// Monster Type (Template or Resources Id)
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int MonsterTypeId {
-      get { return monsterTypeId_; }
-      set {
-        monsterTypeId_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "x" field.</summary>
-    public const int XFieldNumber = 3;
-    private int x_;
-    /// <summary>
-    /// Tile Pos X
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int X {
-      get { return x_; }
-      set {
-        x_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "y" field.</summary>
-    public const int YFieldNumber = 4;
-    private int y_;
-    /// <summary>
-    /// Tile Pos Y
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Y {
-      get { return y_; }
-      set {
-        y_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "dir" field.</summary>
-    public const int DirFieldNumber = 5;
-    private global::Google.Protobuf.Protocol.EDirection dir_ = global::Google.Protobuf.Protocol.EDirection.DirUp;
-    /// <summary>
-    /// 방향 
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Google.Protobuf.Protocol.EDirection Dir {
-      get { return dir_; }
-      set {
-        dir_ = value;
+        monster_ = value;
       }
     }
 
@@ -5096,11 +4981,7 @@ namespace Google.Protobuf.Protocol {
       if (ReferenceEquals(other, this)) {
         return true;
       }
-      if (MonsterId != other.MonsterId) return false;
-      if (MonsterTypeId != other.MonsterTypeId) return false;
-      if (X != other.X) return false;
-      if (Y != other.Y) return false;
-      if (Dir != other.Dir) return false;
+      if (!object.Equals(Monster, other.Monster)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -5108,11 +4989,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
-      if (MonsterId != 0) hash ^= MonsterId.GetHashCode();
-      if (MonsterTypeId != 0) hash ^= MonsterTypeId.GetHashCode();
-      if (X != 0) hash ^= X.GetHashCode();
-      if (Y != 0) hash ^= Y.GetHashCode();
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) hash ^= Dir.GetHashCode();
+      if (monster_ != null) hash ^= Monster.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -5131,25 +5008,9 @@ namespace Google.Protobuf.Protocol {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (MonsterId != 0) {
-        output.WriteRawTag(8);
-        output.WriteInt32(MonsterId);
-      }
-      if (MonsterTypeId != 0) {
-        output.WriteRawTag(16);
-        output.WriteInt32(MonsterTypeId);
-      }
-      if (X != 0) {
-        output.WriteRawTag(24);
-        output.WriteInt32(X);
-      }
-      if (Y != 0) {
-        output.WriteRawTag(32);
-        output.WriteInt32(Y);
-      }
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(40);
-        output.WriteEnum((int) Dir);
+      if (monster_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Monster);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
@@ -5161,25 +5022,9 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (MonsterId != 0) {
-        output.WriteRawTag(8);
-        output.WriteInt32(MonsterId);
-      }
-      if (MonsterTypeId != 0) {
-        output.WriteRawTag(16);
-        output.WriteInt32(MonsterTypeId);
-      }
-      if (X != 0) {
-        output.WriteRawTag(24);
-        output.WriteInt32(X);
-      }
-      if (Y != 0) {
-        output.WriteRawTag(32);
-        output.WriteInt32(Y);
-      }
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(40);
-        output.WriteEnum((int) Dir);
+      if (monster_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Monster);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
@@ -5191,20 +5036,8 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
-      if (MonsterId != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterId);
-      }
-      if (MonsterTypeId != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterTypeId);
-      }
-      if (X != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(X);
-      }
-      if (Y != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Y);
-      }
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Dir);
+      if (monster_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Monster);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -5218,20 +5051,11 @@ namespace Google.Protobuf.Protocol {
       if (other == null) {
         return;
       }
-      if (other.MonsterId != 0) {
-        MonsterId = other.MonsterId;
-      }
-      if (other.MonsterTypeId != 0) {
-        MonsterTypeId = other.MonsterTypeId;
-      }
-      if (other.X != 0) {
-        X = other.X;
-      }
-      if (other.Y != 0) {
-        Y = other.Y;
-      }
-      if (other.Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        Dir = other.Dir;
+      if (other.monster_ != null) {
+        if (monster_ == null) {
+          Monster = new global::Google.Protobuf.Protocol.MonsterInfo();
+        }
+        Monster.MergeFrom(other.Monster);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -5248,24 +5072,11 @@ namespace Google.Protobuf.Protocol {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
-          case 8: {
-            MonsterId = input.ReadInt32();
-            break;
-          }
-          case 16: {
-            MonsterTypeId = input.ReadInt32();
-            break;
-          }
-          case 24: {
-            X = input.ReadInt32();
-            break;
-          }
-          case 32: {
-            Y = input.ReadInt32();
-            break;
-          }
-          case 40: {
-            Dir = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
+          case 10: {
+            if (monster_ == null) {
+              Monster = new global::Google.Protobuf.Protocol.MonsterInfo();
+            }
+            input.ReadMessage(Monster);
             break;
           }
         }
@@ -5283,24 +5094,11 @@ namespace Google.Protobuf.Protocol {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 8: {
-            MonsterId = input.ReadInt32();
-            break;
-          }
-          case 16: {
-            MonsterTypeId = input.ReadInt32();
-            break;
-          }
-          case 24: {
-            X = input.ReadInt32();
-            break;
-          }
-          case 32: {
-            Y = input.ReadInt32();
-            break;
-          }
-          case 40: {
-            Dir = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
+          case 10: {
+            if (monster_ == null) {
+              Monster = new global::Google.Protobuf.Protocol.MonsterInfo();
+            }
+            input.ReadMessage(Monster);
             break;
           }
         }
@@ -9600,6 +9398,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MonsterInfo(MonsterInfo other) : this() {
       monsterId_ = other.monsterId_;
+      monsterTypeId_ = other.monsterTypeId_;
       pos_ = other.pos_ != null ? other.pos_.Clone() : null;
       direction_ = other.direction_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -9614,6 +9413,9 @@ namespace Google.Protobuf.Protocol {
     /// <summary>Field number for the "monsterId" field.</summary>
     public const int MonsterIdFieldNumber = 1;
     private int monsterId_;
+    /// <summary>
+    /// Entity Unique id
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int MonsterId {
@@ -9623,8 +9425,23 @@ namespace Google.Protobuf.Protocol {
       }
     }
 
+    /// <summary>Field number for the "monsterTypeId" field.</summary>
+    public const int MonsterTypeIdFieldNumber = 2;
+    private int monsterTypeId_;
+    /// <summary>
+    /// Monster Type (Template or Resources Id)
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int MonsterTypeId {
+      get { return monsterTypeId_; }
+      set {
+        monsterTypeId_ = value;
+      }
+    }
+
     /// <summary>Field number for the "pos" field.</summary>
-    public const int PosFieldNumber = 2;
+    public const int PosFieldNumber = 3;
     private global::Google.Protobuf.Protocol.Vector2Info pos_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -9636,7 +9453,7 @@ namespace Google.Protobuf.Protocol {
     }
 
     /// <summary>Field number for the "direction" field.</summary>
-    public const int DirectionFieldNumber = 3;
+    public const int DirectionFieldNumber = 4;
     private global::Google.Protobuf.Protocol.EDirection direction_ = global::Google.Protobuf.Protocol.EDirection.DirUp;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -9663,6 +9480,7 @@ namespace Google.Protobuf.Protocol {
         return true;
       }
       if (MonsterId != other.MonsterId) return false;
+      if (MonsterTypeId != other.MonsterTypeId) return false;
       if (!object.Equals(Pos, other.Pos)) return false;
       if (Direction != other.Direction) return false;
       return Equals(_unknownFields, other._unknownFields);
@@ -9673,6 +9491,7 @@ namespace Google.Protobuf.Protocol {
     public override int GetHashCode() {
       int hash = 1;
       if (MonsterId != 0) hash ^= MonsterId.GetHashCode();
+      if (MonsterTypeId != 0) hash ^= MonsterTypeId.GetHashCode();
       if (pos_ != null) hash ^= Pos.GetHashCode();
       if (Direction != global::Google.Protobuf.Protocol.EDirection.DirUp) hash ^= Direction.GetHashCode();
       if (_unknownFields != null) {
@@ -9697,12 +9516,16 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(8);
         output.WriteInt32(MonsterId);
       }
+      if (MonsterTypeId != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(MonsterTypeId);
+      }
       if (pos_ != null) {
-        output.WriteRawTag(18);
+        output.WriteRawTag(26);
         output.WriteMessage(Pos);
       }
       if (Direction != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(24);
+        output.WriteRawTag(32);
         output.WriteEnum((int) Direction);
       }
       if (_unknownFields != null) {
@@ -9719,12 +9542,16 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(8);
         output.WriteInt32(MonsterId);
       }
+      if (MonsterTypeId != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(MonsterTypeId);
+      }
       if (pos_ != null) {
-        output.WriteRawTag(18);
+        output.WriteRawTag(26);
         output.WriteMessage(Pos);
       }
       if (Direction != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(24);
+        output.WriteRawTag(32);
         output.WriteEnum((int) Direction);
       }
       if (_unknownFields != null) {
@@ -9739,6 +9566,9 @@ namespace Google.Protobuf.Protocol {
       int size = 0;
       if (MonsterId != 0) {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterId);
+      }
+      if (MonsterTypeId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterTypeId);
       }
       if (pos_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Pos);
@@ -9760,6 +9590,9 @@ namespace Google.Protobuf.Protocol {
       }
       if (other.MonsterId != 0) {
         MonsterId = other.MonsterId;
+      }
+      if (other.MonsterTypeId != 0) {
+        MonsterTypeId = other.MonsterTypeId;
       }
       if (other.pos_ != null) {
         if (pos_ == null) {
@@ -9789,14 +9622,18 @@ namespace Google.Protobuf.Protocol {
             MonsterId = input.ReadInt32();
             break;
           }
-          case 18: {
+          case 16: {
+            MonsterTypeId = input.ReadInt32();
+            break;
+          }
+          case 26: {
             if (pos_ == null) {
               Pos = new global::Google.Protobuf.Protocol.Vector2Info();
             }
             input.ReadMessage(Pos);
             break;
           }
-          case 24: {
+          case 32: {
             Direction = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
             break;
           }
@@ -9819,14 +9656,18 @@ namespace Google.Protobuf.Protocol {
             MonsterId = input.ReadInt32();
             break;
           }
-          case 18: {
+          case 16: {
+            MonsterTypeId = input.ReadInt32();
+            break;
+          }
+          case 26: {
             if (pos_ == null) {
               Pos = new global::Google.Protobuf.Protocol.Vector2Info();
             }
             input.ReadMessage(Pos);
             break;
           }
-          case 24: {
+          case 32: {
             Direction = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
             break;
           }

--- a/GameServer/FieldRoom.cpp
+++ b/GameServer/FieldRoom.cpp
@@ -95,6 +95,17 @@ void FieldRoom::SendSystemMessageToPlayer(int playerId, const std::string& messa
 	}
 }
 
+void FieldRoom::SendMonstersToPlayer(PlayerRef p)
+{
+	auto pkt = _monsters->BuildMonsterSnapShot(RoomId());
+	auto sendBuffer = ClientPacketHandler::MakeSendBuffer(pkt);
+	if (auto s = p->ownerSession.lock())
+	{
+		auto sendBuffer = ClientPacketHandler::MakeSendBuffer(pkt);
+		s->Send(sendBuffer);
+	}
+}
+
 void FieldRoom::InitRoomSystems()
 {
 	_lastMonsterTickMs = _clock.NowMs(); // 첫 기준 시각
@@ -121,15 +132,7 @@ void FieldRoom::OnEnter(const PlayerRef& p)
 	}
 
 	// 맵에 있는 몬스터 전송 - 나중에 이부분은 합칠 예정
-	{
-		auto pkt = _monsters->BuildMonsterSnapShot(RoomId());
-		auto sendBuffer = ClientPacketHandler::MakeSendBuffer(pkt);
-		if (auto s = p->ownerSession.lock())
-		{
-			auto sendBuffer = ClientPacketHandler::MakeSendBuffer(pkt);
-			s->Send(sendBuffer);
-		}
-	}
+	SendMonstersToPlayer(p);
 	
 }
 
@@ -232,15 +235,19 @@ void FieldRoom::MonsterEntityLinkerImpl::ApplyDamageToPlayer(int pid, int dmg, i
 }
 
 // ------------------- Broadcaster -------------------
-void FieldRoom::MonsterBroadcasterImpl::SpawnMonster(const Monster& m)
+void FieldRoom::MonsterBroadcasterImpl::SpawnMonster(const Monster& monster)
 {
 	Protocol::S_SpawnMonster pkt;
-	pkt.set_monsterid(m.core.id);
-	pkt.set_monstertypeid(m.typeId);
-	pkt.set_x(m.core.pos.x);
-	pkt.set_y(m.core.pos.y);
-	pkt.set_dir(m.core.dir);
-	GConsoleLogger->WriteStdOut(Color::YELLOW, L"몬스터 스폰 Id: %d, x: %d, y: %d, dir: %d\n", m.core.id, m.core.pos.x, m.core.pos.y, (int)m.core.dir);
+	auto* info = pkt.mutable_monster();
+	info->set_monsterid(monster.core.id);
+	info->set_monstertypeid(monster.typeId);
+	auto* pos = info->mutable_pos();
+	pos->set_x(monster.core.pos.x);
+	pos->set_y(monster.core.pos.y);
+
+	info->set_direction(monster.core.dir);
+	
+	GConsoleLogger->WriteStdOut(Color::YELLOW, L"몬스터 스폰 Id: %d, typeId: %d, x: %d, y: %d, dir: %d\n", monster.core.id, monster.typeId, monster.core.pos.x, monster.core.pos.y, (int)monster.core.dir);
 	_r.Broadcast(ClientPacketHandler::MakeSendBuffer(pkt));
 }
 

--- a/GameServer/FieldRoom.h
+++ b/GameServer/FieldRoom.h
@@ -36,6 +36,7 @@ public:
 
     void SendInventoryUpdateToPlayer(int killPlayerId);
     void SendSystemMessageToPlayer(int playerId, const std::string& message, Protocol::EMessageType type);
+    void SendMonstersToPlayer(PlayerRef p);
 
 protected:
 	// 최초 1회 초기화

--- a/GameServer/MonsterContainer.cpp
+++ b/GameServer/MonsterContainer.cpp
@@ -94,7 +94,7 @@ Protocol::S_MonsterList MonsterContainer::BuildMonsterSnapShot(int mapId) const
 	{
 		Protocol::MonsterInfo* info = out->Add();
 		info->set_monsterid(monster.core.id);
-		
+		info->set_monstertypeid(monster.typeId);
 		auto* pos = info->mutable_pos();
 		pos->set_x(monster.core.pos.x);
 		pos->set_y(monster.core.pos.y);

--- a/GameServer/Protocol.pb.cc
+++ b/GameServer/Protocol.pb.cc
@@ -296,8 +296,7 @@ struct C_ChangeRoomReadyDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 C_ChangeRoomReadyDefaultTypeInternal _C_ChangeRoomReady_default_instance_;
 PROTOBUF_CONSTEXPR S_ChangeRoomCommit::S_ChangeRoomCommit(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.snapshots_)*/nullptr
-  , /*decltype(_impl_.transitionid_)*/0
+    /*decltype(_impl_.transitionid_)*/0
   , /*decltype(_impl_.mapid_)*/0
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct S_ChangeRoomCommitDefaultTypeInternal {
@@ -311,11 +310,7 @@ struct S_ChangeRoomCommitDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 S_ChangeRoomCommitDefaultTypeInternal _S_ChangeRoomCommit_default_instance_;
 PROTOBUF_CONSTEXPR S_SpawnMonster::S_SpawnMonster(
     ::_pbi::ConstantInitialized): _impl_{
-    /*decltype(_impl_.monsterid_)*/0
-  , /*decltype(_impl_.monstertypeid_)*/0
-  , /*decltype(_impl_.x_)*/0
-  , /*decltype(_impl_.y_)*/0
-  , /*decltype(_impl_.dir_)*/0
+    /*decltype(_impl_.monster_)*/nullptr
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct S_SpawnMonsterDefaultTypeInternal {
   PROTOBUF_CONSTEXPR S_SpawnMonsterDefaultTypeInternal()
@@ -584,6 +579,7 @@ PROTOBUF_CONSTEXPR MonsterInfo::MonsterInfo(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.pos_)*/nullptr
   , /*decltype(_impl_.monsterid_)*/0
+  , /*decltype(_impl_.monstertypeid_)*/0
   , /*decltype(_impl_.direction_)*/0
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct MonsterInfoDefaultTypeInternal {
@@ -763,18 +759,13 @@ const uint32_t TableStruct_Protocol_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::Protocol::S_ChangeRoomCommit, _impl_.transitionid_),
   PROTOBUF_FIELD_OFFSET(::Protocol::S_ChangeRoomCommit, _impl_.mapid_),
-  PROTOBUF_FIELD_OFFSET(::Protocol::S_ChangeRoomCommit, _impl_.snapshots_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::Protocol::S_SpawnMonster, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
-  PROTOBUF_FIELD_OFFSET(::Protocol::S_SpawnMonster, _impl_.monsterid_),
-  PROTOBUF_FIELD_OFFSET(::Protocol::S_SpawnMonster, _impl_.monstertypeid_),
-  PROTOBUF_FIELD_OFFSET(::Protocol::S_SpawnMonster, _impl_.x_),
-  PROTOBUF_FIELD_OFFSET(::Protocol::S_SpawnMonster, _impl_.y_),
-  PROTOBUF_FIELD_OFFSET(::Protocol::S_SpawnMonster, _impl_.dir_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_SpawnMonster, _impl_.monster_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::Protocol::S_DespawnMonster, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -930,6 +921,7 @@ const uint32_t TableStruct_Protocol_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   ~0u,  // no _weak_field_map_
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::Protocol::MonsterInfo, _impl_.monsterid_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::MonsterInfo, _impl_.monstertypeid_),
   PROTOBUF_FIELD_OFFSET(::Protocol::MonsterInfo, _impl_.pos_),
   PROTOBUF_FIELD_OFFSET(::Protocol::MonsterInfo, _impl_.direction_),
 };
@@ -955,26 +947,26 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 139, -1, -1, sizeof(::Protocol::S_ChangeRoomBegin)},
   { 147, -1, -1, sizeof(::Protocol::C_ChangeRoomReady)},
   { 154, -1, -1, sizeof(::Protocol::S_ChangeRoomCommit)},
-  { 163, -1, -1, sizeof(::Protocol::S_SpawnMonster)},
-  { 174, -1, -1, sizeof(::Protocol::S_DespawnMonster)},
-  { 182, -1, -1, sizeof(::Protocol::S_BroadcastMonsterMove)},
-  { 192, -1, -1, sizeof(::Protocol::S_BroadcastMonsterAttack)},
-  { 200, -1, -1, sizeof(::Protocol::S_BroadcastMonsterDeath)},
-  { 207, -1, -1, sizeof(::Protocol::C_PlayerAttackRequest)},
-  { 213, -1, -1, sizeof(::Protocol::S_BroadcastPlayerAttack)},
-  { 223, -1, -1, sizeof(::Protocol::C_InventoryRequest)},
-  { 229, -1, -1, sizeof(::Protocol::S_InventoryReply)},
-  { 236, -1, -1, sizeof(::Protocol::C_ItemUseRequest)},
-  { 243, -1, -1, sizeof(::Protocol::S_ItemUseReply)},
-  { 251, -1, -1, sizeof(::Protocol::S_InventoryUpdate)},
-  { 258, -1, -1, sizeof(::Protocol::S_SystemMessage)},
-  { 266, -1, -1, sizeof(::Protocol::S_MonsterList)},
-  { 274, -1, -1, sizeof(::Protocol::Vector2Info)},
-  { 282, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
-  { 292, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
-  { 302, -1, -1, sizeof(::Protocol::PlayerInfo)},
-  { 312, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
-  { 322, -1, -1, sizeof(::Protocol::MonsterInfo)},
+  { 162, -1, -1, sizeof(::Protocol::S_SpawnMonster)},
+  { 169, -1, -1, sizeof(::Protocol::S_DespawnMonster)},
+  { 177, -1, -1, sizeof(::Protocol::S_BroadcastMonsterMove)},
+  { 187, -1, -1, sizeof(::Protocol::S_BroadcastMonsterAttack)},
+  { 195, -1, -1, sizeof(::Protocol::S_BroadcastMonsterDeath)},
+  { 202, -1, -1, sizeof(::Protocol::C_PlayerAttackRequest)},
+  { 208, -1, -1, sizeof(::Protocol::S_BroadcastPlayerAttack)},
+  { 218, -1, -1, sizeof(::Protocol::C_InventoryRequest)},
+  { 224, -1, -1, sizeof(::Protocol::S_InventoryReply)},
+  { 231, -1, -1, sizeof(::Protocol::C_ItemUseRequest)},
+  { 238, -1, -1, sizeof(::Protocol::S_ItemUseReply)},
+  { 246, -1, -1, sizeof(::Protocol::S_InventoryUpdate)},
+  { 253, -1, -1, sizeof(::Protocol::S_SystemMessage)},
+  { 261, -1, -1, sizeof(::Protocol::S_MonsterList)},
+  { 269, -1, -1, sizeof(::Protocol::Vector2Info)},
+  { 277, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
+  { 287, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
+  { 297, -1, -1, sizeof(::Protocol::PlayerInfo)},
+  { 307, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
+  { 317, -1, -1, sizeof(::Protocol::MonsterInfo)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -1056,98 +1048,96 @@ const char descriptor_table_protodef_Protocol_2eproto[] PROTOBUF_SECTION_VARIABL
   "Moves\030\002 \003(\0132\030.Protocol.PlayerMoveInfo\"8\n"
   "\021S_ChangeRoomBegin\022\024\n\014transitionId\030\001 \001(\005"
   "\022\r\n\005mapId\030\002 \001(\005\")\n\021C_ChangeRoomReady\022\024\n\014"
-  "transitionId\030\001 \001(\005\"d\n\022S_ChangeRoomCommit"
-  "\022\024\n\014transitionId\030\001 \001(\005\022\r\n\005mapId\030\002 \001(\005\022)\n"
-  "\tsnapshots\030\003 \001(\0132\026.Protocol.S_PlayerList"
-  "\"s\n\016S_SpawnMonster\022\021\n\tmonsterId\030\001 \001(\005\022\025\n"
-  "\rmonsterTypeId\030\002 \001(\005\022\t\n\001x\030\003 \001(\005\022\t\n\001y\030\004 \001"
-  "(\005\022!\n\003dir\030\005 \001(\0162\024.Protocol.EDirection\"O\n"
-  "\020S_DespawnMonster\022\021\n\tmonsterId\030\001 \001(\005\022(\n\006"
-  "reason\030\002 \001(\0162\030.Protocol.EDespawnReason\"d"
-  "\n\026S_BroadcastMonsterMove\022\021\n\tmonsterId\030\001 "
-  "\001(\005\022\t\n\001x\030\002 \001(\005\022\t\n\001y\030\003 \001(\005\022!\n\003dir\030\004 \001(\0162\024"
-  ".Protocol.EDirection\"@\n\030S_BroadcastMonst"
-  "erAttack\022\021\n\tmonsterId\030\001 \001(\005\022\021\n\ttargetPid"
-  "\030\002 \001(\005\",\n\027S_BroadcastMonsterDeath\022\021\n\tmon"
-  "sterId\030\001 \001(\005\"\027\n\025C_PlayerAttackRequest\"^\n"
-  "\027S_BroadcastPlayerAttack\022\020\n\010playerId\030\001 \001"
-  "(\005\022\020\n\010targetId\030\002 \001(\005\022\016\n\006damage\030\003 \001(\005\022\017\n\007"
-  "hpAfter\030\004 \001(\005\"\024\n\022C_InventoryRequest\">\n\020S"
-  "_InventoryReply\022*\n\005slots\030\001 \003(\0132\033.Protoco"
-  "l.InventorySlotInfo\"%\n\020C_ItemUseRequest\022"
-  "\021\n\tslotIndex\030\001 \001(\005\"7\n\016S_ItemUseReply\022\017\n\007"
-  "success\030\001 \001(\010\022\024\n\014errorMessage\030\002 \001(\t\"F\n\021S"
-  "_InventoryUpdate\0221\n\014changedSlots\030\001 \003(\0132\033"
-  ".Protocol.InventorySlotInfo\"H\n\017S_SystemM"
-  "essage\022\017\n\007message\030\001 \001(\t\022$\n\004type\030\002 \001(\0162\026."
-  "Protocol.EMessageType\"G\n\rS_MonsterList\022\r"
-  "\n\005mapId\030\001 \001(\005\022\'\n\010monsters\030\002 \003(\0132\025.Protoc"
-  "ol.MonsterInfo\"#\n\013Vector2Info\022\t\n\001x\030\001 \001(\005"
-  "\022\t\n\001y\030\002 \001(\005\"\231\001\n\016PlayerMoveInfo\022\020\n\010player"
-  "Id\030\001 \001(\005\022\'\n\tdirection\030\002 \001(\0162\024.Protocol.E"
-  "Direction\022%\n\006newPos\030\003 \001(\0132\025.Protocol.Vec"
-  "tor2Info\022%\n\006result\030\004 \001(\0162\025.Protocol.EMov"
-  "eResult\"}\n\024CharacterSummaryInfo\022\020\n\010usern"
-  "ame\030\001 \001(\t\022\r\n\005level\030\002 \001(\005\022!\n\006gender\030\003 \001(\016"
-  "2\021.Protocol.EGender\022!\n\006region\030\004 \001(\0162\021.Pr"
-  "otocol.ERegion\"w\n\nPlayerInfo\022\n\n\002id\030\001 \001(\005"
-  "\022\020\n\010username\030\002 \001(\t\022\"\n\003pos\030\003 \001(\0132\025.Protoc"
-  "ol.Vector2Info\022\'\n\tdirection\030\004 \001(\0162\024.Prot"
-  "ocol.EDirection\"Z\n\021InventorySlotInfo\022\021\n\t"
-  "slotIndex\030\001 \001(\005\022\016\n\006itemId\030\002 \001(\005\022\r\n\005count"
-  "\030\003 \001(\005\022\023\n\013isQuickslot\030\004 \001(\010\"m\n\013MonsterIn"
-  "fo\022\021\n\tmonsterId\030\001 \001(\005\022\"\n\003pos\030\002 \001(\0132\025.Pro"
-  "tocol.Vector2Info\022\'\n\tdirection\030\003 \001(\0162\024.P"
-  "rotocol.EDirection*\206\007\n\005MsgId\022\027\n\023C_JWT_LO"
-  "GIN_REQUEST\020\000\022\025\n\021S_JWT_LOGIN_REPLY\020\001\022\036\n\032"
-  "C_CREATE_CHARACTER_REQUEST\020\002\022\034\n\030S_CREATE"
-  "_CHARACTER_REPLY\020\003\022\034\n\030C_CHARACTER_LIST_R"
-  "EQUEST\020\004\022\032\n\026S_CHARACTER_LIST_REPLY\020\005\022\036\n\032"
-  "C_DELETE_CHARACTER_REQUEST\020\006\022\034\n\030S_DELETE"
-  "_CHARACTER_REPLY\020\007\022\020\n\014C_ENTER_GAME\020\010\022\020\n\014"
-  "S_ENTER_GAME\020\t\022\021\n\rS_PLAYER_LIST\020\n\022\034\n\030S_B"
-  "ROADCAST_PLAYER_ENTER\020\013\022\020\n\014C_LEAVE_GAME\020"
-  "\014\022\020\n\014S_LEAVE_GAME\020\r\022\034\n\030S_BROADCAST_PLAYE"
-  "R_LEAVE\020\016\022\031\n\025C_PLAYER_MOVE_REQUEST\020\017\022\027\n\023"
-  "S_PLAYER_MOVE_REPLY\020\020\022\033\n\027S_BROADCAST_PLA"
-  "YER_MOVE\020\021\022\027\n\023S_CHANGE_ROOM_BEGIN\020\022\022\027\n\023C"
-  "_CHANGE_ROOM_READY\020\023\022\030\n\024S_CHANGE_ROOM_CO"
-  "MMIT\020\024\022\023\n\017S_SPAWN_MONSTER\020\025\022\025\n\021S_DESPAWN"
-  "_MONSTER\020\026\022\034\n\030S_BROADCAST_MONSTER_MOVE\020\027"
-  "\022\036\n\032S_BROADCAST_MONSTER_ATTACK\020\030\022\035\n\031S_BR"
-  "OADCAST_MONSTER_DEATH\020\031\022\033\n\027C_PLAYER_ATTA"
-  "CK_REQUEST\020\032\022\035\n\031S_BROADCAST_PLAYER_ATTAC"
-  "K\020\033\022\027\n\023C_INVENTORY_REQUEST\020\034\022\025\n\021S_INVENT"
-  "ORY_REPLY\020\035\022\026\n\022C_ITEM_USE_REQUEST\020\036\022\024\n\020S"
-  "_ITEM_USE_REPLY\020\037\022\026\n\022S_INVENTORY_UPDATE\020"
-  " \022\024\n\020S_SYSTEM_MESSAGE\020!\022\022\n\016S_MONSTER_LIS"
-  "T\020\"*S\n\014ELoginResult\022\013\n\007SUCCESS\020\000\022\021\n\rINVA"
-  "LID_TOKEN\020\001\022\021\n\rTOKEN_EXPIRED\020\002\022\020\n\014SERVER"
-  "_ERROR\020\003*>\n\007EGender\022\017\n\013GENDER_NONE\020\000\022\017\n\013"
-  "GENDER_MALE\020\001\022\021\n\rGENDER_FEMALE\020\002*:\n\007EReg"
-  "ion\022\017\n\013REGION_NONE\020\000\022\r\n\tREGION_GO\020\001\022\017\n\013R"
-  "EGION_BACK\020\002*C\n\nEDirection\022\n\n\006DIR_UP\020\000\022\014"
-  "\n\010DIR_DOWN\020\001\022\014\n\010DIR_LEFT\020\002\022\r\n\tDIR_RIGHT\020"
-  "\003*|\n\014ELeaveReason\022\021\n\rLEAVE_UNKNOWN\020\000\022\020\n\014"
-  "LEAVE_LOGOUT\020\001\022\025\n\021LEAVE_CHANGE_ROOM\020\002\022\032\n"
-  "\026LEAVE_CHANGE_CHARACTER\020\003\022\024\n\020LEAVE_DISCO"
-  "NNECT\020\004*_\n\013EMoveResult\022\020\n\014MOVE_UNKNOWN\020\000"
-  "\022\013\n\007MOVE_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_COOL"
-  "DOWN\020\003\022\020\n\014MOVE_BLOCKED\020\004*I\n\014EEnterReason"
-  "\022\021\n\rENTER_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022\025\n\021"
-  "ENTER_CHANGE_ROOM\020\002*9\n\016EDespawnReason\022\023\n"
-  "\017DESPAWN_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020\001*~"
-  "\n\tEItemType\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n\024IT"
-  "EM_TYPE_CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQUIPM"
-  "ENT\020\002\022\023\n\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TYPE_"
-  "MISC\020\004*a\n\014EMessageType\022\020\n\014MESSAGE_INFO\020\000"
-  "\022\023\n\017MESSAGE_WARNING\020\001\022\021\n\rMESSAGE_ERROR\020\002"
-  "\022\027\n\023MESSAGE_DROP_FAILED\020\003B\033\252\002\030Google.Pro"
-  "tobuf.Protocolb\006proto3"
+  "transitionId\030\001 \001(\005\"9\n\022S_ChangeRoomCommit"
+  "\022\024\n\014transitionId\030\001 \001(\005\022\r\n\005mapId\030\002 \001(\005\"8\n"
+  "\016S_SpawnMonster\022&\n\007monster\030\001 \001(\0132\025.Proto"
+  "col.MonsterInfo\"O\n\020S_DespawnMonster\022\021\n\tm"
+  "onsterId\030\001 \001(\005\022(\n\006reason\030\002 \001(\0162\030.Protoco"
+  "l.EDespawnReason\"d\n\026S_BroadcastMonsterMo"
+  "ve\022\021\n\tmonsterId\030\001 \001(\005\022\t\n\001x\030\002 \001(\005\022\t\n\001y\030\003 "
+  "\001(\005\022!\n\003dir\030\004 \001(\0162\024.Protocol.EDirection\"@"
+  "\n\030S_BroadcastMonsterAttack\022\021\n\tmonsterId\030"
+  "\001 \001(\005\022\021\n\ttargetPid\030\002 \001(\005\",\n\027S_BroadcastM"
+  "onsterDeath\022\021\n\tmonsterId\030\001 \001(\005\"\027\n\025C_Play"
+  "erAttackRequest\"^\n\027S_BroadcastPlayerAtta"
+  "ck\022\020\n\010playerId\030\001 \001(\005\022\020\n\010targetId\030\002 \001(\005\022\016"
+  "\n\006damage\030\003 \001(\005\022\017\n\007hpAfter\030\004 \001(\005\"\024\n\022C_Inv"
+  "entoryRequest\">\n\020S_InventoryReply\022*\n\005slo"
+  "ts\030\001 \003(\0132\033.Protocol.InventorySlotInfo\"%\n"
+  "\020C_ItemUseRequest\022\021\n\tslotIndex\030\001 \001(\005\"7\n\016"
+  "S_ItemUseReply\022\017\n\007success\030\001 \001(\010\022\024\n\014error"
+  "Message\030\002 \001(\t\"F\n\021S_InventoryUpdate\0221\n\014ch"
+  "angedSlots\030\001 \003(\0132\033.Protocol.InventorySlo"
+  "tInfo\"H\n\017S_SystemMessage\022\017\n\007message\030\001 \001("
+  "\t\022$\n\004type\030\002 \001(\0162\026.Protocol.EMessageType\""
+  "G\n\rS_MonsterList\022\r\n\005mapId\030\001 \001(\005\022\'\n\010monst"
+  "ers\030\002 \003(\0132\025.Protocol.MonsterInfo\"#\n\013Vect"
+  "or2Info\022\t\n\001x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\"\231\001\n\016Player"
+  "MoveInfo\022\020\n\010playerId\030\001 \001(\005\022\'\n\tdirection\030"
+  "\002 \001(\0162\024.Protocol.EDirection\022%\n\006newPos\030\003 "
+  "\001(\0132\025.Protocol.Vector2Info\022%\n\006result\030\004 \001"
+  "(\0162\025.Protocol.EMoveResult\"}\n\024CharacterSu"
+  "mmaryInfo\022\020\n\010username\030\001 \001(\t\022\r\n\005level\030\002 \001"
+  "(\005\022!\n\006gender\030\003 \001(\0162\021.Protocol.EGender\022!\n"
+  "\006region\030\004 \001(\0162\021.Protocol.ERegion\"w\n\nPlay"
+  "erInfo\022\n\n\002id\030\001 \001(\005\022\020\n\010username\030\002 \001(\t\022\"\n\003"
+  "pos\030\003 \001(\0132\025.Protocol.Vector2Info\022\'\n\tdire"
+  "ction\030\004 \001(\0162\024.Protocol.EDirection\"Z\n\021Inv"
+  "entorySlotInfo\022\021\n\tslotIndex\030\001 \001(\005\022\016\n\006ite"
+  "mId\030\002 \001(\005\022\r\n\005count\030\003 \001(\005\022\023\n\013isQuickslot\030"
+  "\004 \001(\010\"\204\001\n\013MonsterInfo\022\021\n\tmonsterId\030\001 \001(\005"
+  "\022\025\n\rmonsterTypeId\030\002 \001(\005\022\"\n\003pos\030\003 \001(\0132\025.P"
+  "rotocol.Vector2Info\022\'\n\tdirection\030\004 \001(\0162\024"
+  ".Protocol.EDirection*\206\007\n\005MsgId\022\027\n\023C_JWT_"
+  "LOGIN_REQUEST\020\000\022\025\n\021S_JWT_LOGIN_REPLY\020\001\022\036"
+  "\n\032C_CREATE_CHARACTER_REQUEST\020\002\022\034\n\030S_CREA"
+  "TE_CHARACTER_REPLY\020\003\022\034\n\030C_CHARACTER_LIST"
+  "_REQUEST\020\004\022\032\n\026S_CHARACTER_LIST_REPLY\020\005\022\036"
+  "\n\032C_DELETE_CHARACTER_REQUEST\020\006\022\034\n\030S_DELE"
+  "TE_CHARACTER_REPLY\020\007\022\020\n\014C_ENTER_GAME\020\010\022\020"
+  "\n\014S_ENTER_GAME\020\t\022\021\n\rS_PLAYER_LIST\020\n\022\034\n\030S"
+  "_BROADCAST_PLAYER_ENTER\020\013\022\020\n\014C_LEAVE_GAM"
+  "E\020\014\022\020\n\014S_LEAVE_GAME\020\r\022\034\n\030S_BROADCAST_PLA"
+  "YER_LEAVE\020\016\022\031\n\025C_PLAYER_MOVE_REQUEST\020\017\022\027"
+  "\n\023S_PLAYER_MOVE_REPLY\020\020\022\033\n\027S_BROADCAST_P"
+  "LAYER_MOVE\020\021\022\027\n\023S_CHANGE_ROOM_BEGIN\020\022\022\027\n"
+  "\023C_CHANGE_ROOM_READY\020\023\022\030\n\024S_CHANGE_ROOM_"
+  "COMMIT\020\024\022\023\n\017S_SPAWN_MONSTER\020\025\022\025\n\021S_DESPA"
+  "WN_MONSTER\020\026\022\034\n\030S_BROADCAST_MONSTER_MOVE"
+  "\020\027\022\036\n\032S_BROADCAST_MONSTER_ATTACK\020\030\022\035\n\031S_"
+  "BROADCAST_MONSTER_DEATH\020\031\022\033\n\027C_PLAYER_AT"
+  "TACK_REQUEST\020\032\022\035\n\031S_BROADCAST_PLAYER_ATT"
+  "ACK\020\033\022\027\n\023C_INVENTORY_REQUEST\020\034\022\025\n\021S_INVE"
+  "NTORY_REPLY\020\035\022\026\n\022C_ITEM_USE_REQUEST\020\036\022\024\n"
+  "\020S_ITEM_USE_REPLY\020\037\022\026\n\022S_INVENTORY_UPDAT"
+  "E\020 \022\024\n\020S_SYSTEM_MESSAGE\020!\022\022\n\016S_MONSTER_L"
+  "IST\020\"*S\n\014ELoginResult\022\013\n\007SUCCESS\020\000\022\021\n\rIN"
+  "VALID_TOKEN\020\001\022\021\n\rTOKEN_EXPIRED\020\002\022\020\n\014SERV"
+  "ER_ERROR\020\003*>\n\007EGender\022\017\n\013GENDER_NONE\020\000\022\017"
+  "\n\013GENDER_MALE\020\001\022\021\n\rGENDER_FEMALE\020\002*:\n\007ER"
+  "egion\022\017\n\013REGION_NONE\020\000\022\r\n\tREGION_GO\020\001\022\017\n"
+  "\013REGION_BACK\020\002*C\n\nEDirection\022\n\n\006DIR_UP\020\000"
+  "\022\014\n\010DIR_DOWN\020\001\022\014\n\010DIR_LEFT\020\002\022\r\n\tDIR_RIGH"
+  "T\020\003*|\n\014ELeaveReason\022\021\n\rLEAVE_UNKNOWN\020\000\022\020"
+  "\n\014LEAVE_LOGOUT\020\001\022\025\n\021LEAVE_CHANGE_ROOM\020\002\022"
+  "\032\n\026LEAVE_CHANGE_CHARACTER\020\003\022\024\n\020LEAVE_DIS"
+  "CONNECT\020\004*_\n\013EMoveResult\022\020\n\014MOVE_UNKNOWN"
+  "\020\000\022\013\n\007MOVE_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_CO"
+  "OLDOWN\020\003\022\020\n\014MOVE_BLOCKED\020\004*I\n\014EEnterReas"
+  "on\022\021\n\rENTER_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022\025"
+  "\n\021ENTER_CHANGE_ROOM\020\002*9\n\016EDespawnReason\022"
+  "\023\n\017DESPAWN_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020\001"
+  "*~\n\tEItemType\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n\024"
+  "ITEM_TYPE_CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQUI"
+  "PMENT\020\002\022\023\n\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TYP"
+  "E_MISC\020\004*a\n\014EMessageType\022\020\n\014MESSAGE_INFO"
+  "\020\000\022\023\n\017MESSAGE_WARNING\020\001\022\021\n\rMESSAGE_ERROR"
+  "\020\002\022\027\n\023MESSAGE_DROP_FAILED\020\003B\033\252\002\030Google.P"
+  "rotobuf.Protocolb\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_Protocol_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_Protocol_2eproto = {
-    false, false, 4862, descriptor_table_protodef_Protocol_2eproto,
+    false, false, 4784, descriptor_table_protodef_Protocol_2eproto,
     "Protocol.proto",
     &descriptor_table_Protocol_2eproto_once, nullptr, 0, 41,
     schemas, file_default_instances, TableStruct_Protocol_2eproto::offsets,
@@ -5430,13 +5420,8 @@ void C_ChangeRoomReady::InternalSwap(C_ChangeRoomReady* other) {
 
 class S_ChangeRoomCommit::_Internal {
  public:
-  static const ::Protocol::S_PlayerList& snapshots(const S_ChangeRoomCommit* msg);
 };
 
-const ::Protocol::S_PlayerList&
-S_ChangeRoomCommit::_Internal::snapshots(const S_ChangeRoomCommit* msg) {
-  return *msg->_impl_.snapshots_;
-}
 S_ChangeRoomCommit::S_ChangeRoomCommit(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
@@ -5447,15 +5432,11 @@ S_ChangeRoomCommit::S_ChangeRoomCommit(const S_ChangeRoomCommit& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   S_ChangeRoomCommit* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.snapshots_){nullptr}
-    , decltype(_impl_.transitionid_){}
+      decltype(_impl_.transitionid_){}
     , decltype(_impl_.mapid_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  if (from._internal_has_snapshots()) {
-    _this->_impl_.snapshots_ = new ::Protocol::S_PlayerList(*from._impl_.snapshots_);
-  }
   ::memcpy(&_impl_.transitionid_, &from._impl_.transitionid_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.mapid_) -
     reinterpret_cast<char*>(&_impl_.transitionid_)) + sizeof(_impl_.mapid_));
@@ -5467,8 +5448,7 @@ inline void S_ChangeRoomCommit::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.snapshots_){nullptr}
-    , decltype(_impl_.transitionid_){0}
+      decltype(_impl_.transitionid_){0}
     , decltype(_impl_.mapid_){0}
     , /*decltype(_impl_._cached_size_)*/{}
   };
@@ -5485,7 +5465,6 @@ S_ChangeRoomCommit::~S_ChangeRoomCommit() {
 
 inline void S_ChangeRoomCommit::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
-  if (this != internal_default_instance()) delete _impl_.snapshots_;
 }
 
 void S_ChangeRoomCommit::SetCachedSize(int size) const {
@@ -5498,10 +5477,6 @@ void S_ChangeRoomCommit::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  if (GetArenaForAllocation() == nullptr && _impl_.snapshots_ != nullptr) {
-    delete _impl_.snapshots_;
-  }
-  _impl_.snapshots_ = nullptr;
   ::memset(&_impl_.transitionid_, 0, static_cast<size_t>(
       reinterpret_cast<char*>(&_impl_.mapid_) -
       reinterpret_cast<char*>(&_impl_.transitionid_)) + sizeof(_impl_.mapid_));
@@ -5526,14 +5501,6 @@ const char* S_ChangeRoomCommit::_InternalParse(const char* ptr, ::_pbi::ParseCon
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
           _impl_.mapid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // .Protocol.S_PlayerList snapshots = 3;
-      case 3:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
-          ptr = ctx->ParseMessage(_internal_mutable_snapshots(), ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
@@ -5579,13 +5546,6 @@ uint8_t* S_ChangeRoomCommit::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteInt32ToArray(2, this->_internal_mapid(), target);
   }
 
-  // .Protocol.S_PlayerList snapshots = 3;
-  if (this->_internal_has_snapshots()) {
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
-      InternalWriteMessage(3, _Internal::snapshots(this),
-        _Internal::snapshots(this).GetCachedSize(), target, stream);
-  }
-
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -5601,13 +5561,6 @@ size_t S_ChangeRoomCommit::ByteSizeLong() const {
   uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
-
-  // .Protocol.S_PlayerList snapshots = 3;
-  if (this->_internal_has_snapshots()) {
-    total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
-        *_impl_.snapshots_);
-  }
 
   // int32 transitionId = 1;
   if (this->_internal_transitionid() != 0) {
@@ -5637,10 +5590,6 @@ void S_ChangeRoomCommit::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, con
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_has_snapshots()) {
-    _this->_internal_mutable_snapshots()->::Protocol::S_PlayerList::MergeFrom(
-        from._internal_snapshots());
-  }
   if (from._internal_transitionid() != 0) {
     _this->_internal_set_transitionid(from._internal_transitionid());
   }
@@ -5667,9 +5616,9 @@ void S_ChangeRoomCommit::InternalSwap(S_ChangeRoomCommit* other) {
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(S_ChangeRoomCommit, _impl_.mapid_)
       + sizeof(S_ChangeRoomCommit::_impl_.mapid_)
-      - PROTOBUF_FIELD_OFFSET(S_ChangeRoomCommit, _impl_.snapshots_)>(
-          reinterpret_cast<char*>(&_impl_.snapshots_),
-          reinterpret_cast<char*>(&other->_impl_.snapshots_));
+      - PROTOBUF_FIELD_OFFSET(S_ChangeRoomCommit, _impl_.transitionid_)>(
+          reinterpret_cast<char*>(&_impl_.transitionid_),
+          reinterpret_cast<char*>(&other->_impl_.transitionid_));
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata S_ChangeRoomCommit::GetMetadata() const {
@@ -5682,8 +5631,13 @@ void S_ChangeRoomCommit::InternalSwap(S_ChangeRoomCommit* other) {
 
 class S_SpawnMonster::_Internal {
  public:
+  static const ::Protocol::MonsterInfo& monster(const S_SpawnMonster* msg);
 };
 
+const ::Protocol::MonsterInfo&
+S_SpawnMonster::_Internal::monster(const S_SpawnMonster* msg) {
+  return *msg->_impl_.monster_;
+}
 S_SpawnMonster::S_SpawnMonster(::PROTOBUF_NAMESPACE_ID::Arena* arena,
                          bool is_message_owned)
   : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
@@ -5694,17 +5648,13 @@ S_SpawnMonster::S_SpawnMonster(const S_SpawnMonster& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   S_SpawnMonster* const _this = this; (void)_this;
   new (&_impl_) Impl_{
-      decltype(_impl_.monsterid_){}
-    , decltype(_impl_.monstertypeid_){}
-    , decltype(_impl_.x_){}
-    , decltype(_impl_.y_){}
-    , decltype(_impl_.dir_){}
+      decltype(_impl_.monster_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
-  ::memcpy(&_impl_.monsterid_, &from._impl_.monsterid_,
-    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.dir_) -
-    reinterpret_cast<char*>(&_impl_.monsterid_)) + sizeof(_impl_.dir_));
+  if (from._internal_has_monster()) {
+    _this->_impl_.monster_ = new ::Protocol::MonsterInfo(*from._impl_.monster_);
+  }
   // @@protoc_insertion_point(copy_constructor:Protocol.S_SpawnMonster)
 }
 
@@ -5713,11 +5663,7 @@ inline void S_SpawnMonster::SharedCtor(
   (void)arena;
   (void)is_message_owned;
   new (&_impl_) Impl_{
-      decltype(_impl_.monsterid_){0}
-    , decltype(_impl_.monstertypeid_){0}
-    , decltype(_impl_.x_){0}
-    , decltype(_impl_.y_){0}
-    , decltype(_impl_.dir_){0}
+      decltype(_impl_.monster_){nullptr}
     , /*decltype(_impl_._cached_size_)*/{}
   };
 }
@@ -5733,6 +5679,7 @@ S_SpawnMonster::~S_SpawnMonster() {
 
 inline void S_SpawnMonster::SharedDtor() {
   GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete _impl_.monster_;
 }
 
 void S_SpawnMonster::SetCachedSize(int size) const {
@@ -5745,9 +5692,10 @@ void S_SpawnMonster::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  ::memset(&_impl_.monsterid_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&_impl_.dir_) -
-      reinterpret_cast<char*>(&_impl_.monsterid_)) + sizeof(_impl_.dir_));
+  if (GetArenaForAllocation() == nullptr && _impl_.monster_ != nullptr) {
+    delete _impl_.monster_;
+  }
+  _impl_.monster_ = nullptr;
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -5757,44 +5705,11 @@ const char* S_SpawnMonster::_InternalParse(const char* ptr, ::_pbi::ParseContext
     uint32_t tag;
     ptr = ::_pbi::ReadTag(ptr, &tag);
     switch (tag >> 3) {
-      // int32 monsterId = 1;
+      // .Protocol.MonsterInfo monster = 1;
       case 1:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
-          _impl_.monsterid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_monster(), ptr);
           CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // int32 monsterTypeId = 2;
-      case 2:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
-          _impl_.monstertypeid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // int32 x = 3;
-      case 3:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
-          _impl_.x_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // int32 y = 4;
-      case 4:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 32)) {
-          _impl_.y_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
-          CHK_(ptr);
-        } else
-          goto handle_unusual;
-        continue;
-      // .Protocol.EDirection dir = 5;
-      case 5:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 40)) {
-          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
-          CHK_(ptr);
-          _internal_set_dir(static_cast<::Protocol::EDirection>(val));
         } else
           goto handle_unusual;
         continue;
@@ -5827,35 +5742,11 @@ uint8_t* S_SpawnMonster::_InternalSerialize(
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // int32 monsterId = 1;
-  if (this->_internal_monsterid() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteInt32ToArray(1, this->_internal_monsterid(), target);
-  }
-
-  // int32 monsterTypeId = 2;
-  if (this->_internal_monstertypeid() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteInt32ToArray(2, this->_internal_monstertypeid(), target);
-  }
-
-  // int32 x = 3;
-  if (this->_internal_x() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteInt32ToArray(3, this->_internal_x(), target);
-  }
-
-  // int32 y = 4;
-  if (this->_internal_y() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteInt32ToArray(4, this->_internal_y(), target);
-  }
-
-  // .Protocol.EDirection dir = 5;
-  if (this->_internal_dir() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteEnumToArray(
-      5, this->_internal_dir(), target);
+  // .Protocol.MonsterInfo monster = 1;
+  if (this->_internal_has_monster()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::monster(this),
+        _Internal::monster(this).GetCachedSize(), target, stream);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -5874,30 +5765,11 @@ size_t S_SpawnMonster::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // int32 monsterId = 1;
-  if (this->_internal_monsterid() != 0) {
-    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_monsterid());
-  }
-
-  // int32 monsterTypeId = 2;
-  if (this->_internal_monstertypeid() != 0) {
-    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_monstertypeid());
-  }
-
-  // int32 x = 3;
-  if (this->_internal_x() != 0) {
-    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_x());
-  }
-
-  // int32 y = 4;
-  if (this->_internal_y() != 0) {
-    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_y());
-  }
-
-  // .Protocol.EDirection dir = 5;
-  if (this->_internal_dir() != 0) {
+  // .Protocol.MonsterInfo monster = 1;
+  if (this->_internal_has_monster()) {
     total_size += 1 +
-      ::_pbi::WireFormatLite::EnumSize(this->_internal_dir());
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.monster_);
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
@@ -5918,20 +5790,9 @@ void S_SpawnMonster::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const :
   uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from._internal_monsterid() != 0) {
-    _this->_internal_set_monsterid(from._internal_monsterid());
-  }
-  if (from._internal_monstertypeid() != 0) {
-    _this->_internal_set_monstertypeid(from._internal_monstertypeid());
-  }
-  if (from._internal_x() != 0) {
-    _this->_internal_set_x(from._internal_x());
-  }
-  if (from._internal_y() != 0) {
-    _this->_internal_set_y(from._internal_y());
-  }
-  if (from._internal_dir() != 0) {
-    _this->_internal_set_dir(from._internal_dir());
+  if (from._internal_has_monster()) {
+    _this->_internal_mutable_monster()->::Protocol::MonsterInfo::MergeFrom(
+        from._internal_monster());
   }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -5950,12 +5811,7 @@ bool S_SpawnMonster::IsInitialized() const {
 void S_SpawnMonster::InternalSwap(S_SpawnMonster* other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(S_SpawnMonster, _impl_.dir_)
-      + sizeof(S_SpawnMonster::_impl_.dir_)
-      - PROTOBUF_FIELD_OFFSET(S_SpawnMonster, _impl_.monsterid_)>(
-          reinterpret_cast<char*>(&_impl_.monsterid_),
-          reinterpret_cast<char*>(&other->_impl_.monsterid_));
+  swap(_impl_.monster_, other->_impl_.monster_);
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata S_SpawnMonster::GetMetadata() const {
@@ -9766,6 +9622,7 @@ MonsterInfo::MonsterInfo(const MonsterInfo& from)
   new (&_impl_) Impl_{
       decltype(_impl_.pos_){nullptr}
     , decltype(_impl_.monsterid_){}
+    , decltype(_impl_.monstertypeid_){}
     , decltype(_impl_.direction_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
@@ -9786,6 +9643,7 @@ inline void MonsterInfo::SharedCtor(
   new (&_impl_) Impl_{
       decltype(_impl_.pos_){nullptr}
     , decltype(_impl_.monsterid_){0}
+    , decltype(_impl_.monstertypeid_){0}
     , decltype(_impl_.direction_){0}
     , /*decltype(_impl_._cached_size_)*/{}
   };
@@ -9839,17 +9697,25 @@ const char* MonsterInfo::_InternalParse(const char* ptr, ::_pbi::ParseContext* c
         } else
           goto handle_unusual;
         continue;
-      // .Protocol.Vector2Info pos = 2;
+      // int32 monsterTypeId = 2;
       case 2:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _impl_.monstertypeid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // .Protocol.Vector2Info pos = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
           ptr = ctx->ParseMessage(_internal_mutable_pos(), ptr);
           CHK_(ptr);
         } else
           goto handle_unusual;
         continue;
-      // .Protocol.EDirection direction = 3;
-      case 3:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 24)) {
+      // .Protocol.EDirection direction = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 32)) {
           uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
           _internal_set_direction(static_cast<::Protocol::EDirection>(val));
@@ -9891,18 +9757,24 @@ uint8_t* MonsterInfo::_InternalSerialize(
     target = ::_pbi::WireFormatLite::WriteInt32ToArray(1, this->_internal_monsterid(), target);
   }
 
-  // .Protocol.Vector2Info pos = 2;
+  // int32 monsterTypeId = 2;
+  if (this->_internal_monstertypeid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteInt32ToArray(2, this->_internal_monstertypeid(), target);
+  }
+
+  // .Protocol.Vector2Info pos = 3;
   if (this->_internal_has_pos()) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
-      InternalWriteMessage(2, _Internal::pos(this),
+      InternalWriteMessage(3, _Internal::pos(this),
         _Internal::pos(this).GetCachedSize(), target, stream);
   }
 
-  // .Protocol.EDirection direction = 3;
+  // .Protocol.EDirection direction = 4;
   if (this->_internal_direction() != 0) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteEnumToArray(
-      3, this->_internal_direction(), target);
+      4, this->_internal_direction(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -9921,7 +9793,7 @@ size_t MonsterInfo::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // .Protocol.Vector2Info pos = 2;
+  // .Protocol.Vector2Info pos = 3;
   if (this->_internal_has_pos()) {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
@@ -9933,7 +9805,12 @@ size_t MonsterInfo::ByteSizeLong() const {
     total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_monsterid());
   }
 
-  // .Protocol.EDirection direction = 3;
+  // int32 monsterTypeId = 2;
+  if (this->_internal_monstertypeid() != 0) {
+    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_monstertypeid());
+  }
+
+  // .Protocol.EDirection direction = 4;
   if (this->_internal_direction() != 0) {
     total_size += 1 +
       ::_pbi::WireFormatLite::EnumSize(this->_internal_direction());
@@ -9963,6 +9840,9 @@ void MonsterInfo::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PR
   }
   if (from._internal_monsterid() != 0) {
     _this->_internal_set_monsterid(from._internal_monsterid());
+  }
+  if (from._internal_monstertypeid() != 0) {
+    _this->_internal_set_monstertypeid(from._internal_monstertypeid());
   }
   if (from._internal_direction() != 0) {
     _this->_internal_set_direction(from._internal_direction());

--- a/GameServer/Protocol.pb.h
+++ b/GameServer/Protocol.pb.h
@@ -3839,28 +3839,9 @@ class S_ChangeRoomCommit final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kSnapshotsFieldNumber = 3,
     kTransitionIdFieldNumber = 1,
     kMapIdFieldNumber = 2,
   };
-  // .Protocol.S_PlayerList snapshots = 3;
-  bool has_snapshots() const;
-  private:
-  bool _internal_has_snapshots() const;
-  public:
-  void clear_snapshots();
-  const ::Protocol::S_PlayerList& snapshots() const;
-  PROTOBUF_NODISCARD ::Protocol::S_PlayerList* release_snapshots();
-  ::Protocol::S_PlayerList* mutable_snapshots();
-  void set_allocated_snapshots(::Protocol::S_PlayerList* snapshots);
-  private:
-  const ::Protocol::S_PlayerList& _internal_snapshots() const;
-  ::Protocol::S_PlayerList* _internal_mutable_snapshots();
-  public:
-  void unsafe_arena_set_allocated_snapshots(
-      ::Protocol::S_PlayerList* snapshots);
-  ::Protocol::S_PlayerList* unsafe_arena_release_snapshots();
-
   // int32 transitionId = 1;
   void clear_transitionid();
   int32_t transitionid() const;
@@ -3887,7 +3868,6 @@ class S_ChangeRoomCommit final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    ::Protocol::S_PlayerList* snapshots_;
     int32_t transitionid_;
     int32_t mapid_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
@@ -4018,56 +3998,25 @@ class S_SpawnMonster final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kMonsterIdFieldNumber = 1,
-    kMonsterTypeIdFieldNumber = 2,
-    kXFieldNumber = 3,
-    kYFieldNumber = 4,
-    kDirFieldNumber = 5,
+    kMonsterFieldNumber = 1,
   };
-  // int32 monsterId = 1;
-  void clear_monsterid();
-  int32_t monsterid() const;
-  void set_monsterid(int32_t value);
+  // .Protocol.MonsterInfo monster = 1;
+  bool has_monster() const;
   private:
-  int32_t _internal_monsterid() const;
-  void _internal_set_monsterid(int32_t value);
+  bool _internal_has_monster() const;
   public:
-
-  // int32 monsterTypeId = 2;
-  void clear_monstertypeid();
-  int32_t monstertypeid() const;
-  void set_monstertypeid(int32_t value);
+  void clear_monster();
+  const ::Protocol::MonsterInfo& monster() const;
+  PROTOBUF_NODISCARD ::Protocol::MonsterInfo* release_monster();
+  ::Protocol::MonsterInfo* mutable_monster();
+  void set_allocated_monster(::Protocol::MonsterInfo* monster);
   private:
-  int32_t _internal_monstertypeid() const;
-  void _internal_set_monstertypeid(int32_t value);
+  const ::Protocol::MonsterInfo& _internal_monster() const;
+  ::Protocol::MonsterInfo* _internal_mutable_monster();
   public:
-
-  // int32 x = 3;
-  void clear_x();
-  int32_t x() const;
-  void set_x(int32_t value);
-  private:
-  int32_t _internal_x() const;
-  void _internal_set_x(int32_t value);
-  public:
-
-  // int32 y = 4;
-  void clear_y();
-  int32_t y() const;
-  void set_y(int32_t value);
-  private:
-  int32_t _internal_y() const;
-  void _internal_set_y(int32_t value);
-  public:
-
-  // .Protocol.EDirection dir = 5;
-  void clear_dir();
-  ::Protocol::EDirection dir() const;
-  void set_dir(::Protocol::EDirection value);
-  private:
-  ::Protocol::EDirection _internal_dir() const;
-  void _internal_set_dir(::Protocol::EDirection value);
-  public:
+  void unsafe_arena_set_allocated_monster(
+      ::Protocol::MonsterInfo* monster);
+  ::Protocol::MonsterInfo* unsafe_arena_release_monster();
 
   // @@protoc_insertion_point(class_scope:Protocol.S_SpawnMonster)
  private:
@@ -4077,11 +4026,7 @@ class S_SpawnMonster final :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   struct Impl_ {
-    int32_t monsterid_;
-    int32_t monstertypeid_;
-    int32_t x_;
-    int32_t y_;
-    int dir_;
+    ::Protocol::MonsterInfo* monster_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -7143,11 +7088,12 @@ class MonsterInfo final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kPosFieldNumber = 2,
+    kPosFieldNumber = 3,
     kMonsterIdFieldNumber = 1,
-    kDirectionFieldNumber = 3,
+    kMonsterTypeIdFieldNumber = 2,
+    kDirectionFieldNumber = 4,
   };
-  // .Protocol.Vector2Info pos = 2;
+  // .Protocol.Vector2Info pos = 3;
   bool has_pos() const;
   private:
   bool _internal_has_pos() const;
@@ -7174,7 +7120,16 @@ class MonsterInfo final :
   void _internal_set_monsterid(int32_t value);
   public:
 
-  // .Protocol.EDirection direction = 3;
+  // int32 monsterTypeId = 2;
+  void clear_monstertypeid();
+  int32_t monstertypeid() const;
+  void set_monstertypeid(int32_t value);
+  private:
+  int32_t _internal_monstertypeid() const;
+  void _internal_set_monstertypeid(int32_t value);
+  public:
+
+  // .Protocol.EDirection direction = 4;
   void clear_direction();
   ::Protocol::EDirection direction() const;
   void set_direction(::Protocol::EDirection value);
@@ -7193,6 +7148,7 @@ class MonsterInfo final :
   struct Impl_ {
     ::Protocol::Vector2Info* pos_;
     int32_t monsterid_;
+    int32_t monstertypeid_;
     int direction_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
@@ -8430,45 +8386,49 @@ inline void S_ChangeRoomCommit::set_mapid(int32_t value) {
   // @@protoc_insertion_point(field_set:Protocol.S_ChangeRoomCommit.mapId)
 }
 
-// .Protocol.S_PlayerList snapshots = 3;
-inline bool S_ChangeRoomCommit::_internal_has_snapshots() const {
-  return this != internal_default_instance() && _impl_.snapshots_ != nullptr;
+// -------------------------------------------------------------------
+
+// S_SpawnMonster
+
+// .Protocol.MonsterInfo monster = 1;
+inline bool S_SpawnMonster::_internal_has_monster() const {
+  return this != internal_default_instance() && _impl_.monster_ != nullptr;
 }
-inline bool S_ChangeRoomCommit::has_snapshots() const {
-  return _internal_has_snapshots();
+inline bool S_SpawnMonster::has_monster() const {
+  return _internal_has_monster();
 }
-inline void S_ChangeRoomCommit::clear_snapshots() {
-  if (GetArenaForAllocation() == nullptr && _impl_.snapshots_ != nullptr) {
-    delete _impl_.snapshots_;
+inline void S_SpawnMonster::clear_monster() {
+  if (GetArenaForAllocation() == nullptr && _impl_.monster_ != nullptr) {
+    delete _impl_.monster_;
   }
-  _impl_.snapshots_ = nullptr;
+  _impl_.monster_ = nullptr;
 }
-inline const ::Protocol::S_PlayerList& S_ChangeRoomCommit::_internal_snapshots() const {
-  const ::Protocol::S_PlayerList* p = _impl_.snapshots_;
-  return p != nullptr ? *p : reinterpret_cast<const ::Protocol::S_PlayerList&>(
-      ::Protocol::_S_PlayerList_default_instance_);
+inline const ::Protocol::MonsterInfo& S_SpawnMonster::_internal_monster() const {
+  const ::Protocol::MonsterInfo* p = _impl_.monster_;
+  return p != nullptr ? *p : reinterpret_cast<const ::Protocol::MonsterInfo&>(
+      ::Protocol::_MonsterInfo_default_instance_);
 }
-inline const ::Protocol::S_PlayerList& S_ChangeRoomCommit::snapshots() const {
-  // @@protoc_insertion_point(field_get:Protocol.S_ChangeRoomCommit.snapshots)
-  return _internal_snapshots();
+inline const ::Protocol::MonsterInfo& S_SpawnMonster::monster() const {
+  // @@protoc_insertion_point(field_get:Protocol.S_SpawnMonster.monster)
+  return _internal_monster();
 }
-inline void S_ChangeRoomCommit::unsafe_arena_set_allocated_snapshots(
-    ::Protocol::S_PlayerList* snapshots) {
+inline void S_SpawnMonster::unsafe_arena_set_allocated_monster(
+    ::Protocol::MonsterInfo* monster) {
   if (GetArenaForAllocation() == nullptr) {
-    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.snapshots_);
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.monster_);
   }
-  _impl_.snapshots_ = snapshots;
-  if (snapshots) {
+  _impl_.monster_ = monster;
+  if (monster) {
     
   } else {
     
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:Protocol.S_ChangeRoomCommit.snapshots)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:Protocol.S_SpawnMonster.monster)
 }
-inline ::Protocol::S_PlayerList* S_ChangeRoomCommit::release_snapshots() {
+inline ::Protocol::MonsterInfo* S_SpawnMonster::release_monster() {
   
-  ::Protocol::S_PlayerList* temp = _impl_.snapshots_;
-  _impl_.snapshots_ = nullptr;
+  ::Protocol::MonsterInfo* temp = _impl_.monster_;
+  _impl_.monster_ = nullptr;
 #ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
   auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
   temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
@@ -8480,148 +8440,44 @@ inline ::Protocol::S_PlayerList* S_ChangeRoomCommit::release_snapshots() {
 #endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
   return temp;
 }
-inline ::Protocol::S_PlayerList* S_ChangeRoomCommit::unsafe_arena_release_snapshots() {
-  // @@protoc_insertion_point(field_release:Protocol.S_ChangeRoomCommit.snapshots)
+inline ::Protocol::MonsterInfo* S_SpawnMonster::unsafe_arena_release_monster() {
+  // @@protoc_insertion_point(field_release:Protocol.S_SpawnMonster.monster)
   
-  ::Protocol::S_PlayerList* temp = _impl_.snapshots_;
-  _impl_.snapshots_ = nullptr;
+  ::Protocol::MonsterInfo* temp = _impl_.monster_;
+  _impl_.monster_ = nullptr;
   return temp;
 }
-inline ::Protocol::S_PlayerList* S_ChangeRoomCommit::_internal_mutable_snapshots() {
+inline ::Protocol::MonsterInfo* S_SpawnMonster::_internal_mutable_monster() {
   
-  if (_impl_.snapshots_ == nullptr) {
-    auto* p = CreateMaybeMessage<::Protocol::S_PlayerList>(GetArenaForAllocation());
-    _impl_.snapshots_ = p;
+  if (_impl_.monster_ == nullptr) {
+    auto* p = CreateMaybeMessage<::Protocol::MonsterInfo>(GetArenaForAllocation());
+    _impl_.monster_ = p;
   }
-  return _impl_.snapshots_;
+  return _impl_.monster_;
 }
-inline ::Protocol::S_PlayerList* S_ChangeRoomCommit::mutable_snapshots() {
-  ::Protocol::S_PlayerList* _msg = _internal_mutable_snapshots();
-  // @@protoc_insertion_point(field_mutable:Protocol.S_ChangeRoomCommit.snapshots)
+inline ::Protocol::MonsterInfo* S_SpawnMonster::mutable_monster() {
+  ::Protocol::MonsterInfo* _msg = _internal_mutable_monster();
+  // @@protoc_insertion_point(field_mutable:Protocol.S_SpawnMonster.monster)
   return _msg;
 }
-inline void S_ChangeRoomCommit::set_allocated_snapshots(::Protocol::S_PlayerList* snapshots) {
+inline void S_SpawnMonster::set_allocated_monster(::Protocol::MonsterInfo* monster) {
   ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
   if (message_arena == nullptr) {
-    delete _impl_.snapshots_;
+    delete _impl_.monster_;
   }
-  if (snapshots) {
+  if (monster) {
     ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
-        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(snapshots);
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(monster);
     if (message_arena != submessage_arena) {
-      snapshots = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
-          message_arena, snapshots, submessage_arena);
+      monster = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, monster, submessage_arena);
     }
     
   } else {
     
   }
-  _impl_.snapshots_ = snapshots;
-  // @@protoc_insertion_point(field_set_allocated:Protocol.S_ChangeRoomCommit.snapshots)
-}
-
-// -------------------------------------------------------------------
-
-// S_SpawnMonster
-
-// int32 monsterId = 1;
-inline void S_SpawnMonster::clear_monsterid() {
-  _impl_.monsterid_ = 0;
-}
-inline int32_t S_SpawnMonster::_internal_monsterid() const {
-  return _impl_.monsterid_;
-}
-inline int32_t S_SpawnMonster::monsterid() const {
-  // @@protoc_insertion_point(field_get:Protocol.S_SpawnMonster.monsterId)
-  return _internal_monsterid();
-}
-inline void S_SpawnMonster::_internal_set_monsterid(int32_t value) {
-  
-  _impl_.monsterid_ = value;
-}
-inline void S_SpawnMonster::set_monsterid(int32_t value) {
-  _internal_set_monsterid(value);
-  // @@protoc_insertion_point(field_set:Protocol.S_SpawnMonster.monsterId)
-}
-
-// int32 monsterTypeId = 2;
-inline void S_SpawnMonster::clear_monstertypeid() {
-  _impl_.monstertypeid_ = 0;
-}
-inline int32_t S_SpawnMonster::_internal_monstertypeid() const {
-  return _impl_.monstertypeid_;
-}
-inline int32_t S_SpawnMonster::monstertypeid() const {
-  // @@protoc_insertion_point(field_get:Protocol.S_SpawnMonster.monsterTypeId)
-  return _internal_monstertypeid();
-}
-inline void S_SpawnMonster::_internal_set_monstertypeid(int32_t value) {
-  
-  _impl_.monstertypeid_ = value;
-}
-inline void S_SpawnMonster::set_monstertypeid(int32_t value) {
-  _internal_set_monstertypeid(value);
-  // @@protoc_insertion_point(field_set:Protocol.S_SpawnMonster.monsterTypeId)
-}
-
-// int32 x = 3;
-inline void S_SpawnMonster::clear_x() {
-  _impl_.x_ = 0;
-}
-inline int32_t S_SpawnMonster::_internal_x() const {
-  return _impl_.x_;
-}
-inline int32_t S_SpawnMonster::x() const {
-  // @@protoc_insertion_point(field_get:Protocol.S_SpawnMonster.x)
-  return _internal_x();
-}
-inline void S_SpawnMonster::_internal_set_x(int32_t value) {
-  
-  _impl_.x_ = value;
-}
-inline void S_SpawnMonster::set_x(int32_t value) {
-  _internal_set_x(value);
-  // @@protoc_insertion_point(field_set:Protocol.S_SpawnMonster.x)
-}
-
-// int32 y = 4;
-inline void S_SpawnMonster::clear_y() {
-  _impl_.y_ = 0;
-}
-inline int32_t S_SpawnMonster::_internal_y() const {
-  return _impl_.y_;
-}
-inline int32_t S_SpawnMonster::y() const {
-  // @@protoc_insertion_point(field_get:Protocol.S_SpawnMonster.y)
-  return _internal_y();
-}
-inline void S_SpawnMonster::_internal_set_y(int32_t value) {
-  
-  _impl_.y_ = value;
-}
-inline void S_SpawnMonster::set_y(int32_t value) {
-  _internal_set_y(value);
-  // @@protoc_insertion_point(field_set:Protocol.S_SpawnMonster.y)
-}
-
-// .Protocol.EDirection dir = 5;
-inline void S_SpawnMonster::clear_dir() {
-  _impl_.dir_ = 0;
-}
-inline ::Protocol::EDirection S_SpawnMonster::_internal_dir() const {
-  return static_cast< ::Protocol::EDirection >(_impl_.dir_);
-}
-inline ::Protocol::EDirection S_SpawnMonster::dir() const {
-  // @@protoc_insertion_point(field_get:Protocol.S_SpawnMonster.dir)
-  return _internal_dir();
-}
-inline void S_SpawnMonster::_internal_set_dir(::Protocol::EDirection value) {
-  
-  _impl_.dir_ = value;
-}
-inline void S_SpawnMonster::set_dir(::Protocol::EDirection value) {
-  _internal_set_dir(value);
-  // @@protoc_insertion_point(field_set:Protocol.S_SpawnMonster.dir)
+  _impl_.monster_ = monster;
+  // @@protoc_insertion_point(field_set_allocated:Protocol.S_SpawnMonster.monster)
 }
 
 // -------------------------------------------------------------------
@@ -9840,7 +9696,27 @@ inline void MonsterInfo::set_monsterid(int32_t value) {
   // @@protoc_insertion_point(field_set:Protocol.MonsterInfo.monsterId)
 }
 
-// .Protocol.Vector2Info pos = 2;
+// int32 monsterTypeId = 2;
+inline void MonsterInfo::clear_monstertypeid() {
+  _impl_.monstertypeid_ = 0;
+}
+inline int32_t MonsterInfo::_internal_monstertypeid() const {
+  return _impl_.monstertypeid_;
+}
+inline int32_t MonsterInfo::monstertypeid() const {
+  // @@protoc_insertion_point(field_get:Protocol.MonsterInfo.monsterTypeId)
+  return _internal_monstertypeid();
+}
+inline void MonsterInfo::_internal_set_monstertypeid(int32_t value) {
+  
+  _impl_.monstertypeid_ = value;
+}
+inline void MonsterInfo::set_monstertypeid(int32_t value) {
+  _internal_set_monstertypeid(value);
+  // @@protoc_insertion_point(field_set:Protocol.MonsterInfo.monsterTypeId)
+}
+
+// .Protocol.Vector2Info pos = 3;
 inline bool MonsterInfo::_internal_has_pos() const {
   return this != internal_default_instance() && _impl_.pos_ != nullptr;
 }
@@ -9930,7 +9806,7 @@ inline void MonsterInfo::set_allocated_pos(::Protocol::Vector2Info* pos) {
   // @@protoc_insertion_point(field_set_allocated:Protocol.MonsterInfo.pos)
 }
 
-// .Protocol.EDirection direction = 3;
+// .Protocol.EDirection direction = 4;
 inline void MonsterInfo::clear_direction() {
   _impl_.direction_ = 0;
 }

--- a/GameServer/Room.cpp
+++ b/GameServer/Room.cpp
@@ -153,8 +153,12 @@ void Room::Enter(PlayerRef p)
     SpawnPoint spawn { ESpawnType::PLAYER_SPAWN, p->core.pos.x, p->core.pos.y };
     AddPlayerInternal(p, spawn, p->core.dir);  // 내부 등록 (SetRoom 포함)
 
-	GConsoleLogger->WriteStdOut(Color::GREEN, L"Room에 ENter 입장\n");
+	GConsoleLogger->WriteStdOut(Color::GREEN, L"Room에 Enter 입장\n");
 	OnEnter(p); // 여기서 모두에게 BroadCasting?
+
+    // 데이터 저장
+    auto fut = p->SaveCharacterToDB();
+    fut.get();
 }
 
 void Room::Leave(PlayerRef p)
@@ -451,15 +455,14 @@ void Room::ChangeRoomReady(const PlayerRef& p, const Protocol::C_ChangeRoomReady
             return;
 
         // 플레이어가 방에서 나가도록
-        src->RemovePlayerInternal(p->playerId, "MapChange");
-        src->BroadcastLeave(p);
+        src->Leave(p);
 
         // dst 잡큐에서 실행
         dst->DoAsync([src, dst, p, pend] {
             // 목적지 스폰 계산 (DB NO, 인메모리)
             auto sp = dst->ResolveSpawn(pend.dstPortalId);
             if (!sp) {
-                // 실패 정책: 간r단히 상태만 해제. (원하면 src로 롤백도 가능)
+                // 실패 정책: 간단히 상태만 해제. (원하면 src로 롤백도 가능)
                 p->ClearRoomChangeState();
                 return;
             }
@@ -467,16 +470,13 @@ void Room::ChangeRoomReady(const PlayerRef& p, const Protocol::C_ChangeRoomReady
             // 인메모리 좌표 반영 후 등록
             p->core.pos.x = sp->x;
             p->core.pos.y = sp->y;
-            dst->AddPlayerInternal(p, {ESpawnType::PLAYER_SPAWN, sp->x, sp->y }, p->core.dir);
 
-            // Commit + 스냅샷 (나 포함)
+            dst->Enter(p);
+
+            // Commit
             Protocol::S_ChangeRoomCommit commit;
             commit.set_transitionid(pend.transitionId);
             commit.set_mapid(dst->RoomId());
-            *commit.mutable_snapshots() = dst->BuildPlayerListSnapshot(p, /*includeSelf=*/true);
-            
-            // DB에 저장
-            p->SaveCharacterToDB();
 
             if (auto s = p->ownerSession.lock())
             {
@@ -484,7 +484,6 @@ void Room::ChangeRoomReady(const PlayerRef& p, const Protocol::C_ChangeRoomReady
                 GConsoleLogger->WriteStdOut(Color::GREEN, L"[Room::S_ChangeRoomCommit]: 커밋 송신 (룸 이동완료) \n");
             }
 
-            dst->BroadcastEnter(p);
             p->ClearRoomChangeState();
             });
         });

--- a/Protocol/Protocol.proto
+++ b/Protocol/Protocol.proto
@@ -178,16 +178,12 @@ message C_ChangeRoomReady {
 message S_ChangeRoomCommit {
   int32 transitionId = 1;
   int32 mapId = 2;
-  S_PlayerList snapshots = 3; // 들어오자마자 월드 동기화
+  // Snapshot은 OnEnter에서 PlayerList보내는것으로 대신함
 }
 
 // (19) 서버 -> 클라 : 몬스터 스폰 알림
 message S_SpawnMonster {
-	int32 monsterId = 1; // Entity Unique id
-	int32 monsterTypeId = 2; // Monster Type (Template or Resources Id)
-	int32 x = 3; // Tile Pos X
-	int32 y = 4; // Tile Pos Y
-	EDirection dir = 5; // 방향 
+	MonsterInfo monster = 1;
 }
 
 // (20) 서버 -> 클라 몬스터 디스폰(제거) 알림 
@@ -387,7 +383,8 @@ message InventorySlotInfo
 
 message MonsterInfo
 {
-	int32 monsterId = 1;
-	Vector2Info pos = 2;
-	EDirection direction =3 ;
+	int32 monsterId = 1; // Entity Unique id
+	int32 monsterTypeId = 2; // Monster Type (Template or Resources Id)
+	Vector2Info pos = 3;
+	EDirection direction = 4;
 }

--- a/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
+++ b/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
@@ -54,85 +54,83 @@ namespace Google.Protobuf.Protocol {
             "ZRIMCgR0aWNrGAEgASgFEi0KC3BsYXllck1vdmVzGAIgAygLMhguUHJvdG9j",
             "b2wuUGxheWVyTW92ZUluZm8iOAoRU19DaGFuZ2VSb29tQmVnaW4SFAoMdHJh",
             "bnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFIikKEUNfQ2hhbmdlUm9v",
-            "bVJlYWR5EhQKDHRyYW5zaXRpb25JZBgBIAEoBSJkChJTX0NoYW5nZVJvb21D",
-            "b21taXQSFAoMdHJhbnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFEikK",
-            "CXNuYXBzaG90cxgDIAEoCzIWLlByb3RvY29sLlNfUGxheWVyTGlzdCJzCg5T",
-            "X1NwYXduTW9uc3RlchIRCgltb25zdGVySWQYASABKAUSFQoNbW9uc3RlclR5",
-            "cGVJZBgCIAEoBRIJCgF4GAMgASgFEgkKAXkYBCABKAUSIQoDZGlyGAUgASgO",
-            "MhQuUHJvdG9jb2wuRURpcmVjdGlvbiJPChBTX0Rlc3Bhd25Nb25zdGVyEhEK",
-            "CW1vbnN0ZXJJZBgBIAEoBRIoCgZyZWFzb24YAiABKA4yGC5Qcm90b2NvbC5F",
-            "RGVzcGF3blJlYXNvbiJkChZTX0Jyb2FkY2FzdE1vbnN0ZXJNb3ZlEhEKCW1v",
-            "bnN0ZXJJZBgBIAEoBRIJCgF4GAIgASgFEgkKAXkYAyABKAUSIQoDZGlyGAQg",
-            "ASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiJAChhTX0Jyb2FkY2FzdE1vbnN0",
-            "ZXJBdHRhY2sSEQoJbW9uc3RlcklkGAEgASgFEhEKCXRhcmdldFBpZBgCIAEo",
-            "BSIsChdTX0Jyb2FkY2FzdE1vbnN0ZXJEZWF0aBIRCgltb25zdGVySWQYASAB",
-            "KAUiFwoVQ19QbGF5ZXJBdHRhY2tSZXF1ZXN0Il4KF1NfQnJvYWRjYXN0UGxh",
-            "eWVyQXR0YWNrEhAKCHBsYXllcklkGAEgASgFEhAKCHRhcmdldElkGAIgASgF",
-            "Eg4KBmRhbWFnZRgDIAEoBRIPCgdocEFmdGVyGAQgASgFIhQKEkNfSW52ZW50",
-            "b3J5UmVxdWVzdCI+ChBTX0ludmVudG9yeVJlcGx5EioKBXNsb3RzGAEgAygL",
-            "MhsuUHJvdG9jb2wuSW52ZW50b3J5U2xvdEluZm8iJQoQQ19JdGVtVXNlUmVx",
-            "dWVzdBIRCglzbG90SW5kZXgYASABKAUiNwoOU19JdGVtVXNlUmVwbHkSDwoH",
-            "c3VjY2VzcxgBIAEoCBIUCgxlcnJvck1lc3NhZ2UYAiABKAkiRgoRU19JbnZl",
-            "bnRvcnlVcGRhdGUSMQoMY2hhbmdlZFNsb3RzGAEgAygLMhsuUHJvdG9jb2wu",
-            "SW52ZW50b3J5U2xvdEluZm8iSAoPU19TeXN0ZW1NZXNzYWdlEg8KB21lc3Nh",
-            "Z2UYASABKAkSJAoEdHlwZRgCIAEoDjIWLlByb3RvY29sLkVNZXNzYWdlVHlw",
-            "ZSJHCg1TX01vbnN0ZXJMaXN0Eg0KBW1hcElkGAEgASgFEicKCG1vbnN0ZXJz",
-            "GAIgAygLMhUuUHJvdG9jb2wuTW9uc3RlckluZm8iIwoLVmVjdG9yMkluZm8S",
-            "CQoBeBgBIAEoBRIJCgF5GAIgASgFIpkBCg5QbGF5ZXJNb3ZlSW5mbxIQCghw",
-            "bGF5ZXJJZBgBIAEoBRInCglkaXJlY3Rpb24YAiABKA4yFC5Qcm90b2NvbC5F",
-            "RGlyZWN0aW9uEiUKBm5ld1BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3RvcjJJ",
-            "bmZvEiUKBnJlc3VsdBgEIAEoDjIVLlByb3RvY29sLkVNb3ZlUmVzdWx0In0K",
-            "FENoYXJhY3RlclN1bW1hcnlJbmZvEhAKCHVzZXJuYW1lGAEgASgJEg0KBWxl",
-            "dmVsGAIgASgFEiEKBmdlbmRlchgDIAEoDjIRLlByb3RvY29sLkVHZW5kZXIS",
-            "IQoGcmVnaW9uGAQgASgOMhEuUHJvdG9jb2wuRVJlZ2lvbiJ3CgpQbGF5ZXJJ",
-            "bmZvEgoKAmlkGAEgASgFEhAKCHVzZXJuYW1lGAIgASgJEiIKA3BvcxgDIAEo",
-            "CzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIU",
-            "LlByb3RvY29sLkVEaXJlY3Rpb24iWgoRSW52ZW50b3J5U2xvdEluZm8SEQoJ",
-            "c2xvdEluZGV4GAEgASgFEg4KBml0ZW1JZBgCIAEoBRINCgVjb3VudBgDIAEo",
-            "BRITCgtpc1F1aWNrc2xvdBgEIAEoCCJtCgtNb25zdGVySW5mbxIRCgltb25z",
-            "dGVySWQYASABKAUSIgoDcG9zGAIgASgLMhUuUHJvdG9jb2wuVmVjdG9yMklu",
-            "Zm8SJwoJZGlyZWN0aW9uGAMgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiqG",
-            "BwoFTXNnSWQSFwoTQ19KV1RfTE9HSU5fUkVRVUVTVBAAEhUKEVNfSldUX0xP",
-            "R0lOX1JFUExZEAESHgoaQ19DUkVBVEVfQ0hBUkFDVEVSX1JFUVVFU1QQAhIc",
-            "ChhTX0NSRUFURV9DSEFSQUNURVJfUkVQTFkQAxIcChhDX0NIQVJBQ1RFUl9M",
-            "SVNUX1JFUVVFU1QQBBIaChZTX0NIQVJBQ1RFUl9MSVNUX1JFUExZEAUSHgoa",
-            "Q19ERUxFVEVfQ0hBUkFDVEVSX1JFUVVFU1QQBhIcChhTX0RFTEVURV9DSEFS",
-            "QUNURVJfUkVQTFkQBxIQCgxDX0VOVEVSX0dBTUUQCBIQCgxTX0VOVEVSX0dB",
-            "TUUQCRIRCg1TX1BMQVlFUl9MSVNUEAoSHAoYU19CUk9BRENBU1RfUExBWUVS",
-            "X0VOVEVSEAsSEAoMQ19MRUFWRV9HQU1FEAwSEAoMU19MRUFWRV9HQU1FEA0S",
-            "HAoYU19CUk9BRENBU1RfUExBWUVSX0xFQVZFEA4SGQoVQ19QTEFZRVJfTU9W",
-            "RV9SRVFVRVNUEA8SFwoTU19QTEFZRVJfTU9WRV9SRVBMWRAQEhsKF1NfQlJP",
-            "QURDQVNUX1BMQVlFUl9NT1ZFEBESFwoTU19DSEFOR0VfUk9PTV9CRUdJThAS",
-            "EhcKE0NfQ0hBTkdFX1JPT01fUkVBRFkQExIYChRTX0NIQU5HRV9ST09NX0NP",
-            "TU1JVBAUEhMKD1NfU1BBV05fTU9OU1RFUhAVEhUKEVNfREVTUEFXTl9NT05T",
-            "VEVSEBYSHAoYU19CUk9BRENBU1RfTU9OU1RFUl9NT1ZFEBcSHgoaU19CUk9B",
-            "RENBU1RfTU9OU1RFUl9BVFRBQ0sQGBIdChlTX0JST0FEQ0FTVF9NT05TVEVS",
-            "X0RFQVRIEBkSGwoXQ19QTEFZRVJfQVRUQUNLX1JFUVVFU1QQGhIdChlTX0JS",
-            "T0FEQ0FTVF9QTEFZRVJfQVRUQUNLEBsSFwoTQ19JTlZFTlRPUllfUkVRVUVT",
-            "VBAcEhUKEVNfSU5WRU5UT1JZX1JFUExZEB0SFgoSQ19JVEVNX1VTRV9SRVFV",
-            "RVNUEB4SFAoQU19JVEVNX1VTRV9SRVBMWRAfEhYKElNfSU5WRU5UT1JZX1VQ",
-            "REFURRAgEhQKEFNfU1lTVEVNX01FU1NBR0UQIRISCg5TX01PTlNURVJfTElT",
-            "VBAiKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAASEQoNSU5WQUxJRF9U",
-            "T0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJWRVJfRVJST1IQAyo+",
-            "CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VOREVSX01BTEUQARIR",
-            "Cg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtSRUdJT05fTk9ORRAA",
-            "Eg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIqQwoKRURpcmVjdGlv",
-            "bhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJUl9MRUZUEAISDQoJ",
-            "RElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxFQVZFX1VOS05PV04Q",
-            "ABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFOR0VfUk9PTRACEhoK",
-            "FkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFWRV9ESVNDT05ORUNU",
-            "EAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dOEAASCwoHTU9WRV9P",
-            "SxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9XThADEhAKDE1PVkVf",
-            "QkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRFUl9VTktOT1dOEAAS",
-            "DwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0VfUk9PTRACKjkKDkVE",
-            "ZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAAEhIKDkRFU1BBV05f",
-            "S0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQRV9VTktOT1dOEAAS",
-            "GAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVNX1RZUEVfRVFVSVBN",
-            "RU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRFTV9UWVBFX01JU0MQ",
-            "BCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZPEAASEwoPTUVTU0FH",
-            "RV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcKE01FU1NBR0VfRFJP",
-            "UF9GQUlMRUQQA0IbqgIYR29vZ2xlLlByb3RvYnVmLlByb3RvY29sYgZwcm90",
-            "bzM="));
+            "bVJlYWR5EhQKDHRyYW5zaXRpb25JZBgBIAEoBSI5ChJTX0NoYW5nZVJvb21D",
+            "b21taXQSFAoMdHJhbnNpdGlvbklkGAEgASgFEg0KBW1hcElkGAIgASgFIjgK",
+            "DlNfU3Bhd25Nb25zdGVyEiYKB21vbnN0ZXIYASABKAsyFS5Qcm90b2NvbC5N",
+            "b25zdGVySW5mbyJPChBTX0Rlc3Bhd25Nb25zdGVyEhEKCW1vbnN0ZXJJZBgB",
+            "IAEoBRIoCgZyZWFzb24YAiABKA4yGC5Qcm90b2NvbC5FRGVzcGF3blJlYXNv",
+            "biJkChZTX0Jyb2FkY2FzdE1vbnN0ZXJNb3ZlEhEKCW1vbnN0ZXJJZBgBIAEo",
+            "BRIJCgF4GAIgASgFEgkKAXkYAyABKAUSIQoDZGlyGAQgASgOMhQuUHJvdG9j",
+            "b2wuRURpcmVjdGlvbiJAChhTX0Jyb2FkY2FzdE1vbnN0ZXJBdHRhY2sSEQoJ",
+            "bW9uc3RlcklkGAEgASgFEhEKCXRhcmdldFBpZBgCIAEoBSIsChdTX0Jyb2Fk",
+            "Y2FzdE1vbnN0ZXJEZWF0aBIRCgltb25zdGVySWQYASABKAUiFwoVQ19QbGF5",
+            "ZXJBdHRhY2tSZXF1ZXN0Il4KF1NfQnJvYWRjYXN0UGxheWVyQXR0YWNrEhAK",
+            "CHBsYXllcklkGAEgASgFEhAKCHRhcmdldElkGAIgASgFEg4KBmRhbWFnZRgD",
+            "IAEoBRIPCgdocEFmdGVyGAQgASgFIhQKEkNfSW52ZW50b3J5UmVxdWVzdCI+",
+            "ChBTX0ludmVudG9yeVJlcGx5EioKBXNsb3RzGAEgAygLMhsuUHJvdG9jb2wu",
+            "SW52ZW50b3J5U2xvdEluZm8iJQoQQ19JdGVtVXNlUmVxdWVzdBIRCglzbG90",
+            "SW5kZXgYASABKAUiNwoOU19JdGVtVXNlUmVwbHkSDwoHc3VjY2VzcxgBIAEo",
+            "CBIUCgxlcnJvck1lc3NhZ2UYAiABKAkiRgoRU19JbnZlbnRvcnlVcGRhdGUS",
+            "MQoMY2hhbmdlZFNsb3RzGAEgAygLMhsuUHJvdG9jb2wuSW52ZW50b3J5U2xv",
+            "dEluZm8iSAoPU19TeXN0ZW1NZXNzYWdlEg8KB21lc3NhZ2UYASABKAkSJAoE",
+            "dHlwZRgCIAEoDjIWLlByb3RvY29sLkVNZXNzYWdlVHlwZSJHCg1TX01vbnN0",
+            "ZXJMaXN0Eg0KBW1hcElkGAEgASgFEicKCG1vbnN0ZXJzGAIgAygLMhUuUHJv",
+            "dG9jb2wuTW9uc3RlckluZm8iIwoLVmVjdG9yMkluZm8SCQoBeBgBIAEoBRIJ",
+            "CgF5GAIgASgFIpkBCg5QbGF5ZXJNb3ZlSW5mbxIQCghwbGF5ZXJJZBgBIAEo",
+            "BRInCglkaXJlY3Rpb24YAiABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9uEiUK",
+            "Bm5ld1BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEiUKBnJlc3Vs",
+            "dBgEIAEoDjIVLlByb3RvY29sLkVNb3ZlUmVzdWx0In0KFENoYXJhY3RlclN1",
+            "bW1hcnlJbmZvEhAKCHVzZXJuYW1lGAEgASgJEg0KBWxldmVsGAIgASgFEiEK",
+            "BmdlbmRlchgDIAEoDjIRLlByb3RvY29sLkVHZW5kZXISIQoGcmVnaW9uGAQg",
+            "ASgOMhEuUHJvdG9jb2wuRVJlZ2lvbiJ3CgpQbGF5ZXJJbmZvEgoKAmlkGAEg",
+            "ASgFEhAKCHVzZXJuYW1lGAIgASgJEiIKA3BvcxgDIAEoCzIVLlByb3RvY29s",
+            "LlZlY3RvcjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVE",
+            "aXJlY3Rpb24iWgoRSW52ZW50b3J5U2xvdEluZm8SEQoJc2xvdEluZGV4GAEg",
+            "ASgFEg4KBml0ZW1JZBgCIAEoBRINCgVjb3VudBgDIAEoBRITCgtpc1F1aWNr",
+            "c2xvdBgEIAEoCCKEAQoLTW9uc3RlckluZm8SEQoJbW9uc3RlcklkGAEgASgF",
+            "EhUKDW1vbnN0ZXJUeXBlSWQYAiABKAUSIgoDcG9zGAMgASgLMhUuUHJvdG9j",
+            "b2wuVmVjdG9yMkluZm8SJwoJZGlyZWN0aW9uGAQgASgOMhQuUHJvdG9jb2wu",
+            "RURpcmVjdGlvbiqGBwoFTXNnSWQSFwoTQ19KV1RfTE9HSU5fUkVRVUVTVBAA",
+            "EhUKEVNfSldUX0xPR0lOX1JFUExZEAESHgoaQ19DUkVBVEVfQ0hBUkFDVEVS",
+            "X1JFUVVFU1QQAhIcChhTX0NSRUFURV9DSEFSQUNURVJfUkVQTFkQAxIcChhD",
+            "X0NIQVJBQ1RFUl9MSVNUX1JFUVVFU1QQBBIaChZTX0NIQVJBQ1RFUl9MSVNU",
+            "X1JFUExZEAUSHgoaQ19ERUxFVEVfQ0hBUkFDVEVSX1JFUVVFU1QQBhIcChhT",
+            "X0RFTEVURV9DSEFSQUNURVJfUkVQTFkQBxIQCgxDX0VOVEVSX0dBTUUQCBIQ",
+            "CgxTX0VOVEVSX0dBTUUQCRIRCg1TX1BMQVlFUl9MSVNUEAoSHAoYU19CUk9B",
+            "RENBU1RfUExBWUVSX0VOVEVSEAsSEAoMQ19MRUFWRV9HQU1FEAwSEAoMU19M",
+            "RUFWRV9HQU1FEA0SHAoYU19CUk9BRENBU1RfUExBWUVSX0xFQVZFEA4SGQoV",
+            "Q19QTEFZRVJfTU9WRV9SRVFVRVNUEA8SFwoTU19QTEFZRVJfTU9WRV9SRVBM",
+            "WRAQEhsKF1NfQlJPQURDQVNUX1BMQVlFUl9NT1ZFEBESFwoTU19DSEFOR0Vf",
+            "Uk9PTV9CRUdJThASEhcKE0NfQ0hBTkdFX1JPT01fUkVBRFkQExIYChRTX0NI",
+            "QU5HRV9ST09NX0NPTU1JVBAUEhMKD1NfU1BBV05fTU9OU1RFUhAVEhUKEVNf",
+            "REVTUEFXTl9NT05TVEVSEBYSHAoYU19CUk9BRENBU1RfTU9OU1RFUl9NT1ZF",
+            "EBcSHgoaU19CUk9BRENBU1RfTU9OU1RFUl9BVFRBQ0sQGBIdChlTX0JST0FE",
+            "Q0FTVF9NT05TVEVSX0RFQVRIEBkSGwoXQ19QTEFZRVJfQVRUQUNLX1JFUVVF",
+            "U1QQGhIdChlTX0JST0FEQ0FTVF9QTEFZRVJfQVRUQUNLEBsSFwoTQ19JTlZF",
+            "TlRPUllfUkVRVUVTVBAcEhUKEVNfSU5WRU5UT1JZX1JFUExZEB0SFgoSQ19J",
+            "VEVNX1VTRV9SRVFVRVNUEB4SFAoQU19JVEVNX1VTRV9SRVBMWRAfEhYKElNf",
+            "SU5WRU5UT1JZX1VQREFURRAgEhQKEFNfU1lTVEVNX01FU1NBR0UQIRISCg5T",
+            "X01PTlNURVJfTElTVBAiKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAAS",
+            "EQoNSU5WQUxJRF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJW",
+            "RVJfRVJST1IQAyo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VO",
+            "REVSX01BTEUQARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtS",
+            "RUdJT05fTk9ORRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIq",
+            "QwoKRURpcmVjdGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJ",
+            "Ul9MRUZUEAISDQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxF",
+            "QVZFX1VOS05PV04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFO",
+            "R0VfUk9PTRACEhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFW",
+            "RV9ESVNDT05ORUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dO",
+            "EAASCwoHTU9WRV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9X",
+            "ThADEhAKDE1PVkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRF",
+            "Ul9VTktOT1dOEAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0Vf",
+            "Uk9PTRACKjkKDkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAA",
+            "EhIKDkRFU1BBV05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQ",
+            "RV9VTktOT1dOEAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVN",
+            "X1RZUEVfRVFVSVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRF",
+            "TV9UWVBFX01JU0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZP",
+            "EAASEwoPTUVTU0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcK",
+            "E01FU1NBR0VfRFJPUF9GQUlMRUQQA0IbqgIYR29vZ2xlLlByb3RvYnVmLlBy",
+            "b3RvY29sYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -156,8 +154,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerMove), global::Google.Protobuf.Protocol.S_BroadcastPlayerMove.Parser, new[]{ "Tick", "PlayerMoves" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_ChangeRoomBegin), global::Google.Protobuf.Protocol.S_ChangeRoomBegin.Parser, new[]{ "TransitionId", "MapId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_ChangeRoomReady), global::Google.Protobuf.Protocol.C_ChangeRoomReady.Parser, new[]{ "TransitionId" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_ChangeRoomCommit), global::Google.Protobuf.Protocol.S_ChangeRoomCommit.Parser, new[]{ "TransitionId", "MapId", "Snapshots" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_SpawnMonster), global::Google.Protobuf.Protocol.S_SpawnMonster.Parser, new[]{ "MonsterId", "MonsterTypeId", "X", "Y", "Dir" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_ChangeRoomCommit), global::Google.Protobuf.Protocol.S_ChangeRoomCommit.Parser, new[]{ "TransitionId", "MapId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_SpawnMonster), global::Google.Protobuf.Protocol.S_SpawnMonster.Parser, new[]{ "Monster" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_DespawnMonster), global::Google.Protobuf.Protocol.S_DespawnMonster.Parser, new[]{ "MonsterId", "Reason" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastMonsterMove), global::Google.Protobuf.Protocol.S_BroadcastMonsterMove.Parser, new[]{ "MonsterId", "X", "Y", "Dir" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastMonsterAttack), global::Google.Protobuf.Protocol.S_BroadcastMonsterAttack.Parser, new[]{ "MonsterId", "TargetPid" }, null, null, null, null),
@@ -176,7 +174,7 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.CharacterSummaryInfo), global::Google.Protobuf.Protocol.CharacterSummaryInfo.Parser, new[]{ "Username", "Level", "Gender", "Region" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerInfo), global::Google.Protobuf.Protocol.PlayerInfo.Parser, new[]{ "Id", "Username", "Pos", "Direction" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.InventorySlotInfo), global::Google.Protobuf.Protocol.InventorySlotInfo.Parser, new[]{ "SlotIndex", "ItemId", "Count", "IsQuickslot" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.MonsterInfo), global::Google.Protobuf.Protocol.MonsterInfo.Parser, new[]{ "MonsterId", "Pos", "Direction" }, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.MonsterInfo), global::Google.Protobuf.Protocol.MonsterInfo.Parser, new[]{ "MonsterId", "MonsterTypeId", "Pos", "Direction" }, null, null, null, null)
           }));
     }
     #endregion
@@ -4716,7 +4714,6 @@ namespace Google.Protobuf.Protocol {
     public S_ChangeRoomCommit(S_ChangeRoomCommit other) : this() {
       transitionId_ = other.transitionId_;
       mapId_ = other.mapId_;
-      snapshots_ = other.snapshots_ != null ? other.snapshots_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -4741,27 +4738,15 @@ namespace Google.Protobuf.Protocol {
     /// <summary>Field number for the "mapId" field.</summary>
     public const int MapIdFieldNumber = 2;
     private int mapId_;
+    /// <summary>
+    /// Snapshot은 OnEnter에서 PlayerList보내는것으로 대신함
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int MapId {
       get { return mapId_; }
       set {
         mapId_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "snapshots" field.</summary>
-    public const int SnapshotsFieldNumber = 3;
-    private global::Google.Protobuf.Protocol.S_PlayerList snapshots_;
-    /// <summary>
-    /// 들어오자마자 월드 동기화
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Google.Protobuf.Protocol.S_PlayerList Snapshots {
-      get { return snapshots_; }
-      set {
-        snapshots_ = value;
       }
     }
 
@@ -4782,7 +4767,6 @@ namespace Google.Protobuf.Protocol {
       }
       if (TransitionId != other.TransitionId) return false;
       if (MapId != other.MapId) return false;
-      if (!object.Equals(Snapshots, other.Snapshots)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -4792,7 +4776,6 @@ namespace Google.Protobuf.Protocol {
       int hash = 1;
       if (TransitionId != 0) hash ^= TransitionId.GetHashCode();
       if (MapId != 0) hash ^= MapId.GetHashCode();
-      if (snapshots_ != null) hash ^= Snapshots.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -4819,10 +4802,6 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(16);
         output.WriteInt32(MapId);
       }
-      if (snapshots_ != null) {
-        output.WriteRawTag(26);
-        output.WriteMessage(Snapshots);
-      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -4841,10 +4820,6 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(16);
         output.WriteInt32(MapId);
       }
-      if (snapshots_ != null) {
-        output.WriteRawTag(26);
-        output.WriteMessage(Snapshots);
-      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -4860,9 +4835,6 @@ namespace Google.Protobuf.Protocol {
       }
       if (MapId != 0) {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(MapId);
-      }
-      if (snapshots_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Snapshots);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -4881,12 +4853,6 @@ namespace Google.Protobuf.Protocol {
       }
       if (other.MapId != 0) {
         MapId = other.MapId;
-      }
-      if (other.snapshots_ != null) {
-        if (snapshots_ == null) {
-          Snapshots = new global::Google.Protobuf.Protocol.S_PlayerList();
-        }
-        Snapshots.MergeFrom(other.Snapshots);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -4911,13 +4877,6 @@ namespace Google.Protobuf.Protocol {
             MapId = input.ReadInt32();
             break;
           }
-          case 26: {
-            if (snapshots_ == null) {
-              Snapshots = new global::Google.Protobuf.Protocol.S_PlayerList();
-            }
-            input.ReadMessage(Snapshots);
-            break;
-          }
         }
       }
     #endif
@@ -4939,13 +4898,6 @@ namespace Google.Protobuf.Protocol {
           }
           case 16: {
             MapId = input.ReadInt32();
-            break;
-          }
-          case 26: {
-            if (snapshots_ == null) {
-              Snapshots = new global::Google.Protobuf.Protocol.S_PlayerList();
-            }
-            input.ReadMessage(Snapshots);
             break;
           }
         }
@@ -4992,11 +4944,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public S_SpawnMonster(S_SpawnMonster other) : this() {
-      monsterId_ = other.monsterId_;
-      monsterTypeId_ = other.monsterTypeId_;
-      x_ = other.x_;
-      y_ = other.y_;
-      dir_ = other.dir_;
+      monster_ = other.monster_ != null ? other.monster_.Clone() : null;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -5006,78 +4954,15 @@ namespace Google.Protobuf.Protocol {
       return new S_SpawnMonster(this);
     }
 
-    /// <summary>Field number for the "monsterId" field.</summary>
-    public const int MonsterIdFieldNumber = 1;
-    private int monsterId_;
-    /// <summary>
-    /// Entity Unique id
-    /// </summary>
+    /// <summary>Field number for the "monster" field.</summary>
+    public const int MonsterFieldNumber = 1;
+    private global::Google.Protobuf.Protocol.MonsterInfo monster_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int MonsterId {
-      get { return monsterId_; }
+    public global::Google.Protobuf.Protocol.MonsterInfo Monster {
+      get { return monster_; }
       set {
-        monsterId_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "monsterTypeId" field.</summary>
-    public const int MonsterTypeIdFieldNumber = 2;
-    private int monsterTypeId_;
-    /// <summary>
-    /// Monster Type (Template or Resources Id)
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int MonsterTypeId {
-      get { return monsterTypeId_; }
-      set {
-        monsterTypeId_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "x" field.</summary>
-    public const int XFieldNumber = 3;
-    private int x_;
-    /// <summary>
-    /// Tile Pos X
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int X {
-      get { return x_; }
-      set {
-        x_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "y" field.</summary>
-    public const int YFieldNumber = 4;
-    private int y_;
-    /// <summary>
-    /// Tile Pos Y
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int Y {
-      get { return y_; }
-      set {
-        y_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "dir" field.</summary>
-    public const int DirFieldNumber = 5;
-    private global::Google.Protobuf.Protocol.EDirection dir_ = global::Google.Protobuf.Protocol.EDirection.DirUp;
-    /// <summary>
-    /// 방향 
-    /// </summary>
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::Google.Protobuf.Protocol.EDirection Dir {
-      get { return dir_; }
-      set {
-        dir_ = value;
+        monster_ = value;
       }
     }
 
@@ -5096,11 +4981,7 @@ namespace Google.Protobuf.Protocol {
       if (ReferenceEquals(other, this)) {
         return true;
       }
-      if (MonsterId != other.MonsterId) return false;
-      if (MonsterTypeId != other.MonsterTypeId) return false;
-      if (X != other.X) return false;
-      if (Y != other.Y) return false;
-      if (Dir != other.Dir) return false;
+      if (!object.Equals(Monster, other.Monster)) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -5108,11 +4989,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
-      if (MonsterId != 0) hash ^= MonsterId.GetHashCode();
-      if (MonsterTypeId != 0) hash ^= MonsterTypeId.GetHashCode();
-      if (X != 0) hash ^= X.GetHashCode();
-      if (Y != 0) hash ^= Y.GetHashCode();
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) hash ^= Dir.GetHashCode();
+      if (monster_ != null) hash ^= Monster.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -5131,25 +5008,9 @@ namespace Google.Protobuf.Protocol {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
-      if (MonsterId != 0) {
-        output.WriteRawTag(8);
-        output.WriteInt32(MonsterId);
-      }
-      if (MonsterTypeId != 0) {
-        output.WriteRawTag(16);
-        output.WriteInt32(MonsterTypeId);
-      }
-      if (X != 0) {
-        output.WriteRawTag(24);
-        output.WriteInt32(X);
-      }
-      if (Y != 0) {
-        output.WriteRawTag(32);
-        output.WriteInt32(Y);
-      }
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(40);
-        output.WriteEnum((int) Dir);
+      if (monster_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Monster);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
@@ -5161,25 +5022,9 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (MonsterId != 0) {
-        output.WriteRawTag(8);
-        output.WriteInt32(MonsterId);
-      }
-      if (MonsterTypeId != 0) {
-        output.WriteRawTag(16);
-        output.WriteInt32(MonsterTypeId);
-      }
-      if (X != 0) {
-        output.WriteRawTag(24);
-        output.WriteInt32(X);
-      }
-      if (Y != 0) {
-        output.WriteRawTag(32);
-        output.WriteInt32(Y);
-      }
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(40);
-        output.WriteEnum((int) Dir);
+      if (monster_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Monster);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
@@ -5191,20 +5036,8 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
-      if (MonsterId != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterId);
-      }
-      if (MonsterTypeId != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterTypeId);
-      }
-      if (X != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(X);
-      }
-      if (Y != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Y);
-      }
-      if (Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Dir);
+      if (monster_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Monster);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -5218,20 +5051,11 @@ namespace Google.Protobuf.Protocol {
       if (other == null) {
         return;
       }
-      if (other.MonsterId != 0) {
-        MonsterId = other.MonsterId;
-      }
-      if (other.MonsterTypeId != 0) {
-        MonsterTypeId = other.MonsterTypeId;
-      }
-      if (other.X != 0) {
-        X = other.X;
-      }
-      if (other.Y != 0) {
-        Y = other.Y;
-      }
-      if (other.Dir != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        Dir = other.Dir;
+      if (other.monster_ != null) {
+        if (monster_ == null) {
+          Monster = new global::Google.Protobuf.Protocol.MonsterInfo();
+        }
+        Monster.MergeFrom(other.Monster);
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -5248,24 +5072,11 @@ namespace Google.Protobuf.Protocol {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
-          case 8: {
-            MonsterId = input.ReadInt32();
-            break;
-          }
-          case 16: {
-            MonsterTypeId = input.ReadInt32();
-            break;
-          }
-          case 24: {
-            X = input.ReadInt32();
-            break;
-          }
-          case 32: {
-            Y = input.ReadInt32();
-            break;
-          }
-          case 40: {
-            Dir = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
+          case 10: {
+            if (monster_ == null) {
+              Monster = new global::Google.Protobuf.Protocol.MonsterInfo();
+            }
+            input.ReadMessage(Monster);
             break;
           }
         }
@@ -5283,24 +5094,11 @@ namespace Google.Protobuf.Protocol {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
-          case 8: {
-            MonsterId = input.ReadInt32();
-            break;
-          }
-          case 16: {
-            MonsterTypeId = input.ReadInt32();
-            break;
-          }
-          case 24: {
-            X = input.ReadInt32();
-            break;
-          }
-          case 32: {
-            Y = input.ReadInt32();
-            break;
-          }
-          case 40: {
-            Dir = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
+          case 10: {
+            if (monster_ == null) {
+              Monster = new global::Google.Protobuf.Protocol.MonsterInfo();
+            }
+            input.ReadMessage(Monster);
             break;
           }
         }
@@ -9600,6 +9398,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public MonsterInfo(MonsterInfo other) : this() {
       monsterId_ = other.monsterId_;
+      monsterTypeId_ = other.monsterTypeId_;
       pos_ = other.pos_ != null ? other.pos_.Clone() : null;
       direction_ = other.direction_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
@@ -9614,6 +9413,9 @@ namespace Google.Protobuf.Protocol {
     /// <summary>Field number for the "monsterId" field.</summary>
     public const int MonsterIdFieldNumber = 1;
     private int monsterId_;
+    /// <summary>
+    /// Entity Unique id
+    /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int MonsterId {
@@ -9623,8 +9425,23 @@ namespace Google.Protobuf.Protocol {
       }
     }
 
+    /// <summary>Field number for the "monsterTypeId" field.</summary>
+    public const int MonsterTypeIdFieldNumber = 2;
+    private int monsterTypeId_;
+    /// <summary>
+    /// Monster Type (Template or Resources Id)
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int MonsterTypeId {
+      get { return monsterTypeId_; }
+      set {
+        monsterTypeId_ = value;
+      }
+    }
+
     /// <summary>Field number for the "pos" field.</summary>
-    public const int PosFieldNumber = 2;
+    public const int PosFieldNumber = 3;
     private global::Google.Protobuf.Protocol.Vector2Info pos_;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -9636,7 +9453,7 @@ namespace Google.Protobuf.Protocol {
     }
 
     /// <summary>Field number for the "direction" field.</summary>
-    public const int DirectionFieldNumber = 3;
+    public const int DirectionFieldNumber = 4;
     private global::Google.Protobuf.Protocol.EDirection direction_ = global::Google.Protobuf.Protocol.EDirection.DirUp;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -9663,6 +9480,7 @@ namespace Google.Protobuf.Protocol {
         return true;
       }
       if (MonsterId != other.MonsterId) return false;
+      if (MonsterTypeId != other.MonsterTypeId) return false;
       if (!object.Equals(Pos, other.Pos)) return false;
       if (Direction != other.Direction) return false;
       return Equals(_unknownFields, other._unknownFields);
@@ -9673,6 +9491,7 @@ namespace Google.Protobuf.Protocol {
     public override int GetHashCode() {
       int hash = 1;
       if (MonsterId != 0) hash ^= MonsterId.GetHashCode();
+      if (MonsterTypeId != 0) hash ^= MonsterTypeId.GetHashCode();
       if (pos_ != null) hash ^= Pos.GetHashCode();
       if (Direction != global::Google.Protobuf.Protocol.EDirection.DirUp) hash ^= Direction.GetHashCode();
       if (_unknownFields != null) {
@@ -9697,12 +9516,16 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(8);
         output.WriteInt32(MonsterId);
       }
+      if (MonsterTypeId != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(MonsterTypeId);
+      }
       if (pos_ != null) {
-        output.WriteRawTag(18);
+        output.WriteRawTag(26);
         output.WriteMessage(Pos);
       }
       if (Direction != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(24);
+        output.WriteRawTag(32);
         output.WriteEnum((int) Direction);
       }
       if (_unknownFields != null) {
@@ -9719,12 +9542,16 @@ namespace Google.Protobuf.Protocol {
         output.WriteRawTag(8);
         output.WriteInt32(MonsterId);
       }
+      if (MonsterTypeId != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(MonsterTypeId);
+      }
       if (pos_ != null) {
-        output.WriteRawTag(18);
+        output.WriteRawTag(26);
         output.WriteMessage(Pos);
       }
       if (Direction != global::Google.Protobuf.Protocol.EDirection.DirUp) {
-        output.WriteRawTag(24);
+        output.WriteRawTag(32);
         output.WriteEnum((int) Direction);
       }
       if (_unknownFields != null) {
@@ -9739,6 +9566,9 @@ namespace Google.Protobuf.Protocol {
       int size = 0;
       if (MonsterId != 0) {
         size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterId);
+      }
+      if (MonsterTypeId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(MonsterTypeId);
       }
       if (pos_ != null) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Pos);
@@ -9760,6 +9590,9 @@ namespace Google.Protobuf.Protocol {
       }
       if (other.MonsterId != 0) {
         MonsterId = other.MonsterId;
+      }
+      if (other.MonsterTypeId != 0) {
+        MonsterTypeId = other.MonsterTypeId;
       }
       if (other.pos_ != null) {
         if (pos_ == null) {
@@ -9789,14 +9622,18 @@ namespace Google.Protobuf.Protocol {
             MonsterId = input.ReadInt32();
             break;
           }
-          case 18: {
+          case 16: {
+            MonsterTypeId = input.ReadInt32();
+            break;
+          }
+          case 26: {
             if (pos_ == null) {
               Pos = new global::Google.Protobuf.Protocol.Vector2Info();
             }
             input.ReadMessage(Pos);
             break;
           }
-          case 24: {
+          case 32: {
             Direction = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
             break;
           }
@@ -9819,14 +9656,18 @@ namespace Google.Protobuf.Protocol {
             MonsterId = input.ReadInt32();
             break;
           }
-          case 18: {
+          case 16: {
+            MonsterTypeId = input.ReadInt32();
+            break;
+          }
+          case 26: {
             if (pos_ == null) {
               Pos = new global::Google.Protobuf.Protocol.Vector2Info();
             }
             input.ReadMessage(Pos);
             break;
           }
-          case 24: {
+          case 32: {
             Direction = (global::Google.Protobuf.Protocol.EDirection) input.ReadEnum();
             break;
           }


### PR DESCRIPTION
● Protocol.proto 변경사항

  1. S_SpawnMonster 프로토콜 구조 변경
```
  // 변경 전
  message S_SpawnMonster {
      int32 monsterId = 1;        // Entity Unique id
      int32 monsterTypeId = 2;    // Monster Type (Template or Resources Id)
      int32 x = 3;                // Tile Pos X
      int32 y = 4;                // Tile Pos Y
      EDirection dir = 5;         // 방향
  }

  // 변경 후
  message S_SpawnMonster {
      MonsterInfo monster = 1;
  }

  2. MonsterInfo 메시지에 monsterTypeId 필드 추가

  // 변경 전
  message MonsterInfo {
      int32 monsterId = 1;
      Vector2Info pos = 2;
      EDirection direction = 3;
  }

  // 변경 후
  message MonsterInfo {
      int32 monsterId = 1;
      int32 monsterTypeId = 2;    // 새로 추가
      Vector2Info pos = 3;
      EDirection direction = 4;
  }

  3. S_ChangeRoomCommit에서 snapshots 필드 제거

  // 변경 전
  message S_ChangeRoomCommit {
      int32 transitionId = 1;
      int32 mapId = 2;
      S_PlayerList snapshots = 3;    // 들어오자마자 월드 동기화
  }

  // 변경 후
  message S_ChangeRoomCommit {
      int32 transitionId = 1;
      int32 mapId = 2;
      // Snapshot은 OnEnter에서 PlayerList보내는것으로 대신함
  }
```
- S_SpawnMonster를 개별 필드에서 MonsterInfo 객체로 통합하여 구조 개선
- MonsterInfo에 monsterTypeId 필드 추가로 몬스터 타입 식별 가능
- S_ChangeRoomCommit에서 snapshots 필드 제거하여 프로토콜 단순화
- 룸 이동시 몬스터가 스폰되지 않던 버그 해결
- DummyClient에서 MonsterTypeId 표시 추가로 디버깅 정보 향상
