### PR TITLE
refactor(monster): 몬스터 상태 전환 시스템 리팩토링 및 FSM 완성 : Server -> Main

### DIFF
--- a/GameServer/FieldRoom.cpp
+++ b/GameServer/FieldRoom.cpp
@@ -345,13 +345,14 @@ void FieldRoom::InitMonsters()
 	auto monsterStatDatas = std::make_unique<vector<pair<int, MonsterStats>>>();
 	auto spawnPointCfgDatas = std::make_unique<vector<SpawnPointCfg>>();
 
+	for(int i=0; i<5; i++)
 	{
 		// 기본 몬스터 (움직이는)
 		int monsterId = 1001;
 		MonsterStats monsterStats = { 30, 5, 1, 1, 1200, 1 };
 		monsterStatDatas->push_back({ monsterId, monsterStats });
 
-		SpawnPointCfg spawnPointCfg = { 1, 15, -4, 5, 1, 8000, 10, monsterId };
+		SpawnPointCfg spawnPointCfg = { 1, 15+i, -4-i, 5, 1, 8000, 10, monsterId };
 		spawnPointCfgDatas->push_back(spawnPointCfg);
 	}
 

--- a/GameServer/MonsterCombatSystem.cpp
+++ b/GameServer/MonsterCombatSystem.cpp
@@ -5,7 +5,6 @@ static inline int Mdist(const Pos2& a, const Pos2& b) {
 	return std::abs(a.x - b.x) + std::abs(a.y - b.y);
 }
 
-
 void MonsterCombatSystem::Tick(MonsterContainer& repo, const MonsterSpawnerSystem& spawner,
 	IMonsterEntityLinker& linker, IMonsterBroadcaster& cast, IMonsterClock& clock,
 	const std::unordered_map<int, MonsterStats>& statsByType) 
@@ -26,62 +25,50 @@ void MonsterCombatSystem::Tick(MonsterContainer& repo, const MonsterSpawnerSyste
 void MonsterCombatSystem::TickOne(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast, IMonsterClock& clock,
 	const MonsterStats& stats) 
 {
-	// 타깃 선정(가장 가까운 플레이어 1명)
-	int bestId = -1, bestDist = std::numeric_limits<int>::max();
-	linker.ForEachPlayerInRange(m.core.pos.x, m.core.pos.y, stats.aggroRangeTiles,
-		[&](const IMonsterEntityLinker::PlayerView& pv) {
-			int d = std::abs(pv.x - m.core.pos.x) + std::abs(pv.y - m.core.pos.y);
-			if (d < bestDist) { bestDist = d; bestId = pv.id; }
-		});
-
-
-	if (bestId < 0) {
-		// 타깃 없음 → Idle/Patrol 유지 또는 Return은 Movement가 처리
-		m.targetPlayerId = -1;
-		return;
-	}
+	// 타깃 선정(가장 aggroRangeTiles 안에 있는 가장 가까운 플레이어 1명)
+	setTarget(m, linker, stats);
 
 	// Get Player
-
 	IMonsterEntityLinker::PlayerView pv;
-	if (linker.TryGetPlayer(bestId, pv)) {
-		int dist = Mdist(m.core.pos, Pos2{ pv.x, pv.y });
-
-		if (dist <= stats.attackRangeTiles) {  // 1칸 거리
-			if (m.state != MState::Combat && m.state != MState::Ready) {
-				GConsoleLogger->WriteStdOut(Color::GREEN, L"[Combat] Monster:%d enters Ready state (target player:%d)\n", m.core.id, bestId);
-				m.state = MState::Ready;  // 처음 접근시만 Ready
-			}
-		}
-		else{  // 멀리 있고 전투 모드면 추적
-			if (m.state == MState::Ready) {
-				// Ready 상태에서 멀어지면 Patrol로 복귀
-				m.state = MState::Patrol;
-				m.targetPlayerId = -1;
-			}
-			else if (m.state == MState::Combat) {
-				// Combat 상태에서 멀어지면 Chase로 전환
-				m.state = MState::Chase;
-			}
-		}
-		m.targetPlayerId = bestId;
-	}
-
+	if(linker.TryGetPlayer(m.targetPlayerId, pv) == false) return;
 
 	// 공격 시도
 	if (m.wasAttacked && m.state == MState::Combat)
 	{
-		const int64_t now = clock.NowMs();
-		if (now >= m.nextAttackAtMs) {
-			IMonsterEntityLinker::PlayerView pv;
-			if (linker.TryGetPlayer(bestId, pv)) {
-				int dist = Mdist(m.core.pos, Pos2{ pv.x, pv.y });
-				if (dist <= stats.attackRangeTiles) {
-					GConsoleLogger->WriteStdOut(Color::WHITE, L"[Combat] Monster:%d attacks player:%d (dmg:%d)\n", m.core.id, bestId, stats.atk);
-					linker.ApplyDamageToPlayer(bestId, stats.atk, (int)m.core.id);
-					cast.BroadcastMonsterAttack(m.core.id, bestId);
-					m.nextAttackAtMs = now + stats.attackCooldownMs;
-				}
+		ExecuteAttack(m, linker, cast, clock, stats);
+	}
+
+
+}
+
+void MonsterCombatSystem::setTarget(Monster& m, IMonsterEntityLinker& linker, const MonsterStats& stats)
+{
+	if(isValidTarget(m)) return; // targetPlayerId가 없을 경우만 체크
+
+	int bestId = -1, bestDist = std::numeric_limits<int>::max();
+	linker.ForEachPlayerInRange(m.core.pos.x, m.core.pos.y, stats.aggroRangeTiles,
+		[&](const IMonsterEntityLinker::PlayerView& pv) 
+		{
+			int d = std::abs(pv.x - m.core.pos.x) + std::abs(pv.y - m.core.pos.y);
+			if (d < bestDist) { bestDist = d; bestId = pv.id; }
+		}
+	);
+
+	m.targetPlayerId = bestId;
+}
+
+void MonsterCombatSystem::ExecuteAttack(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast, IMonsterClock& clock, const MonsterStats& stats)
+{
+	const int64_t now = clock.NowMs();
+	if (now >= m.nextAttackAtMs) {
+		IMonsterEntityLinker::PlayerView pv;
+		if (linker.TryGetPlayer(m.targetPlayerId, pv)) {
+			int dist = Mdist(m.core.pos, Pos2{ pv.x, pv.y });
+			if (dist <= stats.attackRangeTiles) {
+				GConsoleLogger->WriteStdOut(Color::WHITE, L"[Combat] Monster:%d attacks player:%d (dmg:%d)\n", m.core.id, m.targetPlayerId, stats.atk);
+				linker.ApplyDamageToPlayer(m.targetPlayerId, stats.atk, (int)m.core.id);
+				cast.BroadcastMonsterAttack(m.core.id, m.targetPlayerId);
+				m.nextAttackAtMs = now + stats.attackCooldownMs;
 			}
 		}
 	}

--- a/GameServer/MonsterCombatSystem.h
+++ b/GameServer/MonsterCombatSystem.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "MonsterContainer.h"
 #include "MonsterPorts.h"
 #include "MonsterSpawnerSystem.h"
@@ -14,6 +14,16 @@ public:
 private:
 	void TickOne(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast, IMonsterClock& clock,
 		const MonsterStats& stats);
+
+	void setTarget(Monster&m, IMonsterEntityLinker& linker, const MonsterStats& stats);
+	void ExecuteAttack(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast, IMonsterClock& clock, const MonsterStats& stats);
+
+private:
+	// Helper
+	bool isValidTarget(Monster& m) {return m.targetPlayerId != -1; }
+	bool isReadyState(Monster& m) {return m.state == MState::Ready; }
+	bool inAttackRange(int distance, const MonsterStats& stats) {return distance <= stats.attackRangeTiles;}
+
 };
 
 

--- a/GameServer/MonsterMovementSystem.cpp
+++ b/GameServer/MonsterMovementSystem.cpp
@@ -62,144 +62,282 @@ void MonsterMovementSystem::TickOne(Monster& m,
 									IMonsterClock& clock, 
 									IMonsterRng& rng) 
 {
-	// 간단 FSM: Idle/Patrol ↔ Chase ↔ Return
-	// v1: Chase 판단은 CombatSystem에서 타깃을 세팅한다 가정하고, 여기서는 위치만 담당
-
-	// 리쉬 체크(스폰 반경 2배 이상이면 Return)
-	const auto& spawns = spawner.Spawns();
-	auto it = std::find_if(spawns.begin(), spawns.end(),
-		[&](const SpawnPointCfg& s) { return s.id == m.fromSpawnId; });
-	const int leash = (it != spawns.end()) ? it->leashRadiusTiles : 10;
-	const int dx = std::abs(m.core.pos.x - m.spawnX);
-	const int dy = std::abs(m.core.pos.y - m.spawnY);
-	bool outOfLeash = (dx + dy) > leash * 2; // 맨해튼 기준 대충
-
-
-	if (outOfLeash) m.state = MState::Return;
-
+	// 몬스터 스탯 가져오기
 	auto monsterStats = spawner.GetStats(m.typeId);
-	if (monsterStats.moveSpeedTilesPerSec <= 0) // 0보다 작으면 아무런행동 X, MState도 Idle에서 고정
-	{
+	if (monsterStats.moveSpeedTilesPerSec <= 0) {
+		// 이동 불가능한 몬스터는 아무 행동도 하지 않음
 		return;
 	}
 
-	switch (m.state)
-	{
+	// 1단계: 상태 전환 체크
+	CheckStateTransitions(m, spawner, linker, clock, monsterStats);
+
+	// 2단계: 현재 상태에 따른 행동 실행
+	switch (m.state) {
+		case MState::Idle:
+			// Idle은 자동으로 Patrol로 전환
+			m.state = MState::Patrol;
+			[[fallthrough]];
+		case MState::Patrol:
+			ExecutePatrolState(m, map, cast, clock, rng, monsterStats);
+			break;
+		case MState::Ready:
+			ExecuteReadyState(m, linker, cast, clock, monsterStats);
+			break;
+		case MState::Combat:
+			ExecuteCombatState(m, linker, cast, clock, monsterStats);
+			break;
+		case MState::Chase:
+			ExecuteChaseState(m, linker, map, cast, clock, monsterStats);
+			break;
+		case MState::Return:
+			ExecuteReturnState(m, map, cast, clock, monsterStats);
+			break;
+		case MState::Dead:
+		default:
+			// 죽었거나 알 수 없는 상태에서는 아무것도 하지 않음
+			break;
+	}
+}
+
+// ===== 새로운 FSM 구조 =====
+
+void MonsterMovementSystem::CheckStateTransitions(Monster& m, 
+												  const MonsterSpawnerSystem& spawner,
+												  IMonsterEntityLinker& linker, 
+												  IMonsterClock& clock,
+												  const MonsterStats& stats)
+{
+	// 1. 리쉬 체크 (최우선)
+	if (IsOutOfLeash(m, spawner)) {
+		m.state = MState::Return;
+		return;
+	}
+
+	// 2. 죽음 체크
+	if (m.curHp <= 0) {
+		m.state = MState::Dead;
+		return;
+	}
+
+	// 3. 타겟 유효성 체크
+	int distToTarget = GetDistanceToTarget(m, linker);
+	bool hasValidTarget = (m.targetPlayerId != -1 && distToTarget != -1);
+	bool inAttackRange = hasValidTarget && IsPlayerInAttackRange(m, linker, stats.attackRangeTiles);
+
+	// 4. 상태별 전환 규칙
+	switch (m.state) {
 		case MState::Idle:
 		case MState::Patrol:
 		{
-			int stepMs = 1000 / monsterStats.moveSpeedTilesPerSec;
-			
-			// Patrol 시작: 새로운 방향과 스텝 수 설정
-			if (m.patrolStepsRemaining <= 0) {
-				m.targetDirection = static_cast<Protocol::EDirection>(rng.NextInt(0, 3));
-				m.patrolTargetSteps = rng.NextInt(3, 5); // 3-5칸
-				m.patrolStepsRemaining = m.patrolTargetSteps;
-				m.needsRotation = (m.core.dir != m.targetDirection);
-				GConsoleLogger->WriteStdOut(Color::WHITE, L"[Patrol] Monster:%d starting patrol: dir=%d, steps=%d\n", 
-					m.core.id, (int)m.targetDirection, m.patrolTargetSteps);
+			if (hasValidTarget && inAttackRange) {
+				m.state = MState::Ready;
+				GConsoleLogger->WriteStdOut(Color::GREEN, L"[StateTransition] Monster:%d Patrol->Ready (target:%d)\n", 
+					m.core.id, m.targetPlayerId);
 			}
-			
-			// 회전이 필요하면 회전 먼저
-			if (m.needsRotation) {
-				if (this->TryRotate(m, m.targetDirection, cast)) {
-					m.nextMoveAtMs = clock.NowMs() + stepMs;
-				} else {
-					m.nextMoveAtMs = clock.NowMs() + 200;
-				}
-			} else {
-				// 이동 시도
-				if (this->TryStep(m, m.targetDirection, map, cast)) {
-					m.patrolStepsRemaining--;
-					m.nextMoveAtMs = clock.NowMs() + stepMs;
-				} else {
-					// 막혔으면 다른 방향으로 전환
-					m.patrolStepsRemaining = 0; // 새 방향 선택 강제
-					m.nextMoveAtMs = clock.NowMs() + 200;
-				}
-			}
-			m.state = MState::Patrol;
 			break;
 		}
 		case MState::Ready:
 		{
-			int stepMs = 1000 / monsterStats.moveSpeedTilesPerSec;
-			if (m.targetPlayerId != -1) {
-				IMonsterEntityLinker::PlayerView pv;
-				if (linker.TryGetPlayer(m.targetPlayerId, pv)) {
-					Protocol::EDirection targetDir = FaceTo(m.core.pos, Pos2{ pv.x, pv.y });
-					if (m.core.dir != targetDir) {
-						this->TryRotate(m, targetDir, cast);
-					}
-				}
+			if (m.wasAttacked) {
+				m.state = MState::Combat;
+				GConsoleLogger->WriteStdOut(Color::GREEN, L"[StateTransition] Monster:%d Ready->Combat (attacked)\n", 
+					m.core.id);
 			}
-			m.nextMoveAtMs = clock.NowMs() + stepMs;
-			break;
-		}
-		case MState::Chase:
-		{
-			if (m.targetPlayerId == -1)
-			{
+			else if (!hasValidTarget || !inAttackRange) {
 				m.state = MState::Patrol;
-				m.wasAttacked = false;
+				m.targetPlayerId = -1;
 				m.patrolStepsRemaining = 0; // 새 패트롤 시작
-				break;
-			}
-
-			IMonsterEntityLinker::PlayerView pv;
-			Protocol::EDirection targetDir = Protocol::EDirection::DIR_UP;
-			if (linker.TryGetPlayer(m.targetPlayerId, pv)) {
-				targetDir = FaceTo(m.core.pos, Pos2{ pv.x, pv.y });
-				GConsoleLogger->WriteStdOut(Color::WHITE, L"[Movement] Monster:%d tracking player:%d from (%d,%d) to (%d,%d) \n",
-					m.core.id, m.targetPlayerId, m.core.pos.x, m.core.pos.y, pv.x, pv.y);
-			}
-
-			int stepMs = 1000 / monsterStats.moveSpeedTilesPerSec;
-			
-			// 2단계: 회전 먼저, 그 다음 이동
-			if (m.core.dir != targetDir) {
-				if (this->TryRotate(m, targetDir, cast)) {
-					m.nextMoveAtMs = clock.NowMs() + stepMs;
-				} else {
-					m.nextMoveAtMs = clock.NowMs() + 200;
-				}
-			} else {
-				if (this->TryStep(m, targetDir, map, cast))
-					m.nextMoveAtMs = clock.NowMs() + stepMs;
-				else
-					m.nextMoveAtMs = clock.NowMs() + 200; // 막히면 짧게 대기
+				GConsoleLogger->WriteStdOut(Color::GREEN, L"[StateTransition] Monster:%d Ready->Patrol (lost target)\n", 
+					m.core.id);
 			}
 			break;
 		}
 		case MState::Combat:
 		{
-			// 전투 시 이동 X, 방향만 조정
-			if (m.targetPlayerId == -1)
-			{
+			if (!hasValidTarget) {
 				m.state = MState::Patrol;
+				m.targetPlayerId = -1;
 				m.wasAttacked = false;
-				m.patrolStepsRemaining = 0; // 새 패트롤 시작
-				break;
+				m.patrolStepsRemaining = 0;
+				GConsoleLogger->WriteStdOut(Color::GREEN, L"[StateTransition] Monster:%d Combat->Patrol (no target)\n", 
+					m.core.id);
 			}
-
-			IMonsterEntityLinker::PlayerView pv;
-			if (linker.TryGetPlayer(m.targetPlayerId, pv)) {
-				Protocol::EDirection targetDir = FaceTo(m.core.pos, Pos2{ pv.x, pv.y });
-				if (m.core.dir != targetDir) {
-					this->TryRotate(m, targetDir, cast);
-				}
-				GConsoleLogger->WriteStdOut(Color::WHITE, L"[Movement] Monster:%d in combat facing player:%d\n",
-					m.core.id, m.targetPlayerId);
+			else if (!inAttackRange) {
+				m.state = MState::Chase;
+				GConsoleLogger->WriteStdOut(Color::GREEN, L"[StateTransition] Monster:%d Combat->Chase (target far)\n", 
+					m.core.id);
+			}
+			break;
+		}
+		case MState::Chase:
+		{
+			if (!hasValidTarget) {
+				m.state = MState::Patrol;
+				m.targetPlayerId = -1;
+				m.wasAttacked = false;
+				m.patrolStepsRemaining = 0;
+				GConsoleLogger->WriteStdOut(Color::GREEN, L"[StateTransition] Monster:%d Chase->Patrol (no target)\n", 
+					m.core.id);
+			}
+			else if (inAttackRange) {
+				m.state = MState::Combat;
+				GConsoleLogger->WriteStdOut(Color::GREEN, L"[StateTransition] Monster:%d Chase->Combat (in range)\n", 
+					m.core.id);
 			}
 			break;
 		}
 		case MState::Return:
 		{
-			// TODO 스폰 지점으로 복귀
+			// TODO: 스폰 지점 도달 시 Patrol로 복귀
 			break;
 		}
 		case MState::Dead:
 		default:
 			break;
 	}
+}
+
+// 유틸리티 함수들
+int MonsterMovementSystem::GetDistanceToTarget(Monster& m, IMonsterEntityLinker& linker)
+{
+	if (m.targetPlayerId == -1) return -1;
+	
+	IMonsterEntityLinker::PlayerView pv;
+	if (!linker.TryGetPlayer(m.targetPlayerId, pv)) return -1;
+	
+	return std::abs(m.core.pos.x - pv.x) + std::abs(m.core.pos.y - pv.y);
+}
+
+bool MonsterMovementSystem::IsPlayerInAttackRange(Monster& m, IMonsterEntityLinker& linker, int attackRange)
+{
+	int dist = GetDistanceToTarget(m, linker);
+	return (dist != -1 && dist <= attackRange);
+}
+
+bool MonsterMovementSystem::IsOutOfLeash(Monster& m, const MonsterSpawnerSystem& spawner)
+{
+	const auto& spawns = spawner.Spawns();
+	auto it = std::find_if(spawns.begin(), spawns.end(),
+		[&](const SpawnPointCfg& s) { return s.id == m.fromSpawnId; });
+	
+	if (it == spawns.end()) return false;
+	
+	const int leash = it->leashRadiusTiles;
+	const int dx = std::abs(m.core.pos.x - m.spawnX);
+	const int dy = std::abs(m.core.pos.y - m.spawnY);
+	return (dx + dy) > leash * 2; // 맨해튼 기준
+}
+
+// ===== 상태별 실행 로직 =====
+
+void MonsterMovementSystem::ExecutePatrolState(Monster& m, IMonsterMapQuery& map, IMonsterBroadcaster& cast, 
+											   IMonsterClock& clock, IMonsterRng& rng, const MonsterStats& stats)
+{
+	int stepMs = 1000 / stats.moveSpeedTilesPerSec;
+	
+	// Patrol 시작: 새로운 방향과 스텝 수 설정
+	if (m.patrolStepsRemaining <= 0) {
+		m.targetDirection = static_cast<Protocol::EDirection>(rng.NextInt(0, 3));
+		m.patrolTargetSteps = rng.NextInt(3, 5); // 3-5칸
+		m.patrolStepsRemaining = m.patrolTargetSteps;
+		m.needsRotation = (m.core.dir != m.targetDirection);
+		GConsoleLogger->WriteStdOut(Color::WHITE, L"[Patrol] Monster:%d starting patrol: dir=%d, steps=%d\n", 
+			m.core.id, (int)m.targetDirection, m.patrolTargetSteps);
+	}
+	
+	// 회전이 필요하면 회전 먼저
+	if (m.needsRotation) {
+		if (this->TryRotate(m, m.targetDirection, cast)) {
+			m.nextMoveAtMs = clock.NowMs() + stepMs;
+		} else {
+			m.nextMoveAtMs = clock.NowMs() + 200;
+		}
+	} else {
+		// 이동 시도
+		if (this->TryStep(m, m.targetDirection, map, cast)) {
+			m.patrolStepsRemaining--;
+			m.nextMoveAtMs = clock.NowMs() + stepMs;
+		} else {
+			// 막혔으면 다른 방향으로 전환
+			m.patrolStepsRemaining = 0; // 새 방향 선택 강제
+			m.nextMoveAtMs = clock.NowMs() + 200;
+		}
+	}
+}
+
+void MonsterMovementSystem::ExecuteReadyState(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast,
+											 IMonsterClock& clock, const MonsterStats& stats)
+{
+	int stepMs = 1000 / stats.moveSpeedTilesPerSec;
+	
+	// Ready 상태에서는 이동하지 않고 플레이어 방향으로만 회전
+	if (m.targetPlayerId != -1) {
+		IMonsterEntityLinker::PlayerView pv;
+		if (linker.TryGetPlayer(m.targetPlayerId, pv)) {
+			Protocol::EDirection targetDir = FaceTo(m.core.pos, Pos2{ pv.x, pv.y });
+			if (m.core.dir != targetDir) {
+				this->TryRotate(m, targetDir, cast);
+			}
+		}
+	}
+	m.nextMoveAtMs = clock.NowMs() + stepMs;
+}
+
+void MonsterMovementSystem::ExecuteCombatState(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast,
+											  IMonsterClock& clock, const MonsterStats& stats)
+{
+	// Combat 상태에서는 이동하지 않고 플레이어 방향으로만 회전
+	if (m.targetPlayerId != -1) {
+		IMonsterEntityLinker::PlayerView pv;
+		if (linker.TryGetPlayer(m.targetPlayerId, pv)) {
+			Protocol::EDirection targetDir = FaceTo(m.core.pos, Pos2{ pv.x, pv.y });
+			if (m.core.dir != targetDir) {
+				this->TryRotate(m, targetDir, cast);
+			}
+			GConsoleLogger->WriteStdOut(Color::WHITE, L"[Movement] Monster:%d in combat facing player:%d\n",
+				m.core.id, m.targetPlayerId);
+		}
+	}
+}
+
+void MonsterMovementSystem::ExecuteChaseState(Monster& m, IMonsterEntityLinker& linker, IMonsterMapQuery& map,
+											 IMonsterBroadcaster& cast, IMonsterClock& clock, const MonsterStats& stats)
+{
+	if (m.targetPlayerId == -1) return;
+
+	IMonsterEntityLinker::PlayerView pv;
+	Protocol::EDirection targetDir = Protocol::EDirection::DIR_UP;
+	if (linker.TryGetPlayer(m.targetPlayerId, pv)) {
+		targetDir = FaceTo(m.core.pos, Pos2{ pv.x, pv.y });
+		GConsoleLogger->WriteStdOut(Color::WHITE, L"[Movement] Monster:%d tracking player:%d from (%d,%d) to (%d,%d)\n",
+			m.core.id, m.targetPlayerId, m.core.pos.x, m.core.pos.y, pv.x, pv.y);
+	}
+
+	int stepMs = 1000 / stats.moveSpeedTilesPerSec;
+	
+	// 2단계: 회전 먼저, 그 다음 이동
+	if (m.core.dir != targetDir) {
+		if (this->TryRotate(m, targetDir, cast)) {
+			m.nextMoveAtMs = clock.NowMs() + stepMs;
+		} else {
+			m.nextMoveAtMs = clock.NowMs() + 200;
+		}
+	} else {
+		if (this->TryStep(m, targetDir, map, cast))
+			m.nextMoveAtMs = clock.NowMs() + stepMs;
+		else
+			m.nextMoveAtMs = clock.NowMs() + 200; // 막히면 짧게 대기
+	}
+}
+
+void MonsterMovementSystem::ExecuteReturnState(Monster& m, IMonsterMapQuery& map, IMonsterBroadcaster& cast,
+											  IMonsterClock& clock, const MonsterStats& stats)
+{
+	// TODO: 스폰 지점으로 복귀 로직 구현
+	// 현재는 단순히 Patrol로 전환
+	m.state = MState::Patrol;
+	m.targetPlayerId = -1;
+	m.wasAttacked = false;
+	m.patrolStepsRemaining = 0;
 }

--- a/GameServer/MonsterMovementSystem.h
+++ b/GameServer/MonsterMovementSystem.h
@@ -27,7 +27,8 @@ public:
 
 private:
 	Cfg _cfg;
-	// 내부 유틸
+
+	// 메인 처리
 	void TickOne(Monster& m, 
 				 const MonsterSpawnerSystem& spawner,
 				 IMonsterMapQuery& map,
@@ -36,6 +37,31 @@ private:
 				 IMonsterClock& clock,
 				 IMonsterRng& rng);
 	
+	// 상태 전환 체크
+	void CheckStateTransitions(Monster& m, 
+							  const MonsterSpawnerSystem& spawner,
+							  IMonsterEntityLinker& linker, 
+							  IMonsterClock& clock,
+							  const MonsterStats& stats);
+	
+	// 상태별 실행 로직
+	void ExecutePatrolState(Monster& m, IMonsterMapQuery& map, IMonsterBroadcaster& cast, 
+						   IMonsterClock& clock, IMonsterRng& rng, const MonsterStats& stats);
+	void ExecuteReadyState(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast,
+						  IMonsterClock& clock, const MonsterStats& stats);
+	void ExecuteCombatState(Monster& m, IMonsterEntityLinker& linker, IMonsterBroadcaster& cast,
+						   IMonsterClock& clock, const MonsterStats& stats);
+	void ExecuteChaseState(Monster& m, IMonsterEntityLinker& linker, IMonsterMapQuery& map,
+						  IMonsterBroadcaster& cast, IMonsterClock& clock, const MonsterStats& stats);
+	void ExecuteReturnState(Monster& m, IMonsterMapQuery& map, IMonsterBroadcaster& cast,
+						   IMonsterClock& clock, const MonsterStats& stats);
+	
+	// 유틸리티 함수들
+	int GetDistanceToTarget(Monster& m, IMonsterEntityLinker& linker);
+	bool IsPlayerInAttackRange(Monster& m, IMonsterEntityLinker& linker, int attackRange);
+	bool IsOutOfLeash(Monster& m, const MonsterSpawnerSystem& spawner);
+	
+	// 기존 이동 유틸
 	bool TryRotate(Monster& m, Protocol::EDirection targetDir, IMonsterBroadcaster& cast);
 	bool TryStep(Monster& m, Protocol::EDirection dir, IMonsterMapQuery& map, IMonsterBroadcaster& cast);
 };

--- a/GameServer/MonsterService.cpp
+++ b/GameServer/MonsterService.cpp
@@ -16,13 +16,12 @@ void MonsterService::Tick(int64_t /*deltaMs*/) {
 	// 리스폰 처리
 	_spawner.Tick(_container, _cast, _clock);
 
-
-	// 이동 처리
-	_move.Tick(_container, _spawner, _map, _linker, _cast, _clock, _rng);
-
-
-	// 전투 처리
+	// 전투 처리 + 타겟 설정
+	// 타겟 설정하고 이동해야, 로직이 매끄러움
 	_combat.Tick(_container, _spawner, _linker, _cast, _clock, _statsByType);
+
+	// 이동 처리 + 상태 전이
+	_move.Tick(_container, _spawner, _map, _linker, _cast, _clock, _rng);
 }
 
 
@@ -75,12 +74,7 @@ bool MonsterService::ApplyDamageToMonster(EntityId id, int dmg, int srcPlayerId,
 	Monster* m = _container.Find(id);
 	if (!m) return false;
 
-	if (m->state == MState::Ready)
-	{
-		GConsoleLogger->WriteStdOut(Color::WHITE, L"[Combat] Monster:%d attacked! Ready->Combat transition", id);
-		m->state = MState::Combat;
-	}
-
+	m->wasAttacked = true;
 	m->curHp = m->curHp - dmg;
 	hpAfter = m->curHp;
 	if(m->curHp > 0)

--- a/GameServer/MonsterSpawnerSystem.cpp
+++ b/GameServer/MonsterSpawnerSystem.cpp
@@ -29,7 +29,6 @@ void MonsterSpawnerSystem::Init(MonsterContainer& repo, const std::vector<SpawnP
 void MonsterSpawnerSystem::Tick(MonsterContainer& repo, IMonsterBroadcaster& cast, IMonsterClock& clock) {
 	const int64_t now = clock.NowMs();
 
-
 	// 리스폰 due 처리
 	RespawnTask task;
 	while (repo.PopRespawn(now, task)) {


### PR DESCRIPTION

몬스터 Movement와 Combat 시스템을 분리하여 상태 전환 로직을 체계화하고 FSM을 완성했습니다.

- MonsterMovementSystem: 상태 전환 로직과 상태별 실행 로직 분리
- MonsterCombatSystem: 타겟 설정과 공격 로직 분리
- 호출 순서 변경: Combat(타겟설정) → Movement(상태전환+이동)
- 완전한 상태 전환 지원: Patrol↔Ready→Combat↔Chase
- wasAttacked 플래그 설정 및 상태 전환 로직 일관성 확보
- 테스트용 몬스터 스폰 포인트 5개로 확장