### PR TITLE
feat(chat): 채팅 시스템 구현 및 RoomManager DoAsyncForAllRooms 기능 추가

### DIFF
--- a/DummyClientCS/Packet/ServerPacketHandler.cs
+++ b/DummyClientCS/Packet/ServerPacketHandler.cs
@@ -377,5 +377,22 @@ namespace Packet
         {
             Console.WriteLine($"플레이어가 죽어서 BroadCast");
         }
+
+        internal static void HANDLE_S_BroadcastPlayerChat(PacketSession session, S_BroadcastPlayerChat chat)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"\n===== 채팅 메시지 수신 =====");
+
+            foreach (var chatInfo in chat.PlayerChatInfos)
+            {
+                string chatTypeStr = chatInfo.ChatType == EChatType.ChatRoom ? "[룸]" : "[전체]";
+                string playerIdStr = chatInfo.PlayerId > 0 ? $"플레이어{chatInfo.PlayerId}" : "알수없음";
+
+                Console.WriteLine($"{chatTypeStr} {playerIdStr}: {chatInfo.Message}");
+            }
+
+            Console.WriteLine($"============================");
+            Console.ResetColor();
+        }
     }
 }

--- a/DummyClientCS/Packet/ServerPacketManager.cs
+++ b/DummyClientCS/Packet/ServerPacketManager.cs
@@ -52,6 +52,8 @@ namespace Packet
 	    PKT_S_BroadcastPlayerTryAttack = 41,
 	    PKT_S_BroadcastPlayerHpChanged = 42,
 	    PKT_S_BroadcastPlayerDeath = 43,
+	    PKT_C_PlayerChat = 44,
+	    PKT_S_BroadcastPlayerChat = 45,
     }
     public class ServerPacketManager
     {
@@ -90,6 +92,7 @@ namespace Packet
         public static ArraySegment<byte> MakeSendBuffer(C_ItemUseRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_ItemUseRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_NpcInteractRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcInteractRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_NpcShopBuyRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcShopBuyRequest);
+        public static ArraySegment<byte> MakeSendBuffer(C_PlayerChat pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PlayerChat);
 
         void Register()
         {
@@ -128,6 +131,7 @@ namespace Packet
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerTryAttack, ServerPacketHandler.HANDLE_S_BroadcastPlayerTryAttack, S_BroadcastPlayerTryAttack.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerHpChanged, ServerPacketHandler.HANDLE_S_BroadcastPlayerHpChanged, S_BroadcastPlayerHpChanged.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerDeath, ServerPacketHandler.HANDLE_S_BroadcastPlayerDeath, S_BroadcastPlayerDeath.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerChat, ServerPacketHandler.HANDLE_S_BroadcastPlayerChat, S_BroadcastPlayerChat.Parser);
             
                   
         }

--- a/DummyClientCS/Program.cs
+++ b/DummyClientCS/Program.cs
@@ -51,6 +51,9 @@ class Program
             Console.WriteLine("[i] 인벤토리 조회하기");
             Console.WriteLine("[u] 퀵슬롯 사용 (1~9)");
             Console.WriteLine("[o] 슬롯 지정 아이템 사용");
+            Console.WriteLine("\n===== 채팅 테스트 =====");
+            Console.WriteLine("[t] 룸 채팅 (현재 룸의 플레이어들에게만)");
+            Console.WriteLine("[y] 전체 채팅 (모든 룸의 플레이어들에게)");
             Console.WriteLine("\n===== 종료 로직 테스트 =====");
             Console.WriteLine("[x] 룸에서 나가기 (캐릭터 변경)");
             Console.WriteLine("[l] 로그아웃 테스트 (JWT 인증 상태로 복귀)");
@@ -294,6 +297,40 @@ class Program
                     }
                     
                     await SessionManager.Instance.SendItemUseRequest(slotIndex);
+                    break;
+                case "t":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("룸 채팅 메시지 입력: ");
+                    string? roomChatMessage = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(roomChatMessage))
+                    {
+                        Console.WriteLine("메시지를 입력해주세요!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendRoomChat(roomChatMessage);
+                    break;
+                case "y":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("전체 채팅 메시지 입력: ");
+                    string? allChatMessage = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(allChatMessage))
+                    {
+                        Console.WriteLine("메시지를 입력해주세요!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendAllChat(allChatMessage);
                     break;
                 case "x":
                     if (!_isInGame)

--- a/DummyClientCS/Protocol/Protocol.cs
+++ b/DummyClientCS/Protocol/Protocol.cs
@@ -88,74 +88,82 @@ namespace Google.Protobuf.Protocol {
             "cm9hZGNhc3RQbGF5ZXJIcENoYW5nZWQSEAoIcGxheWVySWQYASABKAUSCgoC",
             "aHAYAiABKAUSDQoFbWF4SHAYAyABKAUiQwoWU19Ccm9hZGNhc3RQbGF5ZXJE",
             "ZWF0aBIQCghwbGF5ZXJJZBgBIAEoBRIXCg9raWxsZXJNb25zdGVySWQYAiAB",
-            "KAUiIwoLVmVjdG9yMkluZm8SCQoBeBgBIAEoBRIJCgF5GAIgASgFIpkBCg5Q",
-            "bGF5ZXJNb3ZlSW5mbxIQCghwbGF5ZXJJZBgBIAEoBRInCglkaXJlY3Rpb24Y",
-            "AiABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9uEiUKBm5ld1BvcxgDIAEoCzIV",
-            "LlByb3RvY29sLlZlY3RvcjJJbmZvEiUKBnJlc3VsdBgEIAEoDjIVLlByb3Rv",
-            "Y29sLkVNb3ZlUmVzdWx0In0KFENoYXJhY3RlclN1bW1hcnlJbmZvEhAKCHVz",
-            "ZXJuYW1lGAEgASgJEg0KBWxldmVsGAIgASgFEiEKBmdlbmRlchgDIAEoDjIR",
-            "LlByb3RvY29sLkVHZW5kZXISIQoGcmVnaW9uGAQgASgOMhEuUHJvdG9jb2wu",
-            "RVJlZ2lvbiJ3CgpQbGF5ZXJJbmZvEgoKAmlkGAEgASgFEhAKCHVzZXJuYW1l",
-            "GAIgASgJEiIKA3BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEicK",
-            "CWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVEaXJlY3Rpb24iWgoRSW52",
-            "ZW50b3J5U2xvdEluZm8SEQoJc2xvdEluZGV4GAEgASgFEg4KBml0ZW1JZBgC",
-            "IAEoBRINCgVjb3VudBgDIAEoBRITCgtpc1F1aWNrc2xvdBgEIAEoCCKEAQoL",
-            "TW9uc3RlckluZm8SEQoJbW9uc3RlcklkGAEgASgFEhUKDW1vbnN0ZXJUeXBl",
-            "SWQYAiABKAUSIgoDcG9zGAMgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8S",
-            "JwoJZGlyZWN0aW9uGAQgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiI/CgxT",
-            "aG9wSXRlbUluZm8SDgoGaXRlbUlkGAEgASgFEhAKCHF1YW50aXR5GAIgASgF",
-            "Eg0KBXByaWNlGAMgASgFImkKDlBsYXllclN0YXRJbmZvEg0KBW1heEhwGAEg",
-            "ASgFEgoKAmhwGAIgASgFEg4KBmN1ckV4cBgDIAEoBRIOCgZtYXhFeHAYBCAB",
-            "KAUSDQoFbGV2ZWwYBSABKAUSDQoFbW9uZXkYBiABKAUq/ggKBU1zZ0lkEhcK",
-            "E0NfSldUX0xPR0lOX1JFUVVFU1QQABIVChFTX0pXVF9MT0dJTl9SRVBMWRAB",
-            "Eh4KGkNfQ1JFQVRFX0NIQVJBQ1RFUl9SRVFVRVNUEAISHAoYU19DUkVBVEVf",
-            "Q0hBUkFDVEVSX1JFUExZEAMSHAoYQ19DSEFSQUNURVJfTElTVF9SRVFVRVNU",
-            "EAQSGgoWU19DSEFSQUNURVJfTElTVF9SRVBMWRAFEh4KGkNfREVMRVRFX0NI",
-            "QVJBQ1RFUl9SRVFVRVNUEAYSHAoYU19ERUxFVEVfQ0hBUkFDVEVSX1JFUExZ",
-            "EAcSEAoMQ19FTlRFUl9HQU1FEAgSEAoMU19FTlRFUl9HQU1FEAkSEQoNU19Q",
-            "TEFZRVJfTElTVBAKEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9FTlRFUhALEhAK",
-            "DENfTEVBVkVfR0FNRRAMEhAKDFNfTEVBVkVfR0FNRRANEhwKGFNfQlJPQURD",
-            "QVNUX1BMQVlFUl9MRUFWRRAOEhkKFUNfUExBWUVSX01PVkVfUkVRVUVTVBAP",
-            "EhcKE1NfUExBWUVSX01PVkVfUkVQTFkQEBIbChdTX0JST0FEQ0FTVF9QTEFZ",
-            "RVJfTU9WRRAREhcKE1NfQ0hBTkdFX1JPT01fQkVHSU4QEhIXChNDX0NIQU5H",
-            "RV9ST09NX1JFQURZEBMSGAoUU19DSEFOR0VfUk9PTV9DT01NSVQQFBITCg9T",
-            "X1NQQVdOX01PTlNURVIQFRIVChFTX0RFU1BBV05fTU9OU1RFUhAWEhwKGFNf",
-            "QlJPQURDQVNUX01PTlNURVJfTU9WRRAXEh4KGlNfQlJPQURDQVNUX01PTlNU",
-            "RVJfQVRUQUNLEBgSHQoZU19CUk9BRENBU1RfTU9OU1RFUl9ERUFUSBAZEhsK",
-            "F0NfUExBWUVSX0FUVEFDS19SRVFVRVNUEBoSHQoZU19CUk9BRENBU1RfUExB",
-            "WUVSX0FUVEFDSxAbEhcKE0NfSU5WRU5UT1JZX1JFUVVFU1QQHBIVChFTX0lO",
-            "VkVOVE9SWV9SRVBMWRAdEhYKEkNfSVRFTV9VU0VfUkVRVUVTVBAeEhQKEFNf",
-            "SVRFTV9VU0VfUkVQTFkQHxIWChJTX0lOVkVOVE9SWV9VUERBVEUQIBIUChBT",
-            "X1NZU1RFTV9NRVNTQUdFECESEgoOU19NT05TVEVSX0xJU1QQIhIaChZDX05Q",
-            "Q19JTlRFUkFDVF9SRVFVRVNUECMSGAoUU19OUENfSU5URVJBQ1RfUkVQTFkQ",
-            "JBITCg9TX05QQ19TSE9QX09QRU4QJRIaChZDX05QQ19TSE9QX0JVWV9SRVFV",
-            "RVNUECYSGAoUU19OUENfU0hPUF9CVVlfUkVQTFkQJxIRCg1TX1BMQVlFUl9T",
-            "VEFUECgSIQodU19CUk9BRENBU1RfUExBWUVSX1RSWV9BVFRBQ0sQKRIhCh1T",
-            "X0JST0FEQ0FTVF9QTEFZRVJfSFBfQ0hBTkdFRBAqEhwKGFNfQlJPQURDQVNU",
-            "X1BMQVlFUl9ERUFUSBArKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAAS",
-            "EQoNSU5WQUxJRF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJW",
-            "RVJfRVJST1IQAyo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VO",
-            "REVSX01BTEUQARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtS",
-            "RUdJT05fTk9ORRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIq",
-            "QwoKRURpcmVjdGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJ",
-            "Ul9MRUZUEAISDQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxF",
-            "QVZFX1VOS05PV04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFO",
-            "R0VfUk9PTRACEhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFW",
-            "RV9ESVNDT05ORUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dO",
-            "EAASCwoHTU9WRV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9X",
-            "ThADEhAKDE1PVkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRF",
-            "Ul9VTktOT1dOEAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0Vf",
-            "Uk9PTRACKjkKDkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAA",
-            "EhIKDkRFU1BBV05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQ",
-            "RV9VTktOT1dOEAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVN",
-            "X1RZUEVfRVFVSVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRF",
-            "TV9UWVBFX01JU0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZP",
-            "EAASEwoPTUVTU0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcK",
-            "E01FU1NBR0VfRFJPUF9GQUlMRUQQA0IbqgIYR29vZ2xlLlByb3RvYnVmLlBy",
-            "b3RvY29sYgZwcm90bzM="));
+            "KAUiQAoMQ19QbGF5ZXJDaGF0EjAKDnBsYXllckNoYXRJbmZvGAEgASgLMhgu",
+            "UHJvdG9jb2wuUGxheWVyQ2hhdEluZm8iSgoVU19Ccm9hZGNhc3RQbGF5ZXJD",
+            "aGF0EjEKD3BsYXllckNoYXRJbmZvcxgBIAMoCzIYLlByb3RvY29sLlBsYXll",
+            "ckNoYXRJbmZvIiMKC1ZlY3RvcjJJbmZvEgkKAXgYASABKAUSCQoBeRgCIAEo",
+            "BSKZAQoOUGxheWVyTW92ZUluZm8SEAoIcGxheWVySWQYASABKAUSJwoJZGly",
+            "ZWN0aW9uGAIgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbhIlCgZuZXdQb3MY",
+            "AyABKAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxIlCgZyZXN1bHQYBCABKA4y",
+            "FS5Qcm90b2NvbC5FTW92ZVJlc3VsdCJ9ChRDaGFyYWN0ZXJTdW1tYXJ5SW5m",
+            "bxIQCgh1c2VybmFtZRgBIAEoCRINCgVsZXZlbBgCIAEoBRIhCgZnZW5kZXIY",
+            "AyABKA4yES5Qcm90b2NvbC5FR2VuZGVyEiEKBnJlZ2lvbhgEIAEoDjIRLlBy",
+            "b3RvY29sLkVSZWdpb24idwoKUGxheWVySW5mbxIKCgJpZBgBIAEoBRIQCgh1",
+            "c2VybmFtZRgCIAEoCRIiCgNwb3MYAyABKAsyFS5Qcm90b2NvbC5WZWN0b3Iy",
+            "SW5mbxInCglkaXJlY3Rpb24YBCABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9u",
+            "IloKEUludmVudG9yeVNsb3RJbmZvEhEKCXNsb3RJbmRleBgBIAEoBRIOCgZp",
+            "dGVtSWQYAiABKAUSDQoFY291bnQYAyABKAUSEwoLaXNRdWlja3Nsb3QYBCAB",
+            "KAgihAEKC01vbnN0ZXJJbmZvEhEKCW1vbnN0ZXJJZBgBIAEoBRIVCg1tb25z",
+            "dGVyVHlwZUlkGAIgASgFEiIKA3BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3Rv",
+            "cjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVEaXJlY3Rp",
+            "b24iPwoMU2hvcEl0ZW1JbmZvEg4KBml0ZW1JZBgBIAEoBRIQCghxdWFudGl0",
+            "eRgCIAEoBRINCgVwcmljZRgDIAEoBSJpCg5QbGF5ZXJTdGF0SW5mbxINCgVt",
+            "YXhIcBgBIAEoBRIKCgJocBgCIAEoBRIOCgZjdXJFeHAYAyABKAUSDgoGbWF4",
+            "RXhwGAQgASgFEg0KBWxldmVsGAUgASgFEg0KBW1vbmV5GAYgASgFIoQBCg5Q",
+            "bGF5ZXJDaGF0SW5mbxIUCgpOb25lUGxheWVyGAEgASgISAASEgoIcGxheWVy",
+            "SWQYAiABKAVIABIPCgdtZXNzYWdlGAMgASgJEiUKCGNoYXRUeXBlGAQgASgO",
+            "MhMuUHJvdG9jb2wuRUNoYXRUeXBlQhAKDnBsYXllckluY2x1ZGVkKq4JCgVN",
+            "c2dJZBIXChNDX0pXVF9MT0dJTl9SRVFVRVNUEAASFQoRU19KV1RfTE9HSU5f",
+            "UkVQTFkQARIeChpDX0NSRUFURV9DSEFSQUNURVJfUkVRVUVTVBACEhwKGFNf",
+            "Q1JFQVRFX0NIQVJBQ1RFUl9SRVBMWRADEhwKGENfQ0hBUkFDVEVSX0xJU1Rf",
+            "UkVRVUVTVBAEEhoKFlNfQ0hBUkFDVEVSX0xJU1RfUkVQTFkQBRIeChpDX0RF",
+            "TEVURV9DSEFSQUNURVJfUkVRVUVTVBAGEhwKGFNfREVMRVRFX0NIQVJBQ1RF",
+            "Ul9SRVBMWRAHEhAKDENfRU5URVJfR0FNRRAIEhAKDFNfRU5URVJfR0FNRRAJ",
+            "EhEKDVNfUExBWUVSX0xJU1QQChIcChhTX0JST0FEQ0FTVF9QTEFZRVJfRU5U",
+            "RVIQCxIQCgxDX0xFQVZFX0dBTUUQDBIQCgxTX0xFQVZFX0dBTUUQDRIcChhT",
+            "X0JST0FEQ0FTVF9QTEFZRVJfTEVBVkUQDhIZChVDX1BMQVlFUl9NT1ZFX1JF",
+            "UVVFU1QQDxIXChNTX1BMQVlFUl9NT1ZFX1JFUExZEBASGwoXU19CUk9BRENB",
+            "U1RfUExBWUVSX01PVkUQERIXChNTX0NIQU5HRV9ST09NX0JFR0lOEBISFwoT",
+            "Q19DSEFOR0VfUk9PTV9SRUFEWRATEhgKFFNfQ0hBTkdFX1JPT01fQ09NTUlU",
+            "EBQSEwoPU19TUEFXTl9NT05TVEVSEBUSFQoRU19ERVNQQVdOX01PTlNURVIQ",
+            "FhIcChhTX0JST0FEQ0FTVF9NT05TVEVSX01PVkUQFxIeChpTX0JST0FEQ0FT",
+            "VF9NT05TVEVSX0FUVEFDSxAYEh0KGVNfQlJPQURDQVNUX01PTlNURVJfREVB",
+            "VEgQGRIbChdDX1BMQVlFUl9BVFRBQ0tfUkVRVUVTVBAaEh0KGVNfQlJPQURD",
+            "QVNUX1BMQVlFUl9BVFRBQ0sQGxIXChNDX0lOVkVOVE9SWV9SRVFVRVNUEBwS",
+            "FQoRU19JTlZFTlRPUllfUkVQTFkQHRIWChJDX0lURU1fVVNFX1JFUVVFU1QQ",
+            "HhIUChBTX0lURU1fVVNFX1JFUExZEB8SFgoSU19JTlZFTlRPUllfVVBEQVRF",
+            "ECASFAoQU19TWVNURU1fTUVTU0FHRRAhEhIKDlNfTU9OU1RFUl9MSVNUECIS",
+            "GgoWQ19OUENfSU5URVJBQ1RfUkVRVUVTVBAjEhgKFFNfTlBDX0lOVEVSQUNU",
+            "X1JFUExZECQSEwoPU19OUENfU0hPUF9PUEVOECUSGgoWQ19OUENfU0hPUF9C",
+            "VVlfUkVRVUVTVBAmEhgKFFNfTlBDX1NIT1BfQlVZX1JFUExZECcSEQoNU19Q",
+            "TEFZRVJfU1RBVBAoEiEKHVNfQlJPQURDQVNUX1BMQVlFUl9UUllfQVRUQUNL",
+            "ECkSIQodU19CUk9BRENBU1RfUExBWUVSX0hQX0NIQU5HRUQQKhIcChhTX0JS",
+            "T0FEQ0FTVF9QTEFZRVJfREVBVEgQKxIRCg1DX1BMQVlFUl9DSEFUECwSGwoX",
+            "U19CUk9BRENBU1RfUExBWUVSX0NIQVQQLSpTCgxFTG9naW5SZXN1bHQSCwoH",
+            "U1VDQ0VTUxAAEhEKDUlOVkFMSURfVE9LRU4QARIRCg1UT0tFTl9FWFBJUkVE",
+            "EAISEAoMU0VSVkVSX0VSUk9SEAMqPgoHRUdlbmRlchIPCgtHRU5ERVJfTk9O",
+            "RRAAEg8KC0dFTkRFUl9NQUxFEAESEQoNR0VOREVSX0ZFTUFMRRACKjoKB0VS",
+            "ZWdpb24SDwoLUkVHSU9OX05PTkUQABINCglSRUdJT05fR08QARIPCgtSRUdJ",
+            "T05fQkFDSxACKkMKCkVEaXJlY3Rpb24SCgoGRElSX1VQEAASDAoIRElSX0RP",
+            "V04QARIMCghESVJfTEVGVBACEg0KCURJUl9SSUdIVBADKnwKDEVMZWF2ZVJl",
+            "YXNvbhIRCg1MRUFWRV9VTktOT1dOEAASEAoMTEVBVkVfTE9HT1VUEAESFQoR",
+            "TEVBVkVfQ0hBTkdFX1JPT00QAhIaChZMRUFWRV9DSEFOR0VfQ0hBUkFDVEVS",
+            "EAMSFAoQTEVBVkVfRElTQ09OTkVDVBAEKl8KC0VNb3ZlUmVzdWx0EhAKDE1P",
+            "VkVfVU5LTk9XThAAEgsKB01PVkVfT0sQARIMCghNT1ZFX0RJUhACEhEKDU1P",
+            "VkVfQ09PTERPV04QAxIQCgxNT1ZFX0JMT0NLRUQQBCpJCgxFRW50ZXJSZWFz",
+            "b24SEQoNRU5URVJfVU5LTk9XThAAEg8KC0VOVEVSX0xPR0lOEAESFQoRRU5U",
+            "RVJfQ0hBTkdFX1JPT00QAio5Cg5FRGVzcGF3blJlYXNvbhITCg9ERVNQQVdO",
+            "X1VOS05PV04QABISCg5ERVNQQVdOX0tJTExFRBABKn4KCUVJdGVtVHlwZRIV",
+            "ChFJVEVNX1RZUEVfVU5LTk9XThAAEhgKFElURU1fVFlQRV9DT05TVU1BQkxF",
+            "EAESFwoTSVRFTV9UWVBFX0VRVUlQTUVOVBACEhMKD0lURU1fVFlQRV9RVUVT",
+            "VBADEhIKDklURU1fVFlQRV9NSVNDEAQqYQoMRU1lc3NhZ2VUeXBlEhAKDE1F",
+            "U1NBR0VfSU5GTxAAEhMKD01FU1NBR0VfV0FSTklORxABEhEKDU1FU1NBR0Vf",
+            "RVJST1IQAhIXChNNRVNTQUdFX0RST1BfRkFJTEVEEAMqKAoJRUNoYXRUeXBl",
+            "Eg0KCUNIQVRfUk9PTRAAEgwKCENIQVRfQUxMEAFCG6oCGEdvb2dsZS5Qcm90",
+            "b2J1Zi5Qcm90b2NvbGIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), typeof(global::Google.Protobuf.Protocol.EChatType), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_JwtLoginRequest), global::Google.Protobuf.Protocol.C_JwtLoginRequest.Parser, new[]{ "AccessToken" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_JwtLoginReply), global::Google.Protobuf.Protocol.S_JwtLoginReply.Parser, new[]{ "Result" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_CreateCharacterRequest), global::Google.Protobuf.Protocol.C_CreateCharacterRequest.Parser, new[]{ "Username", "Gender", "Region" }, null, null, null, null),
@@ -200,6 +208,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerTryAttack), global::Google.Protobuf.Protocol.S_BroadcastPlayerTryAttack.Parser, new[]{ "PlayerId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerHpChanged), global::Google.Protobuf.Protocol.S_BroadcastPlayerHpChanged.Parser, new[]{ "PlayerId", "Hp", "MaxHp" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath), global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath.Parser, new[]{ "PlayerId", "KillerMonsterId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_PlayerChat), global::Google.Protobuf.Protocol.C_PlayerChat.Parser, new[]{ "PlayerChatInfo" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerChat), global::Google.Protobuf.Protocol.S_BroadcastPlayerChat.Parser, new[]{ "PlayerChatInfos" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.Vector2Info), global::Google.Protobuf.Protocol.Vector2Info.Parser, new[]{ "X", "Y" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerMoveInfo), global::Google.Protobuf.Protocol.PlayerMoveInfo.Parser, new[]{ "PlayerId", "Direction", "NewPos", "Result" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.CharacterSummaryInfo), global::Google.Protobuf.Protocol.CharacterSummaryInfo.Parser, new[]{ "Username", "Level", "Gender", "Region" }, null, null, null, null),
@@ -207,7 +217,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.InventorySlotInfo), global::Google.Protobuf.Protocol.InventorySlotInfo.Parser, new[]{ "SlotIndex", "ItemId", "Count", "IsQuickslot" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.MonsterInfo), global::Google.Protobuf.Protocol.MonsterInfo.Parser, new[]{ "MonsterId", "MonsterTypeId", "Pos", "Direction" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.ShopItemInfo), global::Google.Protobuf.Protocol.ShopItemInfo.Parser, new[]{ "ItemId", "Quantity", "Price" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerStatInfo), global::Google.Protobuf.Protocol.PlayerStatInfo.Parser, new[]{ "MaxHp", "Hp", "CurExp", "MaxExp", "Level", "Money" }, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerStatInfo), global::Google.Protobuf.Protocol.PlayerStatInfo.Parser, new[]{ "MaxHp", "Hp", "CurExp", "MaxExp", "Level", "Money" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerChatInfo), global::Google.Protobuf.Protocol.PlayerChatInfo.Parser, new[]{ "NonePlayer", "PlayerId", "Message", "ChatType" }, new[]{ "PlayerIncluded" }, null, null, null)
           }));
     }
     #endregion
@@ -259,6 +270,8 @@ namespace Google.Protobuf.Protocol {
     [pbr::OriginalName("S_BROADCAST_PLAYER_TRY_ATTACK")] SBroadcastPlayerTryAttack = 41,
     [pbr::OriginalName("S_BROADCAST_PLAYER_HP_CHANGED")] SBroadcastPlayerHpChanged = 42,
     [pbr::OriginalName("S_BROADCAST_PLAYER_DEATH")] SBroadcastPlayerDeath = 43,
+    [pbr::OriginalName("C_PLAYER_CHAT")] CPlayerChat = 44,
+    [pbr::OriginalName("S_BROADCAST_PLAYER_CHAT")] SBroadcastPlayerChat = 45,
   }
 
   public enum ELoginResult {
@@ -351,6 +364,11 @@ namespace Google.Protobuf.Protocol {
     [pbr::OriginalName("MESSAGE_WARNING")] MessageWarning = 1,
     [pbr::OriginalName("MESSAGE_ERROR")] MessageError = 2,
     [pbr::OriginalName("MESSAGE_DROP_FAILED")] MessageDropFailed = 3,
+  }
+
+  public enum EChatType {
+    [pbr::OriginalName("CHAT_ROOM")] ChatRoom = 0,
+    [pbr::OriginalName("CHAT_ALL")] ChatAll = 1,
   }
 
   #endregion
@@ -10009,6 +10027,388 @@ namespace Google.Protobuf.Protocol {
 
   }
 
+  /// <summary>
+  /// (44) 클라 -> 서버 : C_PlayerChat 채팅 송신
+  /// </summary>
+  public sealed partial class C_PlayerChat : pb::IMessage<C_PlayerChat>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<C_PlayerChat> _parser = new pb::MessageParser<C_PlayerChat>(() => new C_PlayerChat());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<C_PlayerChat> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[44]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_PlayerChat() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_PlayerChat(C_PlayerChat other) : this() {
+      playerChatInfo_ = other.playerChatInfo_ != null ? other.playerChatInfo_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_PlayerChat Clone() {
+      return new C_PlayerChat(this);
+    }
+
+    /// <summary>Field number for the "playerChatInfo" field.</summary>
+    public const int PlayerChatInfoFieldNumber = 1;
+    private global::Google.Protobuf.Protocol.PlayerChatInfo playerChatInfo_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.Protocol.PlayerChatInfo PlayerChatInfo {
+      get { return playerChatInfo_; }
+      set {
+        playerChatInfo_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as C_PlayerChat);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(C_PlayerChat other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (!object.Equals(PlayerChatInfo, other.PlayerChatInfo)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (playerChatInfo_ != null) hash ^= PlayerChatInfo.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (playerChatInfo_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(PlayerChatInfo);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (playerChatInfo_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(PlayerChatInfo);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (playerChatInfo_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(PlayerChatInfo);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(C_PlayerChat other) {
+      if (other == null) {
+        return;
+      }
+      if (other.playerChatInfo_ != null) {
+        if (playerChatInfo_ == null) {
+          PlayerChatInfo = new global::Google.Protobuf.Protocol.PlayerChatInfo();
+        }
+        PlayerChatInfo.MergeFrom(other.PlayerChatInfo);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            if (playerChatInfo_ == null) {
+              PlayerChatInfo = new global::Google.Protobuf.Protocol.PlayerChatInfo();
+            }
+            input.ReadMessage(PlayerChatInfo);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            if (playerChatInfo_ == null) {
+              PlayerChatInfo = new global::Google.Protobuf.Protocol.PlayerChatInfo();
+            }
+            input.ReadMessage(PlayerChatInfo);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// (45) 서버 -> 클라 : S_BroadcastPlayerChat : Room-Tick마다 Server가 Player에게 모아둔 채팅 송신
+  /// </summary>
+  public sealed partial class S_BroadcastPlayerChat : pb::IMessage<S_BroadcastPlayerChat>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<S_BroadcastPlayerChat> _parser = new pb::MessageParser<S_BroadcastPlayerChat>(() => new S_BroadcastPlayerChat());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<S_BroadcastPlayerChat> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[45]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_BroadcastPlayerChat() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_BroadcastPlayerChat(S_BroadcastPlayerChat other) : this() {
+      playerChatInfos_ = other.playerChatInfos_.Clone();
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_BroadcastPlayerChat Clone() {
+      return new S_BroadcastPlayerChat(this);
+    }
+
+    /// <summary>Field number for the "playerChatInfos" field.</summary>
+    public const int PlayerChatInfosFieldNumber = 1;
+    private static readonly pb::FieldCodec<global::Google.Protobuf.Protocol.PlayerChatInfo> _repeated_playerChatInfos_codec
+        = pb::FieldCodec.ForMessage(10, global::Google.Protobuf.Protocol.PlayerChatInfo.Parser);
+    private readonly pbc::RepeatedField<global::Google.Protobuf.Protocol.PlayerChatInfo> playerChatInfos_ = new pbc::RepeatedField<global::Google.Protobuf.Protocol.PlayerChatInfo>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::RepeatedField<global::Google.Protobuf.Protocol.PlayerChatInfo> PlayerChatInfos {
+      get { return playerChatInfos_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as S_BroadcastPlayerChat);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(S_BroadcastPlayerChat other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if(!playerChatInfos_.Equals(other.playerChatInfos_)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      hash ^= playerChatInfos_.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      playerChatInfos_.WriteTo(output, _repeated_playerChatInfos_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      playerChatInfos_.WriteTo(ref output, _repeated_playerChatInfos_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      size += playerChatInfos_.CalculateSize(_repeated_playerChatInfos_codec);
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(S_BroadcastPlayerChat other) {
+      if (other == null) {
+        return;
+      }
+      playerChatInfos_.Add(other.playerChatInfos_);
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            playerChatInfos_.AddEntriesFrom(input, _repeated_playerChatInfos_codec);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            playerChatInfos_.AddEntriesFrom(ref input, _repeated_playerChatInfos_codec);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
   public sealed partial class Vector2Info : pb::IMessage<Vector2Info>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -10023,7 +10423,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[44]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10249,7 +10649,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[45]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10558,7 +10958,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10858,7 +11258,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11167,7 +11567,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11467,7 +11867,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11782,7 +12182,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[52]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12051,7 +12451,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[53]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12402,6 +12802,345 @@ namespace Google.Protobuf.Protocol {
           }
           case 48: {
             Money = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  public sealed partial class PlayerChatInfo : pb::IMessage<PlayerChatInfo>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<PlayerChatInfo> _parser = new pb::MessageParser<PlayerChatInfo>(() => new PlayerChatInfo());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<PlayerChatInfo> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[54]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerChatInfo() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerChatInfo(PlayerChatInfo other) : this() {
+      message_ = other.message_;
+      chatType_ = other.chatType_;
+      switch (other.PlayerIncludedCase) {
+        case PlayerIncludedOneofCase.NonePlayer:
+          NonePlayer = other.NonePlayer;
+          break;
+        case PlayerIncludedOneofCase.PlayerId:
+          PlayerId = other.PlayerId;
+          break;
+      }
+
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerChatInfo Clone() {
+      return new PlayerChatInfo(this);
+    }
+
+    /// <summary>Field number for the "NonePlayer" field.</summary>
+    public const int NonePlayerFieldNumber = 1;
+    /// <summary>
+    /// Client -> Server로 보낼떄
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool NonePlayer {
+      get { return playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer ? (bool) playerIncluded_ : false; }
+      set {
+        playerIncluded_ = value;
+        playerIncludedCase_ = PlayerIncludedOneofCase.NonePlayer;
+      }
+    }
+
+    /// <summary>Field number for the "playerId" field.</summary>
+    public const int PlayerIdFieldNumber = 2;
+    /// <summary>
+    /// Server -> Client로 보낼때
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int PlayerId {
+      get { return playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId ? (int) playerIncluded_ : 0; }
+      set {
+        playerIncluded_ = value;
+        playerIncludedCase_ = PlayerIncludedOneofCase.PlayerId;
+      }
+    }
+
+    /// <summary>Field number for the "message" field.</summary>
+    public const int MessageFieldNumber = 3;
+    private string message_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Message {
+      get { return message_; }
+      set {
+        message_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "chatType" field.</summary>
+    public const int ChatTypeFieldNumber = 4;
+    private global::Google.Protobuf.Protocol.EChatType chatType_ = global::Google.Protobuf.Protocol.EChatType.ChatRoom;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.Protocol.EChatType ChatType {
+      get { return chatType_; }
+      set {
+        chatType_ = value;
+      }
+    }
+
+    private object playerIncluded_;
+    /// <summary>Enum of possible cases for the "playerIncluded" oneof.</summary>
+    public enum PlayerIncludedOneofCase {
+      None = 0,
+      NonePlayer = 1,
+      PlayerId = 2,
+    }
+    private PlayerIncludedOneofCase playerIncludedCase_ = PlayerIncludedOneofCase.None;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerIncludedOneofCase PlayerIncludedCase {
+      get { return playerIncludedCase_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPlayerIncluded() {
+      playerIncludedCase_ = PlayerIncludedOneofCase.None;
+      playerIncluded_ = null;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as PlayerChatInfo);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(PlayerChatInfo other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (NonePlayer != other.NonePlayer) return false;
+      if (PlayerId != other.PlayerId) return false;
+      if (Message != other.Message) return false;
+      if (ChatType != other.ChatType) return false;
+      if (PlayerIncludedCase != other.PlayerIncludedCase) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) hash ^= NonePlayer.GetHashCode();
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) hash ^= PlayerId.GetHashCode();
+      if (Message.Length != 0) hash ^= Message.GetHashCode();
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) hash ^= ChatType.GetHashCode();
+      hash ^= (int) playerIncludedCase_;
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) {
+        output.WriteRawTag(8);
+        output.WriteBool(NonePlayer);
+      }
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) {
+        output.WriteRawTag(16);
+        output.WriteInt32(PlayerId);
+      }
+      if (Message.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(Message);
+      }
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        output.WriteRawTag(32);
+        output.WriteEnum((int) ChatType);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) {
+        output.WriteRawTag(8);
+        output.WriteBool(NonePlayer);
+      }
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) {
+        output.WriteRawTag(16);
+        output.WriteInt32(PlayerId);
+      }
+      if (Message.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(Message);
+      }
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        output.WriteRawTag(32);
+        output.WriteEnum((int) ChatType);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) {
+        size += 1 + 1;
+      }
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(PlayerId);
+      }
+      if (Message.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Message);
+      }
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) ChatType);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(PlayerChatInfo other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Message.Length != 0) {
+        Message = other.Message;
+      }
+      if (other.ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        ChatType = other.ChatType;
+      }
+      switch (other.PlayerIncludedCase) {
+        case PlayerIncludedOneofCase.NonePlayer:
+          NonePlayer = other.NonePlayer;
+          break;
+        case PlayerIncludedOneofCase.PlayerId:
+          PlayerId = other.PlayerId;
+          break;
+      }
+
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            NonePlayer = input.ReadBool();
+            break;
+          }
+          case 16: {
+            PlayerId = input.ReadInt32();
+            break;
+          }
+          case 26: {
+            Message = input.ReadString();
+            break;
+          }
+          case 32: {
+            ChatType = (global::Google.Protobuf.Protocol.EChatType) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            NonePlayer = input.ReadBool();
+            break;
+          }
+          case 16: {
+            PlayerId = input.ReadInt32();
+            break;
+          }
+          case 26: {
+            Message = input.ReadString();
+            break;
+          }
+          case 32: {
+            ChatType = (global::Google.Protobuf.Protocol.EChatType) input.ReadEnum();
             break;
           }
         }

--- a/DummyClientCS/SessionManager.cs
+++ b/DummyClientCS/SessionManager.cs
@@ -293,6 +293,72 @@ namespace DummyClientCS
             }
         }
 
+        // 룸 채팅 전송
+        public async Task SendRoomChat(string message)
+        {
+            if (!_canSendPackets) return;
+
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                Console.WriteLine("❌ 메시지가 비어있습니다.");
+                return;
+            }
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var chatInfo = new Google.Protobuf.Protocol.PlayerChatInfo
+                    {
+                        NonePlayer = true, // 클라이언트->서버 전송시
+                        Message = message,
+                        ChatType = Google.Protobuf.Protocol.EChatType.ChatRoom
+                    };
+
+                    var pkt = new Google.Protobuf.Protocol.C_PlayerChat
+                    {
+                        PlayerChatInfo = chatInfo
+                    };
+
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.WriteLine($"📢 [룸 채팅] '{message}' 전송했습니다.");
+                }
+            }
+        }
+
+        // 전체 채팅 전송
+        public async Task SendAllChat(string message)
+        {
+            if (!_canSendPackets) return;
+
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                Console.WriteLine("❌ 메시지가 비어있습니다.");
+                return;
+            }
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var chatInfo = new Google.Protobuf.Protocol.PlayerChatInfo
+                    {
+                        NonePlayer = true, // 클라이언트->서버 전송시
+                        Message = message,
+                        ChatType = Google.Protobuf.Protocol.EChatType.ChatAll
+                    };
+
+                    var pkt = new Google.Protobuf.Protocol.C_PlayerChat
+                    {
+                        PlayerChatInfo = chatInfo
+                    };
+
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.WriteLine($"🌐 [전체 채팅] '{message}' 전송했습니다.");
+                }
+            }
+        }
+
         // 캐릭터 삭제 요청
         public async Task SendDeleteCharacterRequest(int characterIndex)
         {

--- a/GameServer/ClientPacketHandler.cpp
+++ b/GameServer/ClientPacketHandler.cpp
@@ -450,8 +450,39 @@ bool Handle_C_NpcInteractRequest(PacketSessionRef& session, Protocol::C_NpcInter
 	PlayerRef player = gameSession->_currentPlayer;
 
 	RoomRef room = player->GetRoom();
+
+	// TODO
 }
 bool Handle_C_NpcShopBuyRequest(PacketSessionRef& session, Protocol::C_NpcShopBuyRequest& pkt)
 {
+
+	// TODO
+
 	return false;
+}
+
+bool Handle_C_PlayerChat(PacketSessionRef& session, Protocol::C_PlayerChat& pkt)
+{
+	GameSessionRef gameSession = static_pointer_cast<GameSession>(session);
+
+	if (gameSession->GetState() != GameSession::State::InRoom)
+		return false;
+	
+	PlayerRef player = gameSession->_currentPlayer;
+
+	RoomRef room = player->GetRoom();
+
+	auto playerChatInfo = pkt.playerchatinfo();
+	switch (playerChatInfo.chattype())
+	{
+		case Protocol::EChatType::CHAT_ROOM:
+			room->DoAsync(&Room::AddChat, gameSession, pkt);
+			break;
+		case Protocol::EChatType::CHAT_ALL:
+			RoomManager::Instance().DoAsyncForAllRooms(&Room::AddChat, gameSession, pkt);
+			break;
+		[[unlikely]] default:
+			ASSERT_CRASH("WRONG VALUE");
+	}
+
 }

--- a/GameServer/ClientPacketHandler.h
+++ b/GameServer/ClientPacketHandler.h
@@ -51,6 +51,8 @@ enum : uint16
 	PKT_S_BroadcastPlayerTryAttack = 41,
 	PKT_S_BroadcastPlayerHpChanged = 42,
 	PKT_S_BroadcastPlayerDeath = 43,
+	PKT_C_PlayerChat = 44,
+	PKT_S_BroadcastPlayerChat = 45,
 
 };
 
@@ -70,6 +72,7 @@ bool Handle_C_InventoryRequest(PacketSessionRef& session, Protocol::C_InventoryR
 bool Handle_C_ItemUseRequest(PacketSessionRef& session, Protocol::C_ItemUseRequest& pkt);
 bool Handle_C_NpcInteractRequest(PacketSessionRef& session, Protocol::C_NpcInteractRequest& pkt);
 bool Handle_C_NpcShopBuyRequest(PacketSessionRef& session, Protocol::C_NpcShopBuyRequest& pkt);
+bool Handle_C_PlayerChat(PacketSessionRef& session, Protocol::C_PlayerChat& pkt);
 
 class ClientPacketHandler
 {
@@ -94,6 +97,7 @@ public:
 		GPacketHandler[PKT_C_ItemUseRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_ItemUseRequest>(Handle_C_ItemUseRequest, session, buffer, len); };
 		GPacketHandler[PKT_C_NpcInteractRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_NpcInteractRequest>(Handle_C_NpcInteractRequest, session, buffer, len); };
 		GPacketHandler[PKT_C_NpcShopBuyRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_NpcShopBuyRequest>(Handle_C_NpcShopBuyRequest, session, buffer, len); };
+		GPacketHandler[PKT_C_PlayerChat] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PlayerChat>(Handle_C_PlayerChat, session, buffer, len); };
 		
 	}
 	static bool HandlePacket(PacketSessionRef& session, BYTE* buffer, int32 len)
@@ -132,6 +136,7 @@ public:
 	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPlayerTryAttack& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPlayerTryAttack); };
 	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPlayerHpChanged& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPlayerHpChanged); };
 	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPlayerDeath& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPlayerDeath); };
+	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPlayerChat& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPlayerChat); };
 
 private:
 	template<typename PacketType, typename ProcessFunc>

--- a/GameServer/Protocol.pb.cc
+++ b/GameServer/Protocol.pb.cc
@@ -622,6 +622,32 @@ struct S_BroadcastPlayerDeathDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 S_BroadcastPlayerDeathDefaultTypeInternal _S_BroadcastPlayerDeath_default_instance_;
+PROTOBUF_CONSTEXPR C_PlayerChat::C_PlayerChat(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.playerchatinfo_)*/nullptr
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct C_PlayerChatDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR C_PlayerChatDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~C_PlayerChatDefaultTypeInternal() {}
+  union {
+    C_PlayerChat _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 C_PlayerChatDefaultTypeInternal _C_PlayerChat_default_instance_;
+PROTOBUF_CONSTEXPR S_BroadcastPlayerChat::S_BroadcastPlayerChat(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.playerchatinfos_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct S_BroadcastPlayerChatDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR S_BroadcastPlayerChatDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~S_BroadcastPlayerChatDefaultTypeInternal() {}
+  union {
+    S_BroadcastPlayerChat _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 S_BroadcastPlayerChatDefaultTypeInternal _S_BroadcastPlayerChat_default_instance_;
 PROTOBUF_CONSTEXPR Vector2Info::Vector2Info(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.x_)*/0
@@ -749,9 +775,25 @@ struct PlayerStatInfoDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PlayerStatInfoDefaultTypeInternal _PlayerStatInfo_default_instance_;
+PROTOBUF_CONSTEXPR PlayerChatInfo::PlayerChatInfo(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.message_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.chattype_)*/0
+  , /*decltype(_impl_.playerIncluded_)*/{}
+  , /*decltype(_impl_._cached_size_)*/{}
+  , /*decltype(_impl_._oneof_case_)*/{}} {}
+struct PlayerChatInfoDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR PlayerChatInfoDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~PlayerChatInfoDefaultTypeInternal() {}
+  union {
+    PlayerChatInfo _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PlayerChatInfoDefaultTypeInternal _PlayerChatInfo_default_instance_;
 }  // namespace Protocol
-static ::_pb::Metadata file_level_metadata_Protocol_2eproto[52];
-static const ::_pb::EnumDescriptor* file_level_enum_descriptors_Protocol_2eproto[11];
+static ::_pb::Metadata file_level_metadata_Protocol_2eproto[55];
+static const ::_pb::EnumDescriptor* file_level_enum_descriptors_Protocol_2eproto[12];
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_Protocol_2eproto = nullptr;
 
 const uint32_t TableStruct_Protocol_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
@@ -1097,6 +1139,20 @@ const uint32_t TableStruct_Protocol_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   PROTOBUF_FIELD_OFFSET(::Protocol::S_BroadcastPlayerDeath, _impl_.playerid_),
   PROTOBUF_FIELD_OFFSET(::Protocol::S_BroadcastPlayerDeath, _impl_.killermonsterid_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::Protocol::C_PlayerChat, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::Protocol::C_PlayerChat, _impl_.playerchatinfo_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_BroadcastPlayerChat, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_BroadcastPlayerChat, _impl_.playerchatinfos_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::Protocol::Vector2Info, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -1175,6 +1231,17 @@ const uint32_t TableStruct_Protocol_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   PROTOBUF_FIELD_OFFSET(::Protocol::PlayerStatInfo, _impl_.maxexp_),
   PROTOBUF_FIELD_OFFSET(::Protocol::PlayerStatInfo, _impl_.level_),
   PROTOBUF_FIELD_OFFSET(::Protocol::PlayerStatInfo, _impl_.money_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::Protocol::PlayerChatInfo, _internal_metadata_),
+  ~0u,  // no _extensions_
+  PROTOBUF_FIELD_OFFSET(::Protocol::PlayerChatInfo, _impl_._oneof_case_[0]),
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  ::_pbi::kInvalidFieldOffsetTag,
+  ::_pbi::kInvalidFieldOffsetTag,
+  PROTOBUF_FIELD_OFFSET(::Protocol::PlayerChatInfo, _impl_.message_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::PlayerChatInfo, _impl_.chattype_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::PlayerChatInfo, _impl_.playerIncluded_),
 };
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, -1, sizeof(::Protocol::C_JwtLoginRequest)},
@@ -1221,14 +1288,17 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 317, -1, -1, sizeof(::Protocol::S_BroadcastPlayerTryAttack)},
   { 324, -1, -1, sizeof(::Protocol::S_BroadcastPlayerHpChanged)},
   { 333, -1, -1, sizeof(::Protocol::S_BroadcastPlayerDeath)},
-  { 341, -1, -1, sizeof(::Protocol::Vector2Info)},
-  { 349, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
-  { 359, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
-  { 369, -1, -1, sizeof(::Protocol::PlayerInfo)},
-  { 379, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
-  { 389, -1, -1, sizeof(::Protocol::MonsterInfo)},
-  { 399, -1, -1, sizeof(::Protocol::ShopItemInfo)},
-  { 408, -1, -1, sizeof(::Protocol::PlayerStatInfo)},
+  { 341, -1, -1, sizeof(::Protocol::C_PlayerChat)},
+  { 348, -1, -1, sizeof(::Protocol::S_BroadcastPlayerChat)},
+  { 355, -1, -1, sizeof(::Protocol::Vector2Info)},
+  { 363, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
+  { 373, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
+  { 383, -1, -1, sizeof(::Protocol::PlayerInfo)},
+  { 393, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
+  { 403, -1, -1, sizeof(::Protocol::MonsterInfo)},
+  { 413, -1, -1, sizeof(::Protocol::ShopItemInfo)},
+  { 422, -1, -1, sizeof(::Protocol::PlayerStatInfo)},
+  { 434, -1, -1, sizeof(::Protocol::PlayerChatInfo)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -1276,6 +1346,8 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::Protocol::_S_BroadcastPlayerTryAttack_default_instance_._instance,
   &::Protocol::_S_BroadcastPlayerHpChanged_default_instance_._instance,
   &::Protocol::_S_BroadcastPlayerDeath_default_instance_._instance,
+  &::Protocol::_C_PlayerChat_default_instance_._instance,
+  &::Protocol::_S_BroadcastPlayerChat_default_instance_._instance,
   &::Protocol::_Vector2Info_default_instance_._instance,
   &::Protocol::_PlayerMoveInfo_default_instance_._instance,
   &::Protocol::_CharacterSummaryInfo_default_instance_._instance,
@@ -1284,6 +1356,7 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::Protocol::_MonsterInfo_default_instance_._instance,
   &::Protocol::_ShopItemInfo_default_instance_._instance,
   &::Protocol::_PlayerStatInfo_default_instance_._instance,
+  &::Protocol::_PlayerChatInfo_default_instance_._instance,
 };
 
 const char descriptor_table_protodef_Protocol_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
@@ -1359,85 +1432,94 @@ const char descriptor_table_protodef_Protocol_2eproto[] PROTOBUF_SECTION_VARIABL
   "pChanged\022\020\n\010playerId\030\001 \001(\005\022\n\n\002hp\030\002 \001(\005\022\r"
   "\n\005maxHp\030\003 \001(\005\"C\n\026S_BroadcastPlayerDeath\022"
   "\020\n\010playerId\030\001 \001(\005\022\027\n\017killerMonsterId\030\002 \001"
-  "(\005\"#\n\013Vector2Info\022\t\n\001x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\""
-  "\231\001\n\016PlayerMoveInfo\022\020\n\010playerId\030\001 \001(\005\022\'\n\t"
-  "direction\030\002 \001(\0162\024.Protocol.EDirection\022%\n"
-  "\006newPos\030\003 \001(\0132\025.Protocol.Vector2Info\022%\n\006"
-  "result\030\004 \001(\0162\025.Protocol.EMoveResult\"}\n\024C"
-  "haracterSummaryInfo\022\020\n\010username\030\001 \001(\t\022\r\n"
-  "\005level\030\002 \001(\005\022!\n\006gender\030\003 \001(\0162\021.Protocol."
-  "EGender\022!\n\006region\030\004 \001(\0162\021.Protocol.ERegi"
-  "on\"w\n\nPlayerInfo\022\n\n\002id\030\001 \001(\005\022\020\n\010username"
-  "\030\002 \001(\t\022\"\n\003pos\030\003 \001(\0132\025.Protocol.Vector2In"
-  "fo\022\'\n\tdirection\030\004 \001(\0162\024.Protocol.EDirect"
-  "ion\"Z\n\021InventorySlotInfo\022\021\n\tslotIndex\030\001 "
-  "\001(\005\022\016\n\006itemId\030\002 \001(\005\022\r\n\005count\030\003 \001(\005\022\023\n\013is"
-  "Quickslot\030\004 \001(\010\"\204\001\n\013MonsterInfo\022\021\n\tmonst"
-  "erId\030\001 \001(\005\022\025\n\rmonsterTypeId\030\002 \001(\005\022\"\n\003pos"
-  "\030\003 \001(\0132\025.Protocol.Vector2Info\022\'\n\tdirecti"
-  "on\030\004 \001(\0162\024.Protocol.EDirection\"\?\n\014ShopIt"
-  "emInfo\022\016\n\006itemId\030\001 \001(\005\022\020\n\010quantity\030\002 \001(\005"
-  "\022\r\n\005price\030\003 \001(\005\"i\n\016PlayerStatInfo\022\r\n\005max"
-  "Hp\030\001 \001(\005\022\n\n\002hp\030\002 \001(\005\022\016\n\006curExp\030\003 \001(\005\022\016\n\006"
-  "maxExp\030\004 \001(\005\022\r\n\005level\030\005 \001(\005\022\r\n\005money\030\006 \001"
-  "(\005*\376\010\n\005MsgId\022\027\n\023C_JWT_LOGIN_REQUEST\020\000\022\025\n"
-  "\021S_JWT_LOGIN_REPLY\020\001\022\036\n\032C_CREATE_CHARACT"
-  "ER_REQUEST\020\002\022\034\n\030S_CREATE_CHARACTER_REPLY"
-  "\020\003\022\034\n\030C_CHARACTER_LIST_REQUEST\020\004\022\032\n\026S_CH"
-  "ARACTER_LIST_REPLY\020\005\022\036\n\032C_DELETE_CHARACT"
-  "ER_REQUEST\020\006\022\034\n\030S_DELETE_CHARACTER_REPLY"
-  "\020\007\022\020\n\014C_ENTER_GAME\020\010\022\020\n\014S_ENTER_GAME\020\t\022\021"
-  "\n\rS_PLAYER_LIST\020\n\022\034\n\030S_BROADCAST_PLAYER_"
-  "ENTER\020\013\022\020\n\014C_LEAVE_GAME\020\014\022\020\n\014S_LEAVE_GAM"
-  "E\020\r\022\034\n\030S_BROADCAST_PLAYER_LEAVE\020\016\022\031\n\025C_P"
-  "LAYER_MOVE_REQUEST\020\017\022\027\n\023S_PLAYER_MOVE_RE"
-  "PLY\020\020\022\033\n\027S_BROADCAST_PLAYER_MOVE\020\021\022\027\n\023S_"
-  "CHANGE_ROOM_BEGIN\020\022\022\027\n\023C_CHANGE_ROOM_REA"
-  "DY\020\023\022\030\n\024S_CHANGE_ROOM_COMMIT\020\024\022\023\n\017S_SPAW"
-  "N_MONSTER\020\025\022\025\n\021S_DESPAWN_MONSTER\020\026\022\034\n\030S_"
-  "BROADCAST_MONSTER_MOVE\020\027\022\036\n\032S_BROADCAST_"
-  "MONSTER_ATTACK\020\030\022\035\n\031S_BROADCAST_MONSTER_"
-  "DEATH\020\031\022\033\n\027C_PLAYER_ATTACK_REQUEST\020\032\022\035\n\031"
-  "S_BROADCAST_PLAYER_ATTACK\020\033\022\027\n\023C_INVENTO"
-  "RY_REQUEST\020\034\022\025\n\021S_INVENTORY_REPLY\020\035\022\026\n\022C"
-  "_ITEM_USE_REQUEST\020\036\022\024\n\020S_ITEM_USE_REPLY\020"
-  "\037\022\026\n\022S_INVENTORY_UPDATE\020 \022\024\n\020S_SYSTEM_ME"
-  "SSAGE\020!\022\022\n\016S_MONSTER_LIST\020\"\022\032\n\026C_NPC_INT"
-  "ERACT_REQUEST\020#\022\030\n\024S_NPC_INTERACT_REPLY\020"
-  "$\022\023\n\017S_NPC_SHOP_OPEN\020%\022\032\n\026C_NPC_SHOP_BUY"
-  "_REQUEST\020&\022\030\n\024S_NPC_SHOP_BUY_REPLY\020\'\022\021\n\r"
-  "S_PLAYER_STAT\020(\022!\n\035S_BROADCAST_PLAYER_TR"
-  "Y_ATTACK\020)\022!\n\035S_BROADCAST_PLAYER_HP_CHAN"
-  "GED\020*\022\034\n\030S_BROADCAST_PLAYER_DEATH\020+*S\n\014E"
-  "LoginResult\022\013\n\007SUCCESS\020\000\022\021\n\rINVALID_TOKE"
-  "N\020\001\022\021\n\rTOKEN_EXPIRED\020\002\022\020\n\014SERVER_ERROR\020\003"
-  "*>\n\007EGender\022\017\n\013GENDER_NONE\020\000\022\017\n\013GENDER_M"
-  "ALE\020\001\022\021\n\rGENDER_FEMALE\020\002*:\n\007ERegion\022\017\n\013R"
-  "EGION_NONE\020\000\022\r\n\tREGION_GO\020\001\022\017\n\013REGION_BA"
-  "CK\020\002*C\n\nEDirection\022\n\n\006DIR_UP\020\000\022\014\n\010DIR_DO"
-  "WN\020\001\022\014\n\010DIR_LEFT\020\002\022\r\n\tDIR_RIGHT\020\003*|\n\014ELe"
-  "aveReason\022\021\n\rLEAVE_UNKNOWN\020\000\022\020\n\014LEAVE_LO"
-  "GOUT\020\001\022\025\n\021LEAVE_CHANGE_ROOM\020\002\022\032\n\026LEAVE_C"
-  "HANGE_CHARACTER\020\003\022\024\n\020LEAVE_DISCONNECT\020\004*"
-  "_\n\013EMoveResult\022\020\n\014MOVE_UNKNOWN\020\000\022\013\n\007MOVE"
-  "_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_COOLDOWN\020\003\022\020"
-  "\n\014MOVE_BLOCKED\020\004*I\n\014EEnterReason\022\021\n\rENTE"
-  "R_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022\025\n\021ENTER_CH"
-  "ANGE_ROOM\020\002*9\n\016EDespawnReason\022\023\n\017DESPAWN"
-  "_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020\001*~\n\tEItemT"
-  "ype\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n\024ITEM_TYPE_"
-  "CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQUIPMENT\020\002\022\023\n"
-  "\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TYPE_MISC\020\004*a"
-  "\n\014EMessageType\022\020\n\014MESSAGE_INFO\020\000\022\023\n\017MESS"
-  "AGE_WARNING\020\001\022\021\n\rMESSAGE_ERROR\020\002\022\027\n\023MESS"
-  "AGE_DROP_FAILED\020\003B\033\252\002\030Google.Protobuf.Pr"
-  "otocolb\006proto3"
+  "(\005\"@\n\014C_PlayerChat\0220\n\016playerChatInfo\030\001 \001"
+  "(\0132\030.Protocol.PlayerChatInfo\"J\n\025S_Broadc"
+  "astPlayerChat\0221\n\017playerChatInfos\030\001 \003(\0132\030"
+  ".Protocol.PlayerChatInfo\"#\n\013Vector2Info\022"
+  "\t\n\001x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\"\231\001\n\016PlayerMoveInfo"
+  "\022\020\n\010playerId\030\001 \001(\005\022\'\n\tdirection\030\002 \001(\0162\024."
+  "Protocol.EDirection\022%\n\006newPos\030\003 \001(\0132\025.Pr"
+  "otocol.Vector2Info\022%\n\006result\030\004 \001(\0162\025.Pro"
+  "tocol.EMoveResult\"}\n\024CharacterSummaryInf"
+  "o\022\020\n\010username\030\001 \001(\t\022\r\n\005level\030\002 \001(\005\022!\n\006ge"
+  "nder\030\003 \001(\0162\021.Protocol.EGender\022!\n\006region\030"
+  "\004 \001(\0162\021.Protocol.ERegion\"w\n\nPlayerInfo\022\n"
+  "\n\002id\030\001 \001(\005\022\020\n\010username\030\002 \001(\t\022\"\n\003pos\030\003 \001("
+  "\0132\025.Protocol.Vector2Info\022\'\n\tdirection\030\004 "
+  "\001(\0162\024.Protocol.EDirection\"Z\n\021InventorySl"
+  "otInfo\022\021\n\tslotIndex\030\001 \001(\005\022\016\n\006itemId\030\002 \001("
+  "\005\022\r\n\005count\030\003 \001(\005\022\023\n\013isQuickslot\030\004 \001(\010\"\204\001"
+  "\n\013MonsterInfo\022\021\n\tmonsterId\030\001 \001(\005\022\025\n\rmons"
+  "terTypeId\030\002 \001(\005\022\"\n\003pos\030\003 \001(\0132\025.Protocol."
+  "Vector2Info\022\'\n\tdirection\030\004 \001(\0162\024.Protoco"
+  "l.EDirection\"\?\n\014ShopItemInfo\022\016\n\006itemId\030\001"
+  " \001(\005\022\020\n\010quantity\030\002 \001(\005\022\r\n\005price\030\003 \001(\005\"i\n"
+  "\016PlayerStatInfo\022\r\n\005maxHp\030\001 \001(\005\022\n\n\002hp\030\002 \001"
+  "(\005\022\016\n\006curExp\030\003 \001(\005\022\016\n\006maxExp\030\004 \001(\005\022\r\n\005le"
+  "vel\030\005 \001(\005\022\r\n\005money\030\006 \001(\005\"\204\001\n\016PlayerChatI"
+  "nfo\022\024\n\nNonePlayer\030\001 \001(\010H\000\022\022\n\010playerId\030\002 "
+  "\001(\005H\000\022\017\n\007message\030\003 \001(\t\022%\n\010chatType\030\004 \001(\016"
+  "2\023.Protocol.EChatTypeB\020\n\016playerIncluded*"
+  "\256\t\n\005MsgId\022\027\n\023C_JWT_LOGIN_REQUEST\020\000\022\025\n\021S_"
+  "JWT_LOGIN_REPLY\020\001\022\036\n\032C_CREATE_CHARACTER_"
+  "REQUEST\020\002\022\034\n\030S_CREATE_CHARACTER_REPLY\020\003\022"
+  "\034\n\030C_CHARACTER_LIST_REQUEST\020\004\022\032\n\026S_CHARA"
+  "CTER_LIST_REPLY\020\005\022\036\n\032C_DELETE_CHARACTER_"
+  "REQUEST\020\006\022\034\n\030S_DELETE_CHARACTER_REPLY\020\007\022"
+  "\020\n\014C_ENTER_GAME\020\010\022\020\n\014S_ENTER_GAME\020\t\022\021\n\rS"
+  "_PLAYER_LIST\020\n\022\034\n\030S_BROADCAST_PLAYER_ENT"
+  "ER\020\013\022\020\n\014C_LEAVE_GAME\020\014\022\020\n\014S_LEAVE_GAME\020\r"
+  "\022\034\n\030S_BROADCAST_PLAYER_LEAVE\020\016\022\031\n\025C_PLAY"
+  "ER_MOVE_REQUEST\020\017\022\027\n\023S_PLAYER_MOVE_REPLY"
+  "\020\020\022\033\n\027S_BROADCAST_PLAYER_MOVE\020\021\022\027\n\023S_CHA"
+  "NGE_ROOM_BEGIN\020\022\022\027\n\023C_CHANGE_ROOM_READY\020"
+  "\023\022\030\n\024S_CHANGE_ROOM_COMMIT\020\024\022\023\n\017S_SPAWN_M"
+  "ONSTER\020\025\022\025\n\021S_DESPAWN_MONSTER\020\026\022\034\n\030S_BRO"
+  "ADCAST_MONSTER_MOVE\020\027\022\036\n\032S_BROADCAST_MON"
+  "STER_ATTACK\020\030\022\035\n\031S_BROADCAST_MONSTER_DEA"
+  "TH\020\031\022\033\n\027C_PLAYER_ATTACK_REQUEST\020\032\022\035\n\031S_B"
+  "ROADCAST_PLAYER_ATTACK\020\033\022\027\n\023C_INVENTORY_"
+  "REQUEST\020\034\022\025\n\021S_INVENTORY_REPLY\020\035\022\026\n\022C_IT"
+  "EM_USE_REQUEST\020\036\022\024\n\020S_ITEM_USE_REPLY\020\037\022\026"
+  "\n\022S_INVENTORY_UPDATE\020 \022\024\n\020S_SYSTEM_MESSA"
+  "GE\020!\022\022\n\016S_MONSTER_LIST\020\"\022\032\n\026C_NPC_INTERA"
+  "CT_REQUEST\020#\022\030\n\024S_NPC_INTERACT_REPLY\020$\022\023"
+  "\n\017S_NPC_SHOP_OPEN\020%\022\032\n\026C_NPC_SHOP_BUY_RE"
+  "QUEST\020&\022\030\n\024S_NPC_SHOP_BUY_REPLY\020\'\022\021\n\rS_P"
+  "LAYER_STAT\020(\022!\n\035S_BROADCAST_PLAYER_TRY_A"
+  "TTACK\020)\022!\n\035S_BROADCAST_PLAYER_HP_CHANGED"
+  "\020*\022\034\n\030S_BROADCAST_PLAYER_DEATH\020+\022\021\n\rC_PL"
+  "AYER_CHAT\020,\022\033\n\027S_BROADCAST_PLAYER_CHAT\020-"
+  "*S\n\014ELoginResult\022\013\n\007SUCCESS\020\000\022\021\n\rINVALID"
+  "_TOKEN\020\001\022\021\n\rTOKEN_EXPIRED\020\002\022\020\n\014SERVER_ER"
+  "ROR\020\003*>\n\007EGender\022\017\n\013GENDER_NONE\020\000\022\017\n\013GEN"
+  "DER_MALE\020\001\022\021\n\rGENDER_FEMALE\020\002*:\n\007ERegion"
+  "\022\017\n\013REGION_NONE\020\000\022\r\n\tREGION_GO\020\001\022\017\n\013REGI"
+  "ON_BACK\020\002*C\n\nEDirection\022\n\n\006DIR_UP\020\000\022\014\n\010D"
+  "IR_DOWN\020\001\022\014\n\010DIR_LEFT\020\002\022\r\n\tDIR_RIGHT\020\003*|"
+  "\n\014ELeaveReason\022\021\n\rLEAVE_UNKNOWN\020\000\022\020\n\014LEA"
+  "VE_LOGOUT\020\001\022\025\n\021LEAVE_CHANGE_ROOM\020\002\022\032\n\026LE"
+  "AVE_CHANGE_CHARACTER\020\003\022\024\n\020LEAVE_DISCONNE"
+  "CT\020\004*_\n\013EMoveResult\022\020\n\014MOVE_UNKNOWN\020\000\022\013\n"
+  "\007MOVE_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_COOLDOW"
+  "N\020\003\022\020\n\014MOVE_BLOCKED\020\004*I\n\014EEnterReason\022\021\n"
+  "\rENTER_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022\025\n\021ENT"
+  "ER_CHANGE_ROOM\020\002*9\n\016EDespawnReason\022\023\n\017DE"
+  "SPAWN_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020\001*~\n\tE"
+  "ItemType\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n\024ITEM_"
+  "TYPE_CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQUIPMENT"
+  "\020\002\022\023\n\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TYPE_MIS"
+  "C\020\004*a\n\014EMessageType\022\020\n\014MESSAGE_INFO\020\000\022\023\n"
+  "\017MESSAGE_WARNING\020\001\022\021\n\rMESSAGE_ERROR\020\002\022\027\n"
+  "\023MESSAGE_DROP_FAILED\020\003*(\n\tEChatType\022\r\n\tC"
+  "HAT_ROOM\020\000\022\014\n\010CHAT_ALL\020\001B\033\252\002\030Google.Prot"
+  "obuf.Protocolb\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_Protocol_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_Protocol_2eproto = {
-    false, false, 5774, descriptor_table_protodef_Protocol_2eproto,
+    false, false, 6141, descriptor_table_protodef_Protocol_2eproto,
     "Protocol.proto",
-    &descriptor_table_Protocol_2eproto_once, nullptr, 0, 52,
+    &descriptor_table_Protocol_2eproto_once, nullptr, 0, 55,
     schemas, file_default_instances, TableStruct_Protocol_2eproto::offsets,
     file_level_metadata_Protocol_2eproto, file_level_enum_descriptors_Protocol_2eproto,
     file_level_service_descriptors_Protocol_2eproto,
@@ -1499,6 +1581,8 @@ bool MsgId_IsValid(int value) {
     case 41:
     case 42:
     case 43:
+    case 44:
+    case 45:
       return true;
     default:
       return false;
@@ -1657,6 +1741,20 @@ bool EMessageType_IsValid(int value) {
     case 1:
     case 2:
     case 3:
+      return true;
+    default:
+      return false;
+  }
+}
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* EChatType_descriptor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&descriptor_table_Protocol_2eproto);
+  return file_level_enum_descriptors_Protocol_2eproto[11];
+}
+bool EChatType_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
       return true;
     default:
       return false;
@@ -10355,6 +10453,384 @@ void S_BroadcastPlayerDeath::InternalSwap(S_BroadcastPlayerDeath* other) {
 
 // ===================================================================
 
+class C_PlayerChat::_Internal {
+ public:
+  static const ::Protocol::PlayerChatInfo& playerchatinfo(const C_PlayerChat* msg);
+};
+
+const ::Protocol::PlayerChatInfo&
+C_PlayerChat::_Internal::playerchatinfo(const C_PlayerChat* msg) {
+  return *msg->_impl_.playerchatinfo_;
+}
+C_PlayerChat::C_PlayerChat(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:Protocol.C_PlayerChat)
+}
+C_PlayerChat::C_PlayerChat(const C_PlayerChat& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  C_PlayerChat* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.playerchatinfo_){nullptr}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_playerchatinfo()) {
+    _this->_impl_.playerchatinfo_ = new ::Protocol::PlayerChatInfo(*from._impl_.playerchatinfo_);
+  }
+  // @@protoc_insertion_point(copy_constructor:Protocol.C_PlayerChat)
+}
+
+inline void C_PlayerChat::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.playerchatinfo_){nullptr}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+}
+
+C_PlayerChat::~C_PlayerChat() {
+  // @@protoc_insertion_point(destructor:Protocol.C_PlayerChat)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void C_PlayerChat::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  if (this != internal_default_instance()) delete _impl_.playerchatinfo_;
+}
+
+void C_PlayerChat::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void C_PlayerChat::Clear() {
+// @@protoc_insertion_point(message_clear_start:Protocol.C_PlayerChat)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArenaForAllocation() == nullptr && _impl_.playerchatinfo_ != nullptr) {
+    delete _impl_.playerchatinfo_;
+  }
+  _impl_.playerchatinfo_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* C_PlayerChat::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // .Protocol.PlayerChatInfo playerChatInfo = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_playerchatinfo(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* C_PlayerChat::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:Protocol.C_PlayerChat)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .Protocol.PlayerChatInfo playerChatInfo = 1;
+  if (this->_internal_has_playerchatinfo()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, _Internal::playerchatinfo(this),
+        _Internal::playerchatinfo(this).GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:Protocol.C_PlayerChat)
+  return target;
+}
+
+size_t C_PlayerChat::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:Protocol.C_PlayerChat)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .Protocol.PlayerChatInfo playerChatInfo = 1;
+  if (this->_internal_has_playerchatinfo()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.playerchatinfo_);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData C_PlayerChat::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    C_PlayerChat::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*C_PlayerChat::GetClassData() const { return &_class_data_; }
+
+
+void C_PlayerChat::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<C_PlayerChat*>(&to_msg);
+  auto& from = static_cast<const C_PlayerChat&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:Protocol.C_PlayerChat)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_has_playerchatinfo()) {
+    _this->_internal_mutable_playerchatinfo()->::Protocol::PlayerChatInfo::MergeFrom(
+        from._internal_playerchatinfo());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void C_PlayerChat::CopyFrom(const C_PlayerChat& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:Protocol.C_PlayerChat)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool C_PlayerChat::IsInitialized() const {
+  return true;
+}
+
+void C_PlayerChat::InternalSwap(C_PlayerChat* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.playerchatinfo_, other->_impl_.playerchatinfo_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata C_PlayerChat::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
+      file_level_metadata_Protocol_2eproto[44]);
+}
+
+// ===================================================================
+
+class S_BroadcastPlayerChat::_Internal {
+ public:
+};
+
+S_BroadcastPlayerChat::S_BroadcastPlayerChat(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:Protocol.S_BroadcastPlayerChat)
+}
+S_BroadcastPlayerChat::S_BroadcastPlayerChat(const S_BroadcastPlayerChat& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  S_BroadcastPlayerChat* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.playerchatinfos_){from._impl_.playerchatinfos_}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:Protocol.S_BroadcastPlayerChat)
+}
+
+inline void S_BroadcastPlayerChat::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.playerchatinfos_){arena}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+}
+
+S_BroadcastPlayerChat::~S_BroadcastPlayerChat() {
+  // @@protoc_insertion_point(destructor:Protocol.S_BroadcastPlayerChat)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void S_BroadcastPlayerChat::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.playerchatinfos_.~RepeatedPtrField();
+}
+
+void S_BroadcastPlayerChat::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void S_BroadcastPlayerChat::Clear() {
+// @@protoc_insertion_point(message_clear_start:Protocol.S_BroadcastPlayerChat)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.playerchatinfos_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* S_BroadcastPlayerChat::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // repeated .Protocol.PlayerChatInfo playerChatInfos = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_playerchatinfos(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* S_BroadcastPlayerChat::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:Protocol.S_BroadcastPlayerChat)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .Protocol.PlayerChatInfo playerChatInfos = 1;
+  for (unsigned i = 0,
+      n = static_cast<unsigned>(this->_internal_playerchatinfos_size()); i < n; i++) {
+    const auto& repfield = this->_internal_playerchatinfos(i);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+        InternalWriteMessage(1, repfield, repfield.GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:Protocol.S_BroadcastPlayerChat)
+  return target;
+}
+
+size_t S_BroadcastPlayerChat::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:Protocol.S_BroadcastPlayerChat)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .Protocol.PlayerChatInfo playerChatInfos = 1;
+  total_size += 1UL * this->_internal_playerchatinfos_size();
+  for (const auto& msg : this->_impl_.playerchatinfos_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData S_BroadcastPlayerChat::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    S_BroadcastPlayerChat::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*S_BroadcastPlayerChat::GetClassData() const { return &_class_data_; }
+
+
+void S_BroadcastPlayerChat::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<S_BroadcastPlayerChat*>(&to_msg);
+  auto& from = static_cast<const S_BroadcastPlayerChat&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:Protocol.S_BroadcastPlayerChat)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  _this->_impl_.playerchatinfos_.MergeFrom(from._impl_.playerchatinfos_);
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void S_BroadcastPlayerChat::CopyFrom(const S_BroadcastPlayerChat& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:Protocol.S_BroadcastPlayerChat)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool S_BroadcastPlayerChat::IsInitialized() const {
+  return true;
+}
+
+void S_BroadcastPlayerChat::InternalSwap(S_BroadcastPlayerChat* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  _impl_.playerchatinfos_.InternalSwap(&other->_impl_.playerchatinfos_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata S_BroadcastPlayerChat::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
+      file_level_metadata_Protocol_2eproto[45]);
+}
+
+// ===================================================================
+
 class Vector2Info::_Internal {
  public:
 };
@@ -10561,7 +11037,7 @@ void Vector2Info::InternalSwap(Vector2Info* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata Vector2Info::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[44]);
+      file_level_metadata_Protocol_2eproto[46]);
 }
 
 // ===================================================================
@@ -10843,7 +11319,7 @@ void PlayerMoveInfo::InternalSwap(PlayerMoveInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PlayerMoveInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[45]);
+      file_level_metadata_Protocol_2eproto[47]);
 }
 
 // ===================================================================
@@ -11136,7 +11612,7 @@ void CharacterSummaryInfo::InternalSwap(CharacterSummaryInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CharacterSummaryInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[46]);
+      file_level_metadata_Protocol_2eproto[48]);
 }
 
 // ===================================================================
@@ -11443,7 +11919,7 @@ void PlayerInfo::InternalSwap(PlayerInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PlayerInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[47]);
+      file_level_metadata_Protocol_2eproto[49]);
 }
 
 // ===================================================================
@@ -11702,7 +12178,7 @@ void InventorySlotInfo::InternalSwap(InventorySlotInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata InventorySlotInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[48]);
+      file_level_metadata_Protocol_2eproto[50]);
 }
 
 // ===================================================================
@@ -11981,7 +12457,7 @@ void MonsterInfo::InternalSwap(MonsterInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MonsterInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[49]);
+      file_level_metadata_Protocol_2eproto[51]);
 }
 
 // ===================================================================
@@ -12216,7 +12692,7 @@ void ShopItemInfo::InternalSwap(ShopItemInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ShopItemInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[50]);
+      file_level_metadata_Protocol_2eproto[52]);
 }
 
 // ===================================================================
@@ -12523,7 +12999,340 @@ void PlayerStatInfo::InternalSwap(PlayerStatInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PlayerStatInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[51]);
+      file_level_metadata_Protocol_2eproto[53]);
+}
+
+// ===================================================================
+
+class PlayerChatInfo::_Internal {
+ public:
+};
+
+PlayerChatInfo::PlayerChatInfo(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:Protocol.PlayerChatInfo)
+}
+PlayerChatInfo::PlayerChatInfo(const PlayerChatInfo& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  PlayerChatInfo* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.message_){}
+    , decltype(_impl_.chattype_){}
+    , decltype(_impl_.playerIncluded_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , /*decltype(_impl_._oneof_case_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.message_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.message_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_message().empty()) {
+    _this->_impl_.message_.Set(from._internal_message(), 
+      _this->GetArenaForAllocation());
+  }
+  _this->_impl_.chattype_ = from._impl_.chattype_;
+  clear_has_playerIncluded();
+  switch (from.playerIncluded_case()) {
+    case kNonePlayer: {
+      _this->_internal_set_noneplayer(from._internal_noneplayer());
+      break;
+    }
+    case kPlayerId: {
+      _this->_internal_set_playerid(from._internal_playerid());
+      break;
+    }
+    case PLAYERINCLUDED_NOT_SET: {
+      break;
+    }
+  }
+  // @@protoc_insertion_point(copy_constructor:Protocol.PlayerChatInfo)
+}
+
+inline void PlayerChatInfo::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.message_){}
+    , decltype(_impl_.chattype_){0}
+    , decltype(_impl_.playerIncluded_){}
+    , /*decltype(_impl_._cached_size_)*/{}
+    , /*decltype(_impl_._oneof_case_)*/{}
+  };
+  _impl_.message_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.message_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  clear_has_playerIncluded();
+}
+
+PlayerChatInfo::~PlayerChatInfo() {
+  // @@protoc_insertion_point(destructor:Protocol.PlayerChatInfo)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void PlayerChatInfo::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.message_.Destroy();
+  if (has_playerIncluded()) {
+    clear_playerIncluded();
+  }
+}
+
+void PlayerChatInfo::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void PlayerChatInfo::clear_playerIncluded() {
+// @@protoc_insertion_point(one_of_clear_start:Protocol.PlayerChatInfo)
+  switch (playerIncluded_case()) {
+    case kNonePlayer: {
+      // No need to clear
+      break;
+    }
+    case kPlayerId: {
+      // No need to clear
+      break;
+    }
+    case PLAYERINCLUDED_NOT_SET: {
+      break;
+    }
+  }
+  _impl_._oneof_case_[0] = PLAYERINCLUDED_NOT_SET;
+}
+
+
+void PlayerChatInfo::Clear() {
+// @@protoc_insertion_point(message_clear_start:Protocol.PlayerChatInfo)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.message_.ClearToEmpty();
+  _impl_.chattype_ = 0;
+  clear_playerIncluded();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* PlayerChatInfo::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // bool NonePlayer = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _internal_set_noneplayer(::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr));
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // int32 playerId = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _internal_set_playerid(::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr));
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // string message = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          auto str = _internal_mutable_message();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "Protocol.PlayerChatInfo.message"));
+        } else
+          goto handle_unusual;
+        continue;
+      // .Protocol.EChatType chatType = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 32)) {
+          uint64_t val = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+          _internal_set_chattype(static_cast<::Protocol::EChatType>(val));
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* PlayerChatInfo::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:Protocol.PlayerChatInfo)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool NonePlayer = 1;
+  if (_internal_has_noneplayer()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(1, this->_internal_noneplayer(), target);
+  }
+
+  // int32 playerId = 2;
+  if (_internal_has_playerid()) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteInt32ToArray(2, this->_internal_playerid(), target);
+  }
+
+  // string message = 3;
+  if (!this->_internal_message().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_message().data(), static_cast<int>(this->_internal_message().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "Protocol.PlayerChatInfo.message");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_message(), target);
+  }
+
+  // .Protocol.EChatType chatType = 4;
+  if (this->_internal_chattype() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteEnumToArray(
+      4, this->_internal_chattype(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:Protocol.PlayerChatInfo)
+  return target;
+}
+
+size_t PlayerChatInfo::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:Protocol.PlayerChatInfo)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string message = 3;
+  if (!this->_internal_message().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_message());
+  }
+
+  // .Protocol.EChatType chatType = 4;
+  if (this->_internal_chattype() != 0) {
+    total_size += 1 +
+      ::_pbi::WireFormatLite::EnumSize(this->_internal_chattype());
+  }
+
+  switch (playerIncluded_case()) {
+    // bool NonePlayer = 1;
+    case kNonePlayer: {
+      total_size += 1 + 1;
+      break;
+    }
+    // int32 playerId = 2;
+    case kPlayerId: {
+      total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_playerid());
+      break;
+    }
+    case PLAYERINCLUDED_NOT_SET: {
+      break;
+    }
+  }
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData PlayerChatInfo::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    PlayerChatInfo::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*PlayerChatInfo::GetClassData() const { return &_class_data_; }
+
+
+void PlayerChatInfo::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<PlayerChatInfo*>(&to_msg);
+  auto& from = static_cast<const PlayerChatInfo&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:Protocol.PlayerChatInfo)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_message().empty()) {
+    _this->_internal_set_message(from._internal_message());
+  }
+  if (from._internal_chattype() != 0) {
+    _this->_internal_set_chattype(from._internal_chattype());
+  }
+  switch (from.playerIncluded_case()) {
+    case kNonePlayer: {
+      _this->_internal_set_noneplayer(from._internal_noneplayer());
+      break;
+    }
+    case kPlayerId: {
+      _this->_internal_set_playerid(from._internal_playerid());
+      break;
+    }
+    case PLAYERINCLUDED_NOT_SET: {
+      break;
+    }
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PlayerChatInfo::CopyFrom(const PlayerChatInfo& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:Protocol.PlayerChatInfo)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool PlayerChatInfo::IsInitialized() const {
+  return true;
+}
+
+void PlayerChatInfo::InternalSwap(PlayerChatInfo* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.message_, lhs_arena,
+      &other->_impl_.message_, rhs_arena
+  );
+  swap(_impl_.chattype_, other->_impl_.chattype_);
+  swap(_impl_.playerIncluded_, other->_impl_.playerIncluded_);
+  swap(_impl_._oneof_case_[0], other->_impl_._oneof_case_[0]);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata PlayerChatInfo::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
+      file_level_metadata_Protocol_2eproto[54]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -12705,6 +13514,14 @@ template<> PROTOBUF_NOINLINE ::Protocol::S_BroadcastPlayerDeath*
 Arena::CreateMaybeMessage< ::Protocol::S_BroadcastPlayerDeath >(Arena* arena) {
   return Arena::CreateMessageInternal< ::Protocol::S_BroadcastPlayerDeath >(arena);
 }
+template<> PROTOBUF_NOINLINE ::Protocol::C_PlayerChat*
+Arena::CreateMaybeMessage< ::Protocol::C_PlayerChat >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::Protocol::C_PlayerChat >(arena);
+}
+template<> PROTOBUF_NOINLINE ::Protocol::S_BroadcastPlayerChat*
+Arena::CreateMaybeMessage< ::Protocol::S_BroadcastPlayerChat >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::Protocol::S_BroadcastPlayerChat >(arena);
+}
 template<> PROTOBUF_NOINLINE ::Protocol::Vector2Info*
 Arena::CreateMaybeMessage< ::Protocol::Vector2Info >(Arena* arena) {
   return Arena::CreateMessageInternal< ::Protocol::Vector2Info >(arena);
@@ -12736,6 +13553,10 @@ Arena::CreateMaybeMessage< ::Protocol::ShopItemInfo >(Arena* arena) {
 template<> PROTOBUF_NOINLINE ::Protocol::PlayerStatInfo*
 Arena::CreateMaybeMessage< ::Protocol::PlayerStatInfo >(Arena* arena) {
   return Arena::CreateMessageInternal< ::Protocol::PlayerStatInfo >(arena);
+}
+template<> PROTOBUF_NOINLINE ::Protocol::PlayerChatInfo*
+Arena::CreateMaybeMessage< ::Protocol::PlayerChatInfo >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::Protocol::PlayerChatInfo >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/GameServer/Protocol.pb.h
+++ b/GameServer/Protocol.pb.h
@@ -83,6 +83,9 @@ extern C_NpcShopBuyRequestDefaultTypeInternal _C_NpcShopBuyRequest_default_insta
 class C_PlayerAttackRequest;
 struct C_PlayerAttackRequestDefaultTypeInternal;
 extern C_PlayerAttackRequestDefaultTypeInternal _C_PlayerAttackRequest_default_instance_;
+class C_PlayerChat;
+struct C_PlayerChatDefaultTypeInternal;
+extern C_PlayerChatDefaultTypeInternal _C_PlayerChat_default_instance_;
 class C_PlayerMoveRequest;
 struct C_PlayerMoveRequestDefaultTypeInternal;
 extern C_PlayerMoveRequestDefaultTypeInternal _C_PlayerMoveRequest_default_instance_;
@@ -95,6 +98,9 @@ extern InventorySlotInfoDefaultTypeInternal _InventorySlotInfo_default_instance_
 class MonsterInfo;
 struct MonsterInfoDefaultTypeInternal;
 extern MonsterInfoDefaultTypeInternal _MonsterInfo_default_instance_;
+class PlayerChatInfo;
+struct PlayerChatInfoDefaultTypeInternal;
+extern PlayerChatInfoDefaultTypeInternal _PlayerChatInfo_default_instance_;
 class PlayerInfo;
 struct PlayerInfoDefaultTypeInternal;
 extern PlayerInfoDefaultTypeInternal _PlayerInfo_default_instance_;
@@ -116,6 +122,9 @@ extern S_BroadcastMonsterMoveDefaultTypeInternal _S_BroadcastMonsterMove_default
 class S_BroadcastPlayerAttack;
 struct S_BroadcastPlayerAttackDefaultTypeInternal;
 extern S_BroadcastPlayerAttackDefaultTypeInternal _S_BroadcastPlayerAttack_default_instance_;
+class S_BroadcastPlayerChat;
+struct S_BroadcastPlayerChatDefaultTypeInternal;
+extern S_BroadcastPlayerChatDefaultTypeInternal _S_BroadcastPlayerChat_default_instance_;
 class S_BroadcastPlayerDeath;
 struct S_BroadcastPlayerDeathDefaultTypeInternal;
 extern S_BroadcastPlayerDeathDefaultTypeInternal _S_BroadcastPlayerDeath_default_instance_;
@@ -217,10 +226,12 @@ template<> ::Protocol::C_LeaveGame* Arena::CreateMaybeMessage<::Protocol::C_Leav
 template<> ::Protocol::C_NpcInteractRequest* Arena::CreateMaybeMessage<::Protocol::C_NpcInteractRequest>(Arena*);
 template<> ::Protocol::C_NpcShopBuyRequest* Arena::CreateMaybeMessage<::Protocol::C_NpcShopBuyRequest>(Arena*);
 template<> ::Protocol::C_PlayerAttackRequest* Arena::CreateMaybeMessage<::Protocol::C_PlayerAttackRequest>(Arena*);
+template<> ::Protocol::C_PlayerChat* Arena::CreateMaybeMessage<::Protocol::C_PlayerChat>(Arena*);
 template<> ::Protocol::C_PlayerMoveRequest* Arena::CreateMaybeMessage<::Protocol::C_PlayerMoveRequest>(Arena*);
 template<> ::Protocol::CharacterSummaryInfo* Arena::CreateMaybeMessage<::Protocol::CharacterSummaryInfo>(Arena*);
 template<> ::Protocol::InventorySlotInfo* Arena::CreateMaybeMessage<::Protocol::InventorySlotInfo>(Arena*);
 template<> ::Protocol::MonsterInfo* Arena::CreateMaybeMessage<::Protocol::MonsterInfo>(Arena*);
+template<> ::Protocol::PlayerChatInfo* Arena::CreateMaybeMessage<::Protocol::PlayerChatInfo>(Arena*);
 template<> ::Protocol::PlayerInfo* Arena::CreateMaybeMessage<::Protocol::PlayerInfo>(Arena*);
 template<> ::Protocol::PlayerMoveInfo* Arena::CreateMaybeMessage<::Protocol::PlayerMoveInfo>(Arena*);
 template<> ::Protocol::PlayerStatInfo* Arena::CreateMaybeMessage<::Protocol::PlayerStatInfo>(Arena*);
@@ -228,6 +239,7 @@ template<> ::Protocol::S_BroadcastMonsterAttack* Arena::CreateMaybeMessage<::Pro
 template<> ::Protocol::S_BroadcastMonsterDeath* Arena::CreateMaybeMessage<::Protocol::S_BroadcastMonsterDeath>(Arena*);
 template<> ::Protocol::S_BroadcastMonsterMove* Arena::CreateMaybeMessage<::Protocol::S_BroadcastMonsterMove>(Arena*);
 template<> ::Protocol::S_BroadcastPlayerAttack* Arena::CreateMaybeMessage<::Protocol::S_BroadcastPlayerAttack>(Arena*);
+template<> ::Protocol::S_BroadcastPlayerChat* Arena::CreateMaybeMessage<::Protocol::S_BroadcastPlayerChat>(Arena*);
 template<> ::Protocol::S_BroadcastPlayerDeath* Arena::CreateMaybeMessage<::Protocol::S_BroadcastPlayerDeath>(Arena*);
 template<> ::Protocol::S_BroadcastPlayerEnter* Arena::CreateMaybeMessage<::Protocol::S_BroadcastPlayerEnter>(Arena*);
 template<> ::Protocol::S_BroadcastPlayerHpChanged* Arena::CreateMaybeMessage<::Protocol::S_BroadcastPlayerHpChanged>(Arena*);
@@ -305,12 +317,14 @@ enum MsgId : int {
   S_BROADCAST_PLAYER_TRY_ATTACK = 41,
   S_BROADCAST_PLAYER_HP_CHANGED = 42,
   S_BROADCAST_PLAYER_DEATH = 43,
+  C_PLAYER_CHAT = 44,
+  S_BROADCAST_PLAYER_CHAT = 45,
   MsgId_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
   MsgId_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
 };
 bool MsgId_IsValid(int value);
 constexpr MsgId MsgId_MIN = C_JWT_LOGIN_REQUEST;
-constexpr MsgId MsgId_MAX = S_BROADCAST_PLAYER_DEATH;
+constexpr MsgId MsgId_MAX = S_BROADCAST_PLAYER_CHAT;
 constexpr int MsgId_ARRAYSIZE = MsgId_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* MsgId_descriptor();
@@ -594,6 +608,31 @@ inline bool EMessageType_Parse(
     ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, EMessageType* value) {
   return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<EMessageType>(
     EMessageType_descriptor(), name, value);
+}
+enum EChatType : int {
+  CHAT_ROOM = 0,
+  CHAT_ALL = 1,
+  EChatType_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
+  EChatType_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
+};
+bool EChatType_IsValid(int value);
+constexpr EChatType EChatType_MIN = CHAT_ROOM;
+constexpr EChatType EChatType_MAX = CHAT_ALL;
+constexpr int EChatType_ARRAYSIZE = EChatType_MAX + 1;
+
+const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* EChatType_descriptor();
+template<typename T>
+inline const std::string& EChatType_Name(T enum_t_value) {
+  static_assert(::std::is_same<T, EChatType>::value ||
+    ::std::is_integral<T>::value,
+    "Incorrect type passed to function EChatType_Name.");
+  return ::PROTOBUF_NAMESPACE_ID::internal::NameOfEnum(
+    EChatType_descriptor(), enum_t_value);
+}
+inline bool EChatType_Parse(
+    ::PROTOBUF_NAMESPACE_ID::ConstStringParam name, EChatType* value) {
+  return ::PROTOBUF_NAMESPACE_ID::internal::ParseNamedEnum<EChatType>(
+    EChatType_descriptor(), name, value);
 }
 // ===================================================================
 
@@ -7559,6 +7598,320 @@ class S_BroadcastPlayerDeath final :
 };
 // -------------------------------------------------------------------
 
+class C_PlayerChat final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:Protocol.C_PlayerChat) */ {
+ public:
+  inline C_PlayerChat() : C_PlayerChat(nullptr) {}
+  ~C_PlayerChat() override;
+  explicit PROTOBUF_CONSTEXPR C_PlayerChat(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  C_PlayerChat(const C_PlayerChat& from);
+  C_PlayerChat(C_PlayerChat&& from) noexcept
+    : C_PlayerChat() {
+    *this = ::std::move(from);
+  }
+
+  inline C_PlayerChat& operator=(const C_PlayerChat& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline C_PlayerChat& operator=(C_PlayerChat&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const C_PlayerChat& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const C_PlayerChat* internal_default_instance() {
+    return reinterpret_cast<const C_PlayerChat*>(
+               &_C_PlayerChat_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    44;
+
+  friend void swap(C_PlayerChat& a, C_PlayerChat& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(C_PlayerChat* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(C_PlayerChat* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  C_PlayerChat* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<C_PlayerChat>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const C_PlayerChat& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const C_PlayerChat& from) {
+    C_PlayerChat::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(C_PlayerChat* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "Protocol.C_PlayerChat";
+  }
+  protected:
+  explicit C_PlayerChat(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPlayerChatInfoFieldNumber = 1,
+  };
+  // .Protocol.PlayerChatInfo playerChatInfo = 1;
+  bool has_playerchatinfo() const;
+  private:
+  bool _internal_has_playerchatinfo() const;
+  public:
+  void clear_playerchatinfo();
+  const ::Protocol::PlayerChatInfo& playerchatinfo() const;
+  PROTOBUF_NODISCARD ::Protocol::PlayerChatInfo* release_playerchatinfo();
+  ::Protocol::PlayerChatInfo* mutable_playerchatinfo();
+  void set_allocated_playerchatinfo(::Protocol::PlayerChatInfo* playerchatinfo);
+  private:
+  const ::Protocol::PlayerChatInfo& _internal_playerchatinfo() const;
+  ::Protocol::PlayerChatInfo* _internal_mutable_playerchatinfo();
+  public:
+  void unsafe_arena_set_allocated_playerchatinfo(
+      ::Protocol::PlayerChatInfo* playerchatinfo);
+  ::Protocol::PlayerChatInfo* unsafe_arena_release_playerchatinfo();
+
+  // @@protoc_insertion_point(class_scope:Protocol.C_PlayerChat)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::Protocol::PlayerChatInfo* playerchatinfo_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_Protocol_2eproto;
+};
+// -------------------------------------------------------------------
+
+class S_BroadcastPlayerChat final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:Protocol.S_BroadcastPlayerChat) */ {
+ public:
+  inline S_BroadcastPlayerChat() : S_BroadcastPlayerChat(nullptr) {}
+  ~S_BroadcastPlayerChat() override;
+  explicit PROTOBUF_CONSTEXPR S_BroadcastPlayerChat(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  S_BroadcastPlayerChat(const S_BroadcastPlayerChat& from);
+  S_BroadcastPlayerChat(S_BroadcastPlayerChat&& from) noexcept
+    : S_BroadcastPlayerChat() {
+    *this = ::std::move(from);
+  }
+
+  inline S_BroadcastPlayerChat& operator=(const S_BroadcastPlayerChat& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline S_BroadcastPlayerChat& operator=(S_BroadcastPlayerChat&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const S_BroadcastPlayerChat& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const S_BroadcastPlayerChat* internal_default_instance() {
+    return reinterpret_cast<const S_BroadcastPlayerChat*>(
+               &_S_BroadcastPlayerChat_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    45;
+
+  friend void swap(S_BroadcastPlayerChat& a, S_BroadcastPlayerChat& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(S_BroadcastPlayerChat* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(S_BroadcastPlayerChat* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  S_BroadcastPlayerChat* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<S_BroadcastPlayerChat>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const S_BroadcastPlayerChat& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const S_BroadcastPlayerChat& from) {
+    S_BroadcastPlayerChat::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(S_BroadcastPlayerChat* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "Protocol.S_BroadcastPlayerChat";
+  }
+  protected:
+  explicit S_BroadcastPlayerChat(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPlayerChatInfosFieldNumber = 1,
+  };
+  // repeated .Protocol.PlayerChatInfo playerChatInfos = 1;
+  int playerchatinfos_size() const;
+  private:
+  int _internal_playerchatinfos_size() const;
+  public:
+  void clear_playerchatinfos();
+  ::Protocol::PlayerChatInfo* mutable_playerchatinfos(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::Protocol::PlayerChatInfo >*
+      mutable_playerchatinfos();
+  private:
+  const ::Protocol::PlayerChatInfo& _internal_playerchatinfos(int index) const;
+  ::Protocol::PlayerChatInfo* _internal_add_playerchatinfos();
+  public:
+  const ::Protocol::PlayerChatInfo& playerchatinfos(int index) const;
+  ::Protocol::PlayerChatInfo* add_playerchatinfos();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::Protocol::PlayerChatInfo >&
+      playerchatinfos() const;
+
+  // @@protoc_insertion_point(class_scope:Protocol.S_BroadcastPlayerChat)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::Protocol::PlayerChatInfo > playerchatinfos_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_Protocol_2eproto;
+};
+// -------------------------------------------------------------------
+
 class Vector2Info final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:Protocol.Vector2Info) */ {
  public:
@@ -7607,7 +7960,7 @@ class Vector2Info final :
                &_Vector2Info_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    44;
+    46;
 
   friend void swap(Vector2Info& a, Vector2Info& b) {
     a.Swap(&b);
@@ -7766,7 +8119,7 @@ class PlayerMoveInfo final :
                &_PlayerMoveInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    45;
+    47;
 
   friend void swap(PlayerMoveInfo& a, PlayerMoveInfo& b) {
     a.Swap(&b);
@@ -7956,7 +8309,7 @@ class CharacterSummaryInfo final :
                &_CharacterSummaryInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    46;
+    48;
 
   friend void swap(CharacterSummaryInfo& a, CharacterSummaryInfo& b) {
     a.Swap(&b);
@@ -8142,7 +8495,7 @@ class PlayerInfo final :
                &_PlayerInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    47;
+    49;
 
   friend void swap(PlayerInfo& a, PlayerInfo& b) {
     a.Swap(&b);
@@ -8337,7 +8690,7 @@ class InventorySlotInfo final :
                &_InventorySlotInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    48;
+    50;
 
   friend void swap(InventorySlotInfo& a, InventorySlotInfo& b) {
     a.Swap(&b);
@@ -8518,7 +8871,7 @@ class MonsterInfo final :
                &_MonsterInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    49;
+    51;
 
   friend void swap(MonsterInfo& a, MonsterInfo& b) {
     a.Swap(&b);
@@ -8708,7 +9061,7 @@ class ShopItemInfo final :
                &_ShopItemInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    50;
+    52;
 
   friend void swap(ShopItemInfo& a, ShopItemInfo& b) {
     a.Swap(&b);
@@ -8878,7 +9231,7 @@ class PlayerStatInfo final :
                &_PlayerStatInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    51;
+    53;
 
   friend void swap(PlayerStatInfo& a, PlayerStatInfo& b) {
     a.Swap(&b);
@@ -9027,6 +9380,219 @@ class PlayerStatInfo final :
     int32_t level_;
     int32_t money_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_Protocol_2eproto;
+};
+// -------------------------------------------------------------------
+
+class PlayerChatInfo final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:Protocol.PlayerChatInfo) */ {
+ public:
+  inline PlayerChatInfo() : PlayerChatInfo(nullptr) {}
+  ~PlayerChatInfo() override;
+  explicit PROTOBUF_CONSTEXPR PlayerChatInfo(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  PlayerChatInfo(const PlayerChatInfo& from);
+  PlayerChatInfo(PlayerChatInfo&& from) noexcept
+    : PlayerChatInfo() {
+    *this = ::std::move(from);
+  }
+
+  inline PlayerChatInfo& operator=(const PlayerChatInfo& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PlayerChatInfo& operator=(PlayerChatInfo&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PlayerChatInfo& default_instance() {
+    return *internal_default_instance();
+  }
+  enum PlayerIncludedCase {
+    kNonePlayer = 1,
+    kPlayerId = 2,
+    PLAYERINCLUDED_NOT_SET = 0,
+  };
+
+  static inline const PlayerChatInfo* internal_default_instance() {
+    return reinterpret_cast<const PlayerChatInfo*>(
+               &_PlayerChatInfo_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    54;
+
+  friend void swap(PlayerChatInfo& a, PlayerChatInfo& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(PlayerChatInfo* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PlayerChatInfo* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  PlayerChatInfo* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<PlayerChatInfo>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const PlayerChatInfo& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const PlayerChatInfo& from) {
+    PlayerChatInfo::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(PlayerChatInfo* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "Protocol.PlayerChatInfo";
+  }
+  protected:
+  explicit PlayerChatInfo(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kMessageFieldNumber = 3,
+    kChatTypeFieldNumber = 4,
+    kNonePlayerFieldNumber = 1,
+    kPlayerIdFieldNumber = 2,
+  };
+  // string message = 3;
+  void clear_message();
+  const std::string& message() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_message(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_message();
+  PROTOBUF_NODISCARD std::string* release_message();
+  void set_allocated_message(std::string* message);
+  private:
+  const std::string& _internal_message() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_message(const std::string& value);
+  std::string* _internal_mutable_message();
+  public:
+
+  // .Protocol.EChatType chatType = 4;
+  void clear_chattype();
+  ::Protocol::EChatType chattype() const;
+  void set_chattype(::Protocol::EChatType value);
+  private:
+  ::Protocol::EChatType _internal_chattype() const;
+  void _internal_set_chattype(::Protocol::EChatType value);
+  public:
+
+  // bool NonePlayer = 1;
+  bool has_noneplayer() const;
+  private:
+  bool _internal_has_noneplayer() const;
+  public:
+  void clear_noneplayer();
+  bool noneplayer() const;
+  void set_noneplayer(bool value);
+  private:
+  bool _internal_noneplayer() const;
+  void _internal_set_noneplayer(bool value);
+  public:
+
+  // int32 playerId = 2;
+  bool has_playerid() const;
+  private:
+  bool _internal_has_playerid() const;
+  public:
+  void clear_playerid();
+  int32_t playerid() const;
+  void set_playerid(int32_t value);
+  private:
+  int32_t _internal_playerid() const;
+  void _internal_set_playerid(int32_t value);
+  public:
+
+  void clear_playerIncluded();
+  PlayerIncludedCase playerIncluded_case() const;
+  // @@protoc_insertion_point(class_scope:Protocol.PlayerChatInfo)
+ private:
+  class _Internal;
+  void set_has_noneplayer();
+  void set_has_playerid();
+
+  inline bool has_playerIncluded() const;
+  inline void clear_has_playerIncluded();
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr message_;
+    int chattype_;
+    union PlayerIncludedUnion {
+      constexpr PlayerIncludedUnion() : _constinit_{} {}
+        ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized _constinit_;
+      bool noneplayer_;
+      int32_t playerid_;
+    } playerIncluded_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+    uint32_t _oneof_case_[1];
+
   };
   union { Impl_ _impl_; };
   friend struct ::TableStruct_Protocol_2eproto;
@@ -11541,6 +12107,144 @@ inline void S_BroadcastPlayerDeath::set_killermonsterid(int32_t value) {
 
 // -------------------------------------------------------------------
 
+// C_PlayerChat
+
+// .Protocol.PlayerChatInfo playerChatInfo = 1;
+inline bool C_PlayerChat::_internal_has_playerchatinfo() const {
+  return this != internal_default_instance() && _impl_.playerchatinfo_ != nullptr;
+}
+inline bool C_PlayerChat::has_playerchatinfo() const {
+  return _internal_has_playerchatinfo();
+}
+inline void C_PlayerChat::clear_playerchatinfo() {
+  if (GetArenaForAllocation() == nullptr && _impl_.playerchatinfo_ != nullptr) {
+    delete _impl_.playerchatinfo_;
+  }
+  _impl_.playerchatinfo_ = nullptr;
+}
+inline const ::Protocol::PlayerChatInfo& C_PlayerChat::_internal_playerchatinfo() const {
+  const ::Protocol::PlayerChatInfo* p = _impl_.playerchatinfo_;
+  return p != nullptr ? *p : reinterpret_cast<const ::Protocol::PlayerChatInfo&>(
+      ::Protocol::_PlayerChatInfo_default_instance_);
+}
+inline const ::Protocol::PlayerChatInfo& C_PlayerChat::playerchatinfo() const {
+  // @@protoc_insertion_point(field_get:Protocol.C_PlayerChat.playerChatInfo)
+  return _internal_playerchatinfo();
+}
+inline void C_PlayerChat::unsafe_arena_set_allocated_playerchatinfo(
+    ::Protocol::PlayerChatInfo* playerchatinfo) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.playerchatinfo_);
+  }
+  _impl_.playerchatinfo_ = playerchatinfo;
+  if (playerchatinfo) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:Protocol.C_PlayerChat.playerChatInfo)
+}
+inline ::Protocol::PlayerChatInfo* C_PlayerChat::release_playerchatinfo() {
+  
+  ::Protocol::PlayerChatInfo* temp = _impl_.playerchatinfo_;
+  _impl_.playerchatinfo_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::Protocol::PlayerChatInfo* C_PlayerChat::unsafe_arena_release_playerchatinfo() {
+  // @@protoc_insertion_point(field_release:Protocol.C_PlayerChat.playerChatInfo)
+  
+  ::Protocol::PlayerChatInfo* temp = _impl_.playerchatinfo_;
+  _impl_.playerchatinfo_ = nullptr;
+  return temp;
+}
+inline ::Protocol::PlayerChatInfo* C_PlayerChat::_internal_mutable_playerchatinfo() {
+  
+  if (_impl_.playerchatinfo_ == nullptr) {
+    auto* p = CreateMaybeMessage<::Protocol::PlayerChatInfo>(GetArenaForAllocation());
+    _impl_.playerchatinfo_ = p;
+  }
+  return _impl_.playerchatinfo_;
+}
+inline ::Protocol::PlayerChatInfo* C_PlayerChat::mutable_playerchatinfo() {
+  ::Protocol::PlayerChatInfo* _msg = _internal_mutable_playerchatinfo();
+  // @@protoc_insertion_point(field_mutable:Protocol.C_PlayerChat.playerChatInfo)
+  return _msg;
+}
+inline void C_PlayerChat::set_allocated_playerchatinfo(::Protocol::PlayerChatInfo* playerchatinfo) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.playerchatinfo_;
+  }
+  if (playerchatinfo) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(playerchatinfo);
+    if (message_arena != submessage_arena) {
+      playerchatinfo = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, playerchatinfo, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.playerchatinfo_ = playerchatinfo;
+  // @@protoc_insertion_point(field_set_allocated:Protocol.C_PlayerChat.playerChatInfo)
+}
+
+// -------------------------------------------------------------------
+
+// S_BroadcastPlayerChat
+
+// repeated .Protocol.PlayerChatInfo playerChatInfos = 1;
+inline int S_BroadcastPlayerChat::_internal_playerchatinfos_size() const {
+  return _impl_.playerchatinfos_.size();
+}
+inline int S_BroadcastPlayerChat::playerchatinfos_size() const {
+  return _internal_playerchatinfos_size();
+}
+inline void S_BroadcastPlayerChat::clear_playerchatinfos() {
+  _impl_.playerchatinfos_.Clear();
+}
+inline ::Protocol::PlayerChatInfo* S_BroadcastPlayerChat::mutable_playerchatinfos(int index) {
+  // @@protoc_insertion_point(field_mutable:Protocol.S_BroadcastPlayerChat.playerChatInfos)
+  return _impl_.playerchatinfos_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::Protocol::PlayerChatInfo >*
+S_BroadcastPlayerChat::mutable_playerchatinfos() {
+  // @@protoc_insertion_point(field_mutable_list:Protocol.S_BroadcastPlayerChat.playerChatInfos)
+  return &_impl_.playerchatinfos_;
+}
+inline const ::Protocol::PlayerChatInfo& S_BroadcastPlayerChat::_internal_playerchatinfos(int index) const {
+  return _impl_.playerchatinfos_.Get(index);
+}
+inline const ::Protocol::PlayerChatInfo& S_BroadcastPlayerChat::playerchatinfos(int index) const {
+  // @@protoc_insertion_point(field_get:Protocol.S_BroadcastPlayerChat.playerChatInfos)
+  return _internal_playerchatinfos(index);
+}
+inline ::Protocol::PlayerChatInfo* S_BroadcastPlayerChat::_internal_add_playerchatinfos() {
+  return _impl_.playerchatinfos_.Add();
+}
+inline ::Protocol::PlayerChatInfo* S_BroadcastPlayerChat::add_playerchatinfos() {
+  ::Protocol::PlayerChatInfo* _add = _internal_add_playerchatinfos();
+  // @@protoc_insertion_point(field_add:Protocol.S_BroadcastPlayerChat.playerChatInfos)
+  return _add;
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::Protocol::PlayerChatInfo >&
+S_BroadcastPlayerChat::playerchatinfos() const {
+  // @@protoc_insertion_point(field_list:Protocol.S_BroadcastPlayerChat.playerChatInfos)
+  return _impl_.playerchatinfos_;
+}
+
+// -------------------------------------------------------------------
+
 // Vector2Info
 
 // int32 x = 1;
@@ -12461,9 +13165,174 @@ inline void PlayerStatInfo::set_money(int32_t value) {
   // @@protoc_insertion_point(field_set:Protocol.PlayerStatInfo.money)
 }
 
+// -------------------------------------------------------------------
+
+// PlayerChatInfo
+
+// bool NonePlayer = 1;
+inline bool PlayerChatInfo::_internal_has_noneplayer() const {
+  return playerIncluded_case() == kNonePlayer;
+}
+inline bool PlayerChatInfo::has_noneplayer() const {
+  return _internal_has_noneplayer();
+}
+inline void PlayerChatInfo::set_has_noneplayer() {
+  _impl_._oneof_case_[0] = kNonePlayer;
+}
+inline void PlayerChatInfo::clear_noneplayer() {
+  if (_internal_has_noneplayer()) {
+    _impl_.playerIncluded_.noneplayer_ = false;
+    clear_has_playerIncluded();
+  }
+}
+inline bool PlayerChatInfo::_internal_noneplayer() const {
+  if (_internal_has_noneplayer()) {
+    return _impl_.playerIncluded_.noneplayer_;
+  }
+  return false;
+}
+inline void PlayerChatInfo::_internal_set_noneplayer(bool value) {
+  if (!_internal_has_noneplayer()) {
+    clear_playerIncluded();
+    set_has_noneplayer();
+  }
+  _impl_.playerIncluded_.noneplayer_ = value;
+}
+inline bool PlayerChatInfo::noneplayer() const {
+  // @@protoc_insertion_point(field_get:Protocol.PlayerChatInfo.NonePlayer)
+  return _internal_noneplayer();
+}
+inline void PlayerChatInfo::set_noneplayer(bool value) {
+  _internal_set_noneplayer(value);
+  // @@protoc_insertion_point(field_set:Protocol.PlayerChatInfo.NonePlayer)
+}
+
+// int32 playerId = 2;
+inline bool PlayerChatInfo::_internal_has_playerid() const {
+  return playerIncluded_case() == kPlayerId;
+}
+inline bool PlayerChatInfo::has_playerid() const {
+  return _internal_has_playerid();
+}
+inline void PlayerChatInfo::set_has_playerid() {
+  _impl_._oneof_case_[0] = kPlayerId;
+}
+inline void PlayerChatInfo::clear_playerid() {
+  if (_internal_has_playerid()) {
+    _impl_.playerIncluded_.playerid_ = 0;
+    clear_has_playerIncluded();
+  }
+}
+inline int32_t PlayerChatInfo::_internal_playerid() const {
+  if (_internal_has_playerid()) {
+    return _impl_.playerIncluded_.playerid_;
+  }
+  return 0;
+}
+inline void PlayerChatInfo::_internal_set_playerid(int32_t value) {
+  if (!_internal_has_playerid()) {
+    clear_playerIncluded();
+    set_has_playerid();
+  }
+  _impl_.playerIncluded_.playerid_ = value;
+}
+inline int32_t PlayerChatInfo::playerid() const {
+  // @@protoc_insertion_point(field_get:Protocol.PlayerChatInfo.playerId)
+  return _internal_playerid();
+}
+inline void PlayerChatInfo::set_playerid(int32_t value) {
+  _internal_set_playerid(value);
+  // @@protoc_insertion_point(field_set:Protocol.PlayerChatInfo.playerId)
+}
+
+// string message = 3;
+inline void PlayerChatInfo::clear_message() {
+  _impl_.message_.ClearToEmpty();
+}
+inline const std::string& PlayerChatInfo::message() const {
+  // @@protoc_insertion_point(field_get:Protocol.PlayerChatInfo.message)
+  return _internal_message();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void PlayerChatInfo::set_message(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.message_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:Protocol.PlayerChatInfo.message)
+}
+inline std::string* PlayerChatInfo::mutable_message() {
+  std::string* _s = _internal_mutable_message();
+  // @@protoc_insertion_point(field_mutable:Protocol.PlayerChatInfo.message)
+  return _s;
+}
+inline const std::string& PlayerChatInfo::_internal_message() const {
+  return _impl_.message_.Get();
+}
+inline void PlayerChatInfo::_internal_set_message(const std::string& value) {
+  
+  _impl_.message_.Set(value, GetArenaForAllocation());
+}
+inline std::string* PlayerChatInfo::_internal_mutable_message() {
+  
+  return _impl_.message_.Mutable(GetArenaForAllocation());
+}
+inline std::string* PlayerChatInfo::release_message() {
+  // @@protoc_insertion_point(field_release:Protocol.PlayerChatInfo.message)
+  return _impl_.message_.Release();
+}
+inline void PlayerChatInfo::set_allocated_message(std::string* message) {
+  if (message != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.message_.SetAllocated(message, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.message_.IsDefault()) {
+    _impl_.message_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:Protocol.PlayerChatInfo.message)
+}
+
+// .Protocol.EChatType chatType = 4;
+inline void PlayerChatInfo::clear_chattype() {
+  _impl_.chattype_ = 0;
+}
+inline ::Protocol::EChatType PlayerChatInfo::_internal_chattype() const {
+  return static_cast< ::Protocol::EChatType >(_impl_.chattype_);
+}
+inline ::Protocol::EChatType PlayerChatInfo::chattype() const {
+  // @@protoc_insertion_point(field_get:Protocol.PlayerChatInfo.chatType)
+  return _internal_chattype();
+}
+inline void PlayerChatInfo::_internal_set_chattype(::Protocol::EChatType value) {
+  
+  _impl_.chattype_ = value;
+}
+inline void PlayerChatInfo::set_chattype(::Protocol::EChatType value) {
+  _internal_set_chattype(value);
+  // @@protoc_insertion_point(field_set:Protocol.PlayerChatInfo.chatType)
+}
+
+inline bool PlayerChatInfo::has_playerIncluded() const {
+  return playerIncluded_case() != PLAYERINCLUDED_NOT_SET;
+}
+inline void PlayerChatInfo::clear_has_playerIncluded() {
+  _impl_._oneof_case_[0] = PLAYERINCLUDED_NOT_SET;
+}
+inline PlayerChatInfo::PlayerIncludedCase PlayerChatInfo::playerIncluded_case() const {
+  return PlayerChatInfo::PlayerIncludedCase(_impl_._oneof_case_[0]);
+}
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
@@ -12627,6 +13496,11 @@ template <> struct is_proto_enum< ::Protocol::EMessageType> : ::std::true_type {
 template <>
 inline const EnumDescriptor* GetEnumDescriptor< ::Protocol::EMessageType>() {
   return ::Protocol::EMessageType_descriptor();
+}
+template <> struct is_proto_enum< ::Protocol::EChatType> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::Protocol::EChatType>() {
+  return ::Protocol::EChatType_descriptor();
 }
 
 PROTOBUF_NAMESPACE_CLOSE

--- a/GameServer/Room.cpp
+++ b/GameServer/Room.cpp
@@ -329,6 +329,34 @@ void Room::SendNpcInfo(PlayerRef player)
         s->Send(sendBuffer);
 }
 
+void Room::AddChat(GameSessionRef session, Protocol::C_PlayerChat chatPkt)
+{
+    _pendingChats.emplace_back(session, chatPkt);
+}
+
+void Room::ProcessChatTick()
+{
+    if(_pendingChats.empty()) return; // 비어있을 경우 리턴
+    
+    Protocol::S_BroadcastPlayerChat broadcastChatPkt;
+    broadcastChatPkt.mutable_playerchatinfos()->Reserve(_pendingChats.size()); // 미리 확보
+    for (const auto& [sess, cchat] : _pendingChats)
+    {
+        auto message = cchat.playerchatinfo().message();
+        auto chatType = cchat.playerchatinfo().chattype();
+        Protocol::PlayerChatInfo* chat = broadcastChatPkt.add_playerchatinfos();
+
+        chat->set_playerid(sess->_currentPlayer->playerId);
+        chat->set_message(message);
+        chat->set_chattype(chatType);
+    }
+
+    auto sendBuffer = ClientPacketHandler::MakeSendBuffer(broadcastChatPkt);
+    Broadcast(sendBuffer);
+
+    _pendingChats.clear();
+}
+
 bool Room::CanEnterTile(int nx, int ny) const
 {
     UNREFERENCED_PARAMETER(nx);
@@ -366,6 +394,7 @@ void Room::InitRoomSystems(){}
 void Room::OnRoomTick()
 {
     ProcessMovesTick();
+    ProcessChatTick();
 
     _reserved.clear(); // 예약 버퍼 비움
 }

--- a/GameServer/Room.h
+++ b/GameServer/Room.h
@@ -56,7 +56,6 @@ protected:
 	void ProcessMovesTick(); // 이번 틱에 요청이 있는 플레이어만 처리
 	void SendMoveAck(PlayerRef p, int clientSeq, Protocol::EMoveResult result);
 
-
 /*-----------------
 	Meta Datas
 -----------------*/
@@ -155,5 +154,17 @@ public:
 public:
 	void SendNpcInfo(PlayerRef player);
 
+/*-------------------
+	Chat System
+-------------------*/
+public:
+	void AddChat(GameSessionRef session, Protocol::C_PlayerChat chatPkt); // TODO: 패킷 복사 Too Much
+
+private:
+	void ProcessChatTick();
+
+private:
+	using chatPair = pair<GameSessionRef, Protocol::C_PlayerChat>;
+	Vector<chatPair> _pendingChats;
 };
 

--- a/GameServer/RoomManager.h
+++ b/GameServer/RoomManager.h
@@ -19,6 +19,45 @@ public:
 		_rooms[r->RoomId()] = std::move(r); // r을 Move하기 때문에 mapNametoIds가 먼저
 	}
 
+public:
+	// Execute DoAsync for All Rooms 
+
+	// Lambda or Func 
+	template<typename F>
+	void DoAsyncForAllRooms(F&& f)
+	{
+		for (auto& [roomIOd, room] : _rooms)
+		{
+			if (room)
+			{
+				room->DoAsync(std::forward<F>(f));
+			}
+		}
+	}
+
+	// 멤버함수 포인터 버전
+	template<typename T, typename Ret, typename... FArgs, typename... CallArgs>
+	void DoAsyncForAllRooms(Ret(T::* memFunc)(FArgs...), CallArgs&&... callArgs)
+	{
+		for (auto& [roomId, room] : _rooms)
+		{
+			if (room)
+			{
+				room->DoAsync(memFunc, std::forward<CallArgs>(callArgs)...);
+			}
+		}
+	}
+
+	// 멤버함수 포인터 Const 버전
+	template<typename T, typename Ret, typename... FArgs, typename... CallArgs>
+	void DoAsyncForAllRooms(Ret(T::* memFunc)(FArgs...) const, CallArgs&&... callArgs)
+	{
+		for (auto& [roomId, room] : _rooms) {
+			if (room) {
+				room->DoAsync(memFunc, std::forward<CallArgs>(callArgs)...);
+			}
+		}
+	}
 
 public:
 	// Helper Function

--- a/Protocol/Protocol.proto
+++ b/Protocol/Protocol.proto
@@ -49,6 +49,8 @@ enum MsgId
 	S_BROADCAST_PLAYER_TRY_ATTACK = 41;
 	S_BROADCAST_PLAYER_HP_CHANGED = 42;
 	S_BROADCAST_PLAYER_DEATH = 43;
+	C_PLAYER_CHAT = 44;
+	S_BROADCAST_PLAYER_CHAT = 45;
 }
 
 // 클라 -> 게임 서버 jwt 로그인 인증 (0)
@@ -328,6 +330,17 @@ message S_BroadcastPlayerDeath
 	int32 killerMonsterId = 2;
 }
 
+// (44) 클라 -> 서버 : C_PlayerChat 채팅 송신
+message C_PlayerChat
+{
+	PlayerChatInfo playerChatInfo = 1;
+}
+
+// (45) 서버 -> 클라 : S_BroadcastPlayerChat : Room-Tick마다 Server가 Player에게 모아둔 채팅 송신
+message S_BroadcastPlayerChat
+{
+	repeated PlayerChatInfo playerChatInfos = 1; 
+}
 
 enum ELoginResult
 {
@@ -407,6 +420,11 @@ enum EMessageType
 	MESSAGE_DROP_FAILED = 3;
 }
 
+enum EChatType
+{
+	CHAT_ROOM = 0;
+	CHAT_ALL = 1;
+}
 message Vector2Info
 {
 	int32 x = 1;
@@ -469,4 +487,14 @@ message PlayerStatInfo
 	int32 maxExp = 4;
 	int32 level = 5;
 	int32 money = 6;
+}
+
+message PlayerChatInfo
+{
+	oneof playerIncluded {
+		bool NonePlayer = 1; // Client -> Server로 보낼떄
+		int32 playerId = 2; // Server -> Client로 보낼때
+	}
+	string message = 3;
+	EChatType chatType = 4; 
 }

--- a/TestClientUnity/Assembly-CSharp.csproj
+++ b/TestClientUnity/Assembly-CSharp.csproj
@@ -122,7 +122,7 @@
     <None Include="Assets\TextMesh Pro\Shaders\TMP_SDF-Mobile Overlay.shader" />
     <None Include="Assets\TextMesh Pro\Shaders\TMP_SDF-Mobile-2-Pass.shader" />
     <None Include="Assets\Packages\Grpc.Core.Api.2.71.0\lib\netstandard2.1\Grpc.Core.Api.xml" />
-    <None Include="Assets\Packages\System.Diagnostics.DiagnosticSource.6.0.1\lib\netstandard2.0\System.Diagnostics.DiagnosticSource.dll" />
+    <None Include="Assets\Resources\Data\SpawnPoint_data.json" />
     <None Include="Assets\TextMesh Pro\Shaders\TMP_Bitmap.shader" />
     <None Include="Assets\Packages\System.Diagnostics.DiagnosticSource.6.0.1\useSharedDesignerContext.txt" />
     <None Include="Assets\TextMesh Pro\Shaders\TMPro_Mobile.cginc" />

--- a/TestClientUnity/Assets/@Scripts/Packet/ServerPacketManager.cs
+++ b/TestClientUnity/Assets/@Scripts/Packet/ServerPacketManager.cs
@@ -52,6 +52,8 @@ namespace Packet
 	    PKT_S_BroadcastPlayerTryAttack = 41,
 	    PKT_S_BroadcastPlayerHpChanged = 42,
 	    PKT_S_BroadcastPlayerDeath = 43,
+	    PKT_C_PlayerChat = 44,
+	    PKT_S_BroadcastPlayerChat = 45,
     }
     public class ServerPacketManager
     {
@@ -90,6 +92,7 @@ namespace Packet
         public static ArraySegment<byte> MakeSendBuffer(C_ItemUseRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_ItemUseRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_NpcInteractRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcInteractRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_NpcShopBuyRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcShopBuyRequest);
+        public static ArraySegment<byte> MakeSendBuffer(C_PlayerChat pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PlayerChat);
 
         void Register()
         {
@@ -128,6 +131,7 @@ namespace Packet
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerTryAttack, ServerPacketHandler.HANDLE_S_BroadcastPlayerTryAttack, S_BroadcastPlayerTryAttack.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerHpChanged, ServerPacketHandler.HANDLE_S_BroadcastPlayerHpChanged, S_BroadcastPlayerHpChanged.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerDeath, ServerPacketHandler.HANDLE_S_BroadcastPlayerDeath, S_BroadcastPlayerDeath.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerChat, ServerPacketHandler.HANDLE_S_BroadcastPlayerChat, S_BroadcastPlayerChat.Parser);
             
                   
         }

--- a/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
+++ b/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
@@ -88,74 +88,82 @@ namespace Google.Protobuf.Protocol {
             "cm9hZGNhc3RQbGF5ZXJIcENoYW5nZWQSEAoIcGxheWVySWQYASABKAUSCgoC",
             "aHAYAiABKAUSDQoFbWF4SHAYAyABKAUiQwoWU19Ccm9hZGNhc3RQbGF5ZXJE",
             "ZWF0aBIQCghwbGF5ZXJJZBgBIAEoBRIXCg9raWxsZXJNb25zdGVySWQYAiAB",
-            "KAUiIwoLVmVjdG9yMkluZm8SCQoBeBgBIAEoBRIJCgF5GAIgASgFIpkBCg5Q",
-            "bGF5ZXJNb3ZlSW5mbxIQCghwbGF5ZXJJZBgBIAEoBRInCglkaXJlY3Rpb24Y",
-            "AiABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9uEiUKBm5ld1BvcxgDIAEoCzIV",
-            "LlByb3RvY29sLlZlY3RvcjJJbmZvEiUKBnJlc3VsdBgEIAEoDjIVLlByb3Rv",
-            "Y29sLkVNb3ZlUmVzdWx0In0KFENoYXJhY3RlclN1bW1hcnlJbmZvEhAKCHVz",
-            "ZXJuYW1lGAEgASgJEg0KBWxldmVsGAIgASgFEiEKBmdlbmRlchgDIAEoDjIR",
-            "LlByb3RvY29sLkVHZW5kZXISIQoGcmVnaW9uGAQgASgOMhEuUHJvdG9jb2wu",
-            "RVJlZ2lvbiJ3CgpQbGF5ZXJJbmZvEgoKAmlkGAEgASgFEhAKCHVzZXJuYW1l",
-            "GAIgASgJEiIKA3BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEicK",
-            "CWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVEaXJlY3Rpb24iWgoRSW52",
-            "ZW50b3J5U2xvdEluZm8SEQoJc2xvdEluZGV4GAEgASgFEg4KBml0ZW1JZBgC",
-            "IAEoBRINCgVjb3VudBgDIAEoBRITCgtpc1F1aWNrc2xvdBgEIAEoCCKEAQoL",
-            "TW9uc3RlckluZm8SEQoJbW9uc3RlcklkGAEgASgFEhUKDW1vbnN0ZXJUeXBl",
-            "SWQYAiABKAUSIgoDcG9zGAMgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8S",
-            "JwoJZGlyZWN0aW9uGAQgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiI/CgxT",
-            "aG9wSXRlbUluZm8SDgoGaXRlbUlkGAEgASgFEhAKCHF1YW50aXR5GAIgASgF",
-            "Eg0KBXByaWNlGAMgASgFImkKDlBsYXllclN0YXRJbmZvEg0KBW1heEhwGAEg",
-            "ASgFEgoKAmhwGAIgASgFEg4KBmN1ckV4cBgDIAEoBRIOCgZtYXhFeHAYBCAB",
-            "KAUSDQoFbGV2ZWwYBSABKAUSDQoFbW9uZXkYBiABKAUq/ggKBU1zZ0lkEhcK",
-            "E0NfSldUX0xPR0lOX1JFUVVFU1QQABIVChFTX0pXVF9MT0dJTl9SRVBMWRAB",
-            "Eh4KGkNfQ1JFQVRFX0NIQVJBQ1RFUl9SRVFVRVNUEAISHAoYU19DUkVBVEVf",
-            "Q0hBUkFDVEVSX1JFUExZEAMSHAoYQ19DSEFSQUNURVJfTElTVF9SRVFVRVNU",
-            "EAQSGgoWU19DSEFSQUNURVJfTElTVF9SRVBMWRAFEh4KGkNfREVMRVRFX0NI",
-            "QVJBQ1RFUl9SRVFVRVNUEAYSHAoYU19ERUxFVEVfQ0hBUkFDVEVSX1JFUExZ",
-            "EAcSEAoMQ19FTlRFUl9HQU1FEAgSEAoMU19FTlRFUl9HQU1FEAkSEQoNU19Q",
-            "TEFZRVJfTElTVBAKEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9FTlRFUhALEhAK",
-            "DENfTEVBVkVfR0FNRRAMEhAKDFNfTEVBVkVfR0FNRRANEhwKGFNfQlJPQURD",
-            "QVNUX1BMQVlFUl9MRUFWRRAOEhkKFUNfUExBWUVSX01PVkVfUkVRVUVTVBAP",
-            "EhcKE1NfUExBWUVSX01PVkVfUkVQTFkQEBIbChdTX0JST0FEQ0FTVF9QTEFZ",
-            "RVJfTU9WRRAREhcKE1NfQ0hBTkdFX1JPT01fQkVHSU4QEhIXChNDX0NIQU5H",
-            "RV9ST09NX1JFQURZEBMSGAoUU19DSEFOR0VfUk9PTV9DT01NSVQQFBITCg9T",
-            "X1NQQVdOX01PTlNURVIQFRIVChFTX0RFU1BBV05fTU9OU1RFUhAWEhwKGFNf",
-            "QlJPQURDQVNUX01PTlNURVJfTU9WRRAXEh4KGlNfQlJPQURDQVNUX01PTlNU",
-            "RVJfQVRUQUNLEBgSHQoZU19CUk9BRENBU1RfTU9OU1RFUl9ERUFUSBAZEhsK",
-            "F0NfUExBWUVSX0FUVEFDS19SRVFVRVNUEBoSHQoZU19CUk9BRENBU1RfUExB",
-            "WUVSX0FUVEFDSxAbEhcKE0NfSU5WRU5UT1JZX1JFUVVFU1QQHBIVChFTX0lO",
-            "VkVOVE9SWV9SRVBMWRAdEhYKEkNfSVRFTV9VU0VfUkVRVUVTVBAeEhQKEFNf",
-            "SVRFTV9VU0VfUkVQTFkQHxIWChJTX0lOVkVOVE9SWV9VUERBVEUQIBIUChBT",
-            "X1NZU1RFTV9NRVNTQUdFECESEgoOU19NT05TVEVSX0xJU1QQIhIaChZDX05Q",
-            "Q19JTlRFUkFDVF9SRVFVRVNUECMSGAoUU19OUENfSU5URVJBQ1RfUkVQTFkQ",
-            "JBITCg9TX05QQ19TSE9QX09QRU4QJRIaChZDX05QQ19TSE9QX0JVWV9SRVFV",
-            "RVNUECYSGAoUU19OUENfU0hPUF9CVVlfUkVQTFkQJxIRCg1TX1BMQVlFUl9T",
-            "VEFUECgSIQodU19CUk9BRENBU1RfUExBWUVSX1RSWV9BVFRBQ0sQKRIhCh1T",
-            "X0JST0FEQ0FTVF9QTEFZRVJfSFBfQ0hBTkdFRBAqEhwKGFNfQlJPQURDQVNU",
-            "X1BMQVlFUl9ERUFUSBArKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAAS",
-            "EQoNSU5WQUxJRF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJW",
-            "RVJfRVJST1IQAyo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VO",
-            "REVSX01BTEUQARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtS",
-            "RUdJT05fTk9ORRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIq",
-            "QwoKRURpcmVjdGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJ",
-            "Ul9MRUZUEAISDQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxF",
-            "QVZFX1VOS05PV04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFO",
-            "R0VfUk9PTRACEhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFW",
-            "RV9ESVNDT05ORUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dO",
-            "EAASCwoHTU9WRV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9X",
-            "ThADEhAKDE1PVkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRF",
-            "Ul9VTktOT1dOEAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0Vf",
-            "Uk9PTRACKjkKDkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAA",
-            "EhIKDkRFU1BBV05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQ",
-            "RV9VTktOT1dOEAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVN",
-            "X1RZUEVfRVFVSVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRF",
-            "TV9UWVBFX01JU0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZP",
-            "EAASEwoPTUVTU0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcK",
-            "E01FU1NBR0VfRFJPUF9GQUlMRUQQA0IbqgIYR29vZ2xlLlByb3RvYnVmLlBy",
-            "b3RvY29sYgZwcm90bzM="));
+            "KAUiQAoMQ19QbGF5ZXJDaGF0EjAKDnBsYXllckNoYXRJbmZvGAEgASgLMhgu",
+            "UHJvdG9jb2wuUGxheWVyQ2hhdEluZm8iSgoVU19Ccm9hZGNhc3RQbGF5ZXJD",
+            "aGF0EjEKD3BsYXllckNoYXRJbmZvcxgBIAMoCzIYLlByb3RvY29sLlBsYXll",
+            "ckNoYXRJbmZvIiMKC1ZlY3RvcjJJbmZvEgkKAXgYASABKAUSCQoBeRgCIAEo",
+            "BSKZAQoOUGxheWVyTW92ZUluZm8SEAoIcGxheWVySWQYASABKAUSJwoJZGly",
+            "ZWN0aW9uGAIgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbhIlCgZuZXdQb3MY",
+            "AyABKAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxIlCgZyZXN1bHQYBCABKA4y",
+            "FS5Qcm90b2NvbC5FTW92ZVJlc3VsdCJ9ChRDaGFyYWN0ZXJTdW1tYXJ5SW5m",
+            "bxIQCgh1c2VybmFtZRgBIAEoCRINCgVsZXZlbBgCIAEoBRIhCgZnZW5kZXIY",
+            "AyABKA4yES5Qcm90b2NvbC5FR2VuZGVyEiEKBnJlZ2lvbhgEIAEoDjIRLlBy",
+            "b3RvY29sLkVSZWdpb24idwoKUGxheWVySW5mbxIKCgJpZBgBIAEoBRIQCgh1",
+            "c2VybmFtZRgCIAEoCRIiCgNwb3MYAyABKAsyFS5Qcm90b2NvbC5WZWN0b3Iy",
+            "SW5mbxInCglkaXJlY3Rpb24YBCABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9u",
+            "IloKEUludmVudG9yeVNsb3RJbmZvEhEKCXNsb3RJbmRleBgBIAEoBRIOCgZp",
+            "dGVtSWQYAiABKAUSDQoFY291bnQYAyABKAUSEwoLaXNRdWlja3Nsb3QYBCAB",
+            "KAgihAEKC01vbnN0ZXJJbmZvEhEKCW1vbnN0ZXJJZBgBIAEoBRIVCg1tb25z",
+            "dGVyVHlwZUlkGAIgASgFEiIKA3BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3Rv",
+            "cjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVEaXJlY3Rp",
+            "b24iPwoMU2hvcEl0ZW1JbmZvEg4KBml0ZW1JZBgBIAEoBRIQCghxdWFudGl0",
+            "eRgCIAEoBRINCgVwcmljZRgDIAEoBSJpCg5QbGF5ZXJTdGF0SW5mbxINCgVt",
+            "YXhIcBgBIAEoBRIKCgJocBgCIAEoBRIOCgZjdXJFeHAYAyABKAUSDgoGbWF4",
+            "RXhwGAQgASgFEg0KBWxldmVsGAUgASgFEg0KBW1vbmV5GAYgASgFIoQBCg5Q",
+            "bGF5ZXJDaGF0SW5mbxIUCgpOb25lUGxheWVyGAEgASgISAASEgoIcGxheWVy",
+            "SWQYAiABKAVIABIPCgdtZXNzYWdlGAMgASgJEiUKCGNoYXRUeXBlGAQgASgO",
+            "MhMuUHJvdG9jb2wuRUNoYXRUeXBlQhAKDnBsYXllckluY2x1ZGVkKq4JCgVN",
+            "c2dJZBIXChNDX0pXVF9MT0dJTl9SRVFVRVNUEAASFQoRU19KV1RfTE9HSU5f",
+            "UkVQTFkQARIeChpDX0NSRUFURV9DSEFSQUNURVJfUkVRVUVTVBACEhwKGFNf",
+            "Q1JFQVRFX0NIQVJBQ1RFUl9SRVBMWRADEhwKGENfQ0hBUkFDVEVSX0xJU1Rf",
+            "UkVRVUVTVBAEEhoKFlNfQ0hBUkFDVEVSX0xJU1RfUkVQTFkQBRIeChpDX0RF",
+            "TEVURV9DSEFSQUNURVJfUkVRVUVTVBAGEhwKGFNfREVMRVRFX0NIQVJBQ1RF",
+            "Ul9SRVBMWRAHEhAKDENfRU5URVJfR0FNRRAIEhAKDFNfRU5URVJfR0FNRRAJ",
+            "EhEKDVNfUExBWUVSX0xJU1QQChIcChhTX0JST0FEQ0FTVF9QTEFZRVJfRU5U",
+            "RVIQCxIQCgxDX0xFQVZFX0dBTUUQDBIQCgxTX0xFQVZFX0dBTUUQDRIcChhT",
+            "X0JST0FEQ0FTVF9QTEFZRVJfTEVBVkUQDhIZChVDX1BMQVlFUl9NT1ZFX1JF",
+            "UVVFU1QQDxIXChNTX1BMQVlFUl9NT1ZFX1JFUExZEBASGwoXU19CUk9BRENB",
+            "U1RfUExBWUVSX01PVkUQERIXChNTX0NIQU5HRV9ST09NX0JFR0lOEBISFwoT",
+            "Q19DSEFOR0VfUk9PTV9SRUFEWRATEhgKFFNfQ0hBTkdFX1JPT01fQ09NTUlU",
+            "EBQSEwoPU19TUEFXTl9NT05TVEVSEBUSFQoRU19ERVNQQVdOX01PTlNURVIQ",
+            "FhIcChhTX0JST0FEQ0FTVF9NT05TVEVSX01PVkUQFxIeChpTX0JST0FEQ0FT",
+            "VF9NT05TVEVSX0FUVEFDSxAYEh0KGVNfQlJPQURDQVNUX01PTlNURVJfREVB",
+            "VEgQGRIbChdDX1BMQVlFUl9BVFRBQ0tfUkVRVUVTVBAaEh0KGVNfQlJPQURD",
+            "QVNUX1BMQVlFUl9BVFRBQ0sQGxIXChNDX0lOVkVOVE9SWV9SRVFVRVNUEBwS",
+            "FQoRU19JTlZFTlRPUllfUkVQTFkQHRIWChJDX0lURU1fVVNFX1JFUVVFU1QQ",
+            "HhIUChBTX0lURU1fVVNFX1JFUExZEB8SFgoSU19JTlZFTlRPUllfVVBEQVRF",
+            "ECASFAoQU19TWVNURU1fTUVTU0FHRRAhEhIKDlNfTU9OU1RFUl9MSVNUECIS",
+            "GgoWQ19OUENfSU5URVJBQ1RfUkVRVUVTVBAjEhgKFFNfTlBDX0lOVEVSQUNU",
+            "X1JFUExZECQSEwoPU19OUENfU0hPUF9PUEVOECUSGgoWQ19OUENfU0hPUF9C",
+            "VVlfUkVRVUVTVBAmEhgKFFNfTlBDX1NIT1BfQlVZX1JFUExZECcSEQoNU19Q",
+            "TEFZRVJfU1RBVBAoEiEKHVNfQlJPQURDQVNUX1BMQVlFUl9UUllfQVRUQUNL",
+            "ECkSIQodU19CUk9BRENBU1RfUExBWUVSX0hQX0NIQU5HRUQQKhIcChhTX0JS",
+            "T0FEQ0FTVF9QTEFZRVJfREVBVEgQKxIRCg1DX1BMQVlFUl9DSEFUECwSGwoX",
+            "U19CUk9BRENBU1RfUExBWUVSX0NIQVQQLSpTCgxFTG9naW5SZXN1bHQSCwoH",
+            "U1VDQ0VTUxAAEhEKDUlOVkFMSURfVE9LRU4QARIRCg1UT0tFTl9FWFBJUkVE",
+            "EAISEAoMU0VSVkVSX0VSUk9SEAMqPgoHRUdlbmRlchIPCgtHRU5ERVJfTk9O",
+            "RRAAEg8KC0dFTkRFUl9NQUxFEAESEQoNR0VOREVSX0ZFTUFMRRACKjoKB0VS",
+            "ZWdpb24SDwoLUkVHSU9OX05PTkUQABINCglSRUdJT05fR08QARIPCgtSRUdJ",
+            "T05fQkFDSxACKkMKCkVEaXJlY3Rpb24SCgoGRElSX1VQEAASDAoIRElSX0RP",
+            "V04QARIMCghESVJfTEVGVBACEg0KCURJUl9SSUdIVBADKnwKDEVMZWF2ZVJl",
+            "YXNvbhIRCg1MRUFWRV9VTktOT1dOEAASEAoMTEVBVkVfTE9HT1VUEAESFQoR",
+            "TEVBVkVfQ0hBTkdFX1JPT00QAhIaChZMRUFWRV9DSEFOR0VfQ0hBUkFDVEVS",
+            "EAMSFAoQTEVBVkVfRElTQ09OTkVDVBAEKl8KC0VNb3ZlUmVzdWx0EhAKDE1P",
+            "VkVfVU5LTk9XThAAEgsKB01PVkVfT0sQARIMCghNT1ZFX0RJUhACEhEKDU1P",
+            "VkVfQ09PTERPV04QAxIQCgxNT1ZFX0JMT0NLRUQQBCpJCgxFRW50ZXJSZWFz",
+            "b24SEQoNRU5URVJfVU5LTk9XThAAEg8KC0VOVEVSX0xPR0lOEAESFQoRRU5U",
+            "RVJfQ0hBTkdFX1JPT00QAio5Cg5FRGVzcGF3blJlYXNvbhITCg9ERVNQQVdO",
+            "X1VOS05PV04QABISCg5ERVNQQVdOX0tJTExFRBABKn4KCUVJdGVtVHlwZRIV",
+            "ChFJVEVNX1RZUEVfVU5LTk9XThAAEhgKFElURU1fVFlQRV9DT05TVU1BQkxF",
+            "EAESFwoTSVRFTV9UWVBFX0VRVUlQTUVOVBACEhMKD0lURU1fVFlQRV9RVUVT",
+            "VBADEhIKDklURU1fVFlQRV9NSVNDEAQqYQoMRU1lc3NhZ2VUeXBlEhAKDE1F",
+            "U1NBR0VfSU5GTxAAEhMKD01FU1NBR0VfV0FSTklORxABEhEKDU1FU1NBR0Vf",
+            "RVJST1IQAhIXChNNRVNTQUdFX0RST1BfRkFJTEVEEAMqKAoJRUNoYXRUeXBl",
+            "Eg0KCUNIQVRfUk9PTRAAEgwKCENIQVRfQUxMEAFCG6oCGEdvb2dsZS5Qcm90",
+            "b2J1Zi5Qcm90b2NvbGIGcHJvdG8z"));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), }, null, new pbr::GeneratedClrTypeInfo[] {
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), typeof(global::Google.Protobuf.Protocol.EChatType), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_JwtLoginRequest), global::Google.Protobuf.Protocol.C_JwtLoginRequest.Parser, new[]{ "AccessToken" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_JwtLoginReply), global::Google.Protobuf.Protocol.S_JwtLoginReply.Parser, new[]{ "Result" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_CreateCharacterRequest), global::Google.Protobuf.Protocol.C_CreateCharacterRequest.Parser, new[]{ "Username", "Gender", "Region" }, null, null, null, null),
@@ -200,6 +208,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerTryAttack), global::Google.Protobuf.Protocol.S_BroadcastPlayerTryAttack.Parser, new[]{ "PlayerId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerHpChanged), global::Google.Protobuf.Protocol.S_BroadcastPlayerHpChanged.Parser, new[]{ "PlayerId", "Hp", "MaxHp" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath), global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath.Parser, new[]{ "PlayerId", "KillerMonsterId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_PlayerChat), global::Google.Protobuf.Protocol.C_PlayerChat.Parser, new[]{ "PlayerChatInfo" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerChat), global::Google.Protobuf.Protocol.S_BroadcastPlayerChat.Parser, new[]{ "PlayerChatInfos" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.Vector2Info), global::Google.Protobuf.Protocol.Vector2Info.Parser, new[]{ "X", "Y" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerMoveInfo), global::Google.Protobuf.Protocol.PlayerMoveInfo.Parser, new[]{ "PlayerId", "Direction", "NewPos", "Result" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.CharacterSummaryInfo), global::Google.Protobuf.Protocol.CharacterSummaryInfo.Parser, new[]{ "Username", "Level", "Gender", "Region" }, null, null, null, null),
@@ -207,7 +217,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.InventorySlotInfo), global::Google.Protobuf.Protocol.InventorySlotInfo.Parser, new[]{ "SlotIndex", "ItemId", "Count", "IsQuickslot" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.MonsterInfo), global::Google.Protobuf.Protocol.MonsterInfo.Parser, new[]{ "MonsterId", "MonsterTypeId", "Pos", "Direction" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.ShopItemInfo), global::Google.Protobuf.Protocol.ShopItemInfo.Parser, new[]{ "ItemId", "Quantity", "Price" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerStatInfo), global::Google.Protobuf.Protocol.PlayerStatInfo.Parser, new[]{ "MaxHp", "Hp", "CurExp", "MaxExp", "Level", "Money" }, null, null, null, null)
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerStatInfo), global::Google.Protobuf.Protocol.PlayerStatInfo.Parser, new[]{ "MaxHp", "Hp", "CurExp", "MaxExp", "Level", "Money" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerChatInfo), global::Google.Protobuf.Protocol.PlayerChatInfo.Parser, new[]{ "NonePlayer", "PlayerId", "Message", "ChatType" }, new[]{ "PlayerIncluded" }, null, null, null)
           }));
     }
     #endregion
@@ -259,6 +270,8 @@ namespace Google.Protobuf.Protocol {
     [pbr::OriginalName("S_BROADCAST_PLAYER_TRY_ATTACK")] SBroadcastPlayerTryAttack = 41,
     [pbr::OriginalName("S_BROADCAST_PLAYER_HP_CHANGED")] SBroadcastPlayerHpChanged = 42,
     [pbr::OriginalName("S_BROADCAST_PLAYER_DEATH")] SBroadcastPlayerDeath = 43,
+    [pbr::OriginalName("C_PLAYER_CHAT")] CPlayerChat = 44,
+    [pbr::OriginalName("S_BROADCAST_PLAYER_CHAT")] SBroadcastPlayerChat = 45,
   }
 
   public enum ELoginResult {
@@ -351,6 +364,11 @@ namespace Google.Protobuf.Protocol {
     [pbr::OriginalName("MESSAGE_WARNING")] MessageWarning = 1,
     [pbr::OriginalName("MESSAGE_ERROR")] MessageError = 2,
     [pbr::OriginalName("MESSAGE_DROP_FAILED")] MessageDropFailed = 3,
+  }
+
+  public enum EChatType {
+    [pbr::OriginalName("CHAT_ROOM")] ChatRoom = 0,
+    [pbr::OriginalName("CHAT_ALL")] ChatAll = 1,
   }
 
   #endregion
@@ -10009,6 +10027,388 @@ namespace Google.Protobuf.Protocol {
 
   }
 
+  /// <summary>
+  /// (44) 클라 -> 서버 : C_PlayerChat 채팅 송신
+  /// </summary>
+  public sealed partial class C_PlayerChat : pb::IMessage<C_PlayerChat>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<C_PlayerChat> _parser = new pb::MessageParser<C_PlayerChat>(() => new C_PlayerChat());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<C_PlayerChat> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[44]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_PlayerChat() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_PlayerChat(C_PlayerChat other) : this() {
+      playerChatInfo_ = other.playerChatInfo_ != null ? other.playerChatInfo_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_PlayerChat Clone() {
+      return new C_PlayerChat(this);
+    }
+
+    /// <summary>Field number for the "playerChatInfo" field.</summary>
+    public const int PlayerChatInfoFieldNumber = 1;
+    private global::Google.Protobuf.Protocol.PlayerChatInfo playerChatInfo_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.Protocol.PlayerChatInfo PlayerChatInfo {
+      get { return playerChatInfo_; }
+      set {
+        playerChatInfo_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as C_PlayerChat);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(C_PlayerChat other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (!object.Equals(PlayerChatInfo, other.PlayerChatInfo)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (playerChatInfo_ != null) hash ^= PlayerChatInfo.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (playerChatInfo_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(PlayerChatInfo);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (playerChatInfo_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(PlayerChatInfo);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (playerChatInfo_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(PlayerChatInfo);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(C_PlayerChat other) {
+      if (other == null) {
+        return;
+      }
+      if (other.playerChatInfo_ != null) {
+        if (playerChatInfo_ == null) {
+          PlayerChatInfo = new global::Google.Protobuf.Protocol.PlayerChatInfo();
+        }
+        PlayerChatInfo.MergeFrom(other.PlayerChatInfo);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            if (playerChatInfo_ == null) {
+              PlayerChatInfo = new global::Google.Protobuf.Protocol.PlayerChatInfo();
+            }
+            input.ReadMessage(PlayerChatInfo);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            if (playerChatInfo_ == null) {
+              PlayerChatInfo = new global::Google.Protobuf.Protocol.PlayerChatInfo();
+            }
+            input.ReadMessage(PlayerChatInfo);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// (45) 서버 -> 클라 : S_BroadcastPlayerChat : Room-Tick마다 Server가 Player에게 모아둔 채팅 송신
+  /// </summary>
+  public sealed partial class S_BroadcastPlayerChat : pb::IMessage<S_BroadcastPlayerChat>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<S_BroadcastPlayerChat> _parser = new pb::MessageParser<S_BroadcastPlayerChat>(() => new S_BroadcastPlayerChat());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<S_BroadcastPlayerChat> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[45]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_BroadcastPlayerChat() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_BroadcastPlayerChat(S_BroadcastPlayerChat other) : this() {
+      playerChatInfos_ = other.playerChatInfos_.Clone();
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_BroadcastPlayerChat Clone() {
+      return new S_BroadcastPlayerChat(this);
+    }
+
+    /// <summary>Field number for the "playerChatInfos" field.</summary>
+    public const int PlayerChatInfosFieldNumber = 1;
+    private static readonly pb::FieldCodec<global::Google.Protobuf.Protocol.PlayerChatInfo> _repeated_playerChatInfos_codec
+        = pb::FieldCodec.ForMessage(10, global::Google.Protobuf.Protocol.PlayerChatInfo.Parser);
+    private readonly pbc::RepeatedField<global::Google.Protobuf.Protocol.PlayerChatInfo> playerChatInfos_ = new pbc::RepeatedField<global::Google.Protobuf.Protocol.PlayerChatInfo>();
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pbc::RepeatedField<global::Google.Protobuf.Protocol.PlayerChatInfo> PlayerChatInfos {
+      get { return playerChatInfos_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as S_BroadcastPlayerChat);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(S_BroadcastPlayerChat other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if(!playerChatInfos_.Equals(other.playerChatInfos_)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      hash ^= playerChatInfos_.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      playerChatInfos_.WriteTo(output, _repeated_playerChatInfos_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      playerChatInfos_.WriteTo(ref output, _repeated_playerChatInfos_codec);
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      size += playerChatInfos_.CalculateSize(_repeated_playerChatInfos_codec);
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(S_BroadcastPlayerChat other) {
+      if (other == null) {
+        return;
+      }
+      playerChatInfos_.Add(other.playerChatInfos_);
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            playerChatInfos_.AddEntriesFrom(input, _repeated_playerChatInfos_codec);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            playerChatInfos_.AddEntriesFrom(ref input, _repeated_playerChatInfos_codec);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
   public sealed partial class Vector2Info : pb::IMessage<Vector2Info>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -10023,7 +10423,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[44]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10249,7 +10649,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[45]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10558,7 +10958,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10858,7 +11258,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11167,7 +11567,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11467,7 +11867,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11782,7 +12182,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[52]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12051,7 +12451,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[53]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12402,6 +12802,345 @@ namespace Google.Protobuf.Protocol {
           }
           case 48: {
             Money = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  public sealed partial class PlayerChatInfo : pb::IMessage<PlayerChatInfo>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<PlayerChatInfo> _parser = new pb::MessageParser<PlayerChatInfo>(() => new PlayerChatInfo());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<PlayerChatInfo> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[54]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerChatInfo() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerChatInfo(PlayerChatInfo other) : this() {
+      message_ = other.message_;
+      chatType_ = other.chatType_;
+      switch (other.PlayerIncludedCase) {
+        case PlayerIncludedOneofCase.NonePlayer:
+          NonePlayer = other.NonePlayer;
+          break;
+        case PlayerIncludedOneofCase.PlayerId:
+          PlayerId = other.PlayerId;
+          break;
+      }
+
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerChatInfo Clone() {
+      return new PlayerChatInfo(this);
+    }
+
+    /// <summary>Field number for the "NonePlayer" field.</summary>
+    public const int NonePlayerFieldNumber = 1;
+    /// <summary>
+    /// Client -> Server로 보낼떄
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool NonePlayer {
+      get { return playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer ? (bool) playerIncluded_ : false; }
+      set {
+        playerIncluded_ = value;
+        playerIncludedCase_ = PlayerIncludedOneofCase.NonePlayer;
+      }
+    }
+
+    /// <summary>Field number for the "playerId" field.</summary>
+    public const int PlayerIdFieldNumber = 2;
+    /// <summary>
+    /// Server -> Client로 보낼때
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int PlayerId {
+      get { return playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId ? (int) playerIncluded_ : 0; }
+      set {
+        playerIncluded_ = value;
+        playerIncludedCase_ = PlayerIncludedOneofCase.PlayerId;
+      }
+    }
+
+    /// <summary>Field number for the "message" field.</summary>
+    public const int MessageFieldNumber = 3;
+    private string message_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Message {
+      get { return message_; }
+      set {
+        message_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "chatType" field.</summary>
+    public const int ChatTypeFieldNumber = 4;
+    private global::Google.Protobuf.Protocol.EChatType chatType_ = global::Google.Protobuf.Protocol.EChatType.ChatRoom;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.Protocol.EChatType ChatType {
+      get { return chatType_; }
+      set {
+        chatType_ = value;
+      }
+    }
+
+    private object playerIncluded_;
+    /// <summary>Enum of possible cases for the "playerIncluded" oneof.</summary>
+    public enum PlayerIncludedOneofCase {
+      None = 0,
+      NonePlayer = 1,
+      PlayerId = 2,
+    }
+    private PlayerIncludedOneofCase playerIncludedCase_ = PlayerIncludedOneofCase.None;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PlayerIncludedOneofCase PlayerIncludedCase {
+      get { return playerIncludedCase_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearPlayerIncluded() {
+      playerIncludedCase_ = PlayerIncludedOneofCase.None;
+      playerIncluded_ = null;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as PlayerChatInfo);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(PlayerChatInfo other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (NonePlayer != other.NonePlayer) return false;
+      if (PlayerId != other.PlayerId) return false;
+      if (Message != other.Message) return false;
+      if (ChatType != other.ChatType) return false;
+      if (PlayerIncludedCase != other.PlayerIncludedCase) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) hash ^= NonePlayer.GetHashCode();
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) hash ^= PlayerId.GetHashCode();
+      if (Message.Length != 0) hash ^= Message.GetHashCode();
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) hash ^= ChatType.GetHashCode();
+      hash ^= (int) playerIncludedCase_;
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) {
+        output.WriteRawTag(8);
+        output.WriteBool(NonePlayer);
+      }
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) {
+        output.WriteRawTag(16);
+        output.WriteInt32(PlayerId);
+      }
+      if (Message.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(Message);
+      }
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        output.WriteRawTag(32);
+        output.WriteEnum((int) ChatType);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) {
+        output.WriteRawTag(8);
+        output.WriteBool(NonePlayer);
+      }
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) {
+        output.WriteRawTag(16);
+        output.WriteInt32(PlayerId);
+      }
+      if (Message.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(Message);
+      }
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        output.WriteRawTag(32);
+        output.WriteEnum((int) ChatType);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.NonePlayer) {
+        size += 1 + 1;
+      }
+      if (playerIncludedCase_ == PlayerIncludedOneofCase.PlayerId) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(PlayerId);
+      }
+      if (Message.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Message);
+      }
+      if (ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) ChatType);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(PlayerChatInfo other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Message.Length != 0) {
+        Message = other.Message;
+      }
+      if (other.ChatType != global::Google.Protobuf.Protocol.EChatType.ChatRoom) {
+        ChatType = other.ChatType;
+      }
+      switch (other.PlayerIncludedCase) {
+        case PlayerIncludedOneofCase.NonePlayer:
+          NonePlayer = other.NonePlayer;
+          break;
+        case PlayerIncludedOneofCase.PlayerId:
+          PlayerId = other.PlayerId;
+          break;
+      }
+
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            NonePlayer = input.ReadBool();
+            break;
+          }
+          case 16: {
+            PlayerId = input.ReadInt32();
+            break;
+          }
+          case 26: {
+            Message = input.ReadString();
+            break;
+          }
+          case 32: {
+            ChatType = (global::Google.Protobuf.Protocol.EChatType) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            NonePlayer = input.ReadBool();
+            break;
+          }
+          case 16: {
+            PlayerId = input.ReadInt32();
+            break;
+          }
+          case 26: {
+            Message = input.ReadString();
+            break;
+          }
+          case 32: {
+            ChatType = (global::Google.Protobuf.Protocol.EChatType) input.ReadEnum();
             break;
           }
         }


### PR DESCRIPTION
## Summary
- 룸별 채팅과 전체 채팅 지원을 위한 프로토콜 추가 (C_PlayerChat, S_BroadcastPlayerChat)
- EChatType 열거형으로 CHAT_ROOM과 CHAT_ALL 구분
- RoomManager에 DoAsyncForAllRooms 템플릿 함수 구현 (람다, 멤버함수 포인터 지원)
- Room 클래스에 채팅 큐잉 및 틱 기반 브로드캐스트 시스템 구현
- DummyClientCS에서 룸 채팅(t키)과 전체 채팅(y키) 테스트 기능 추가
- 채팅 수신 핸들러 구현으로 실시간 메시지 표시

## Test plan
- [ ] DummyClient에서 룸 채팅 기능 테스트 (t키)
- [ ] DummyClient에서 전체 채팅 기능 테스트 (y키)
- [ ] 다중 룸 환경에서 전체 채팅 브로드캐스트 확인
- [ ] DoAsyncForAllRooms 기능이 모든 룸에 정상적으로 작동하는지 확인
- [ ] 채팅 메시지 수신이 실시간으로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)