### PR TITLE
feat(item): 아이템 효과 처리 시스템 개선 및 테스트 기능 추가

### DIFF
--- a/DummyClientCS/Packet/ServerPacketHandler.cs
+++ b/DummyClientCS/Packet/ServerPacketHandler.cs
@@ -394,5 +394,42 @@ namespace Packet
             Console.WriteLine($"============================");
             Console.ResetColor();
         }
+
+        internal static void HANDLE_S_GiveItemReply(PacketSession session, S_GiveItemReply reply)
+        {
+            Console.ForegroundColor = ConsoleColor.Magenta;
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.WriteLine("🎁 [S_GiveItemReply] 아이템 지급 결과");
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+
+            if (reply.Success)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("✅ 아이템 지급 성공!");
+
+                if (reply.AddedSlot != null)
+                {
+                    Console.WriteLine($"📦 추가된 슬롯 정보:");
+                    Console.WriteLine($"   슬롯 인덱스: {reply.AddedSlot.SlotIndex}");
+                    Console.WriteLine($"   아이템 ID: {reply.AddedSlot.ItemId}");
+                    Console.WriteLine($"   수량: {reply.AddedSlot.Count}");
+                    Console.WriteLine($"   퀵슬롯 여부: {(reply.AddedSlot.IsQuickslot ? "예" : "아니오")}");
+                }
+
+                Console.WriteLine("💡 인벤토리 조회('i' 키)로 전체 인벤토리를 확인해보세요!");
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("❌ 아이템 지급 실패!");
+                if (!string.IsNullOrEmpty(reply.ErrorMessage))
+                {
+                    Console.WriteLine($"🚫 오류 메시지: {reply.ErrorMessage}");
+                }
+            }
+
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.ResetColor();
+        }
     }
 }

--- a/DummyClientCS/Packet/ServerPacketManager.cs
+++ b/DummyClientCS/Packet/ServerPacketManager.cs
@@ -54,6 +54,8 @@ namespace Packet
 	    PKT_S_BroadcastPlayerDeath = 43,
 	    PKT_C_PlayerChat = 44,
 	    PKT_S_BroadcastPlayerChat = 45,
+	    PKT_C_GiveItemRequest = 46,
+	    PKT_S_GiveItemReply = 47,
     }
     public class ServerPacketManager
     {
@@ -93,6 +95,7 @@ namespace Packet
         public static ArraySegment<byte> MakeSendBuffer(C_NpcInteractRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcInteractRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_NpcShopBuyRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcShopBuyRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_PlayerChat pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PlayerChat);
+        public static ArraySegment<byte> MakeSendBuffer(C_GiveItemRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_GiveItemRequest);
 
         void Register()
         {
@@ -132,6 +135,7 @@ namespace Packet
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerHpChanged, ServerPacketHandler.HANDLE_S_BroadcastPlayerHpChanged, S_BroadcastPlayerHpChanged.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerDeath, ServerPacketHandler.HANDLE_S_BroadcastPlayerDeath, S_BroadcastPlayerDeath.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerChat, ServerPacketHandler.HANDLE_S_BroadcastPlayerChat, S_BroadcastPlayerChat.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_GiveItemReply, ServerPacketHandler.HANDLE_S_GiveItemReply, S_GiveItemReply.Parser);
             
                   
         }

--- a/DummyClientCS/Program.cs
+++ b/DummyClientCS/Program.cs
@@ -51,6 +51,7 @@ class Program
             Console.WriteLine("[i] 인벤토리 조회하기");
             Console.WriteLine("[u] 퀵슬롯 사용 (1~9)");
             Console.WriteLine("[o] 슬롯 지정 아이템 사용");
+            Console.WriteLine("[g] 아이템 지급 테스트 (서버에서 아이템 받기)");
             Console.WriteLine("\n===== 채팅 테스트 =====");
             Console.WriteLine("[t] 룸 채팅 (현재 룸의 플레이어들에게만)");
             Console.WriteLine("[y] 전체 채팅 (모든 룸의 플레이어들에게)");
@@ -297,6 +298,54 @@ class Program
                     }
                     
                     await SessionManager.Instance.SendItemUseRequest(slotIndex);
+                    break;
+                case "g":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("아이템 ID 입력 (예: 10001=체력포션): ");
+                    string? itemIdInput = Console.ReadLine();
+
+                    // 아이템ID 유효성 검사
+                    if (string.IsNullOrWhiteSpace(itemIdInput))
+                    {
+                        Console.WriteLine("아이템 ID를 입력해주세요!");
+                        break;
+                    }
+                    if (!Int32.TryParse(itemIdInput, out int itemId))
+                    {
+                        Console.WriteLine("아이템 ID는 숫자여야 합니다!");
+                        break;
+                    }
+                    if (itemId <= 0)
+                    {
+                        Console.WriteLine("아이템 ID는 0보다 큰 숫자여야 합니다!");
+                        break;
+                    }
+
+                    Console.Write("수량 입력 (예: 5): ");
+                    string? countInput = Console.ReadLine();
+
+                    // 수량 유효성 검사
+                    if (string.IsNullOrWhiteSpace(countInput))
+                    {
+                        Console.WriteLine("수량을 입력해주세요!");
+                        break;
+                    }
+                    if (!Int32.TryParse(countInput, out int count))
+                    {
+                        Console.WriteLine("수량은 숫자여야 합니다!");
+                        break;
+                    }
+                    if (count <= 0)
+                    {
+                        Console.WriteLine("수량은 0보다 큰 숫자여야 합니다!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendGiveItemRequest(itemId, count);
                     break;
                 case "t":
                     if (!_isInGame)

--- a/DummyClientCS/Protocol/Protocol.cs
+++ b/DummyClientCS/Protocol/Protocol.cs
@@ -91,76 +91,81 @@ namespace Google.Protobuf.Protocol {
             "KAUiQAoMQ19QbGF5ZXJDaGF0EjAKDnBsYXllckNoYXRJbmZvGAEgASgLMhgu",
             "UHJvdG9jb2wuUGxheWVyQ2hhdEluZm8iSgoVU19Ccm9hZGNhc3RQbGF5ZXJD",
             "aGF0EjEKD3BsYXllckNoYXRJbmZvcxgBIAMoCzIYLlByb3RvY29sLlBsYXll",
-            "ckNoYXRJbmZvIiMKC1ZlY3RvcjJJbmZvEgkKAXgYASABKAUSCQoBeRgCIAEo",
-            "BSKZAQoOUGxheWVyTW92ZUluZm8SEAoIcGxheWVySWQYASABKAUSJwoJZGly",
-            "ZWN0aW9uGAIgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbhIlCgZuZXdQb3MY",
-            "AyABKAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxIlCgZyZXN1bHQYBCABKA4y",
-            "FS5Qcm90b2NvbC5FTW92ZVJlc3VsdCJ9ChRDaGFyYWN0ZXJTdW1tYXJ5SW5m",
-            "bxIQCgh1c2VybmFtZRgBIAEoCRINCgVsZXZlbBgCIAEoBRIhCgZnZW5kZXIY",
-            "AyABKA4yES5Qcm90b2NvbC5FR2VuZGVyEiEKBnJlZ2lvbhgEIAEoDjIRLlBy",
-            "b3RvY29sLkVSZWdpb24idwoKUGxheWVySW5mbxIKCgJpZBgBIAEoBRIQCgh1",
-            "c2VybmFtZRgCIAEoCRIiCgNwb3MYAyABKAsyFS5Qcm90b2NvbC5WZWN0b3Iy",
-            "SW5mbxInCglkaXJlY3Rpb24YBCABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9u",
-            "IloKEUludmVudG9yeVNsb3RJbmZvEhEKCXNsb3RJbmRleBgBIAEoBRIOCgZp",
-            "dGVtSWQYAiABKAUSDQoFY291bnQYAyABKAUSEwoLaXNRdWlja3Nsb3QYBCAB",
-            "KAgihAEKC01vbnN0ZXJJbmZvEhEKCW1vbnN0ZXJJZBgBIAEoBRIVCg1tb25z",
-            "dGVyVHlwZUlkGAIgASgFEiIKA3BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3Rv",
-            "cjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVEaXJlY3Rp",
-            "b24iPwoMU2hvcEl0ZW1JbmZvEg4KBml0ZW1JZBgBIAEoBRIQCghxdWFudGl0",
-            "eRgCIAEoBRINCgVwcmljZRgDIAEoBSJpCg5QbGF5ZXJTdGF0SW5mbxINCgVt",
-            "YXhIcBgBIAEoBRIKCgJocBgCIAEoBRIOCgZjdXJFeHAYAyABKAUSDgoGbWF4",
-            "RXhwGAQgASgFEg0KBWxldmVsGAUgASgFEg0KBW1vbmV5GAYgASgFIoQBCg5Q",
-            "bGF5ZXJDaGF0SW5mbxIUCgpOb25lUGxheWVyGAEgASgISAASEgoIcGxheWVy",
-            "SWQYAiABKAVIABIPCgdtZXNzYWdlGAMgASgJEiUKCGNoYXRUeXBlGAQgASgO",
-            "MhMuUHJvdG9jb2wuRUNoYXRUeXBlQhAKDnBsYXllckluY2x1ZGVkKq4JCgVN",
-            "c2dJZBIXChNDX0pXVF9MT0dJTl9SRVFVRVNUEAASFQoRU19KV1RfTE9HSU5f",
-            "UkVQTFkQARIeChpDX0NSRUFURV9DSEFSQUNURVJfUkVRVUVTVBACEhwKGFNf",
-            "Q1JFQVRFX0NIQVJBQ1RFUl9SRVBMWRADEhwKGENfQ0hBUkFDVEVSX0xJU1Rf",
-            "UkVRVUVTVBAEEhoKFlNfQ0hBUkFDVEVSX0xJU1RfUkVQTFkQBRIeChpDX0RF",
-            "TEVURV9DSEFSQUNURVJfUkVRVUVTVBAGEhwKGFNfREVMRVRFX0NIQVJBQ1RF",
-            "Ul9SRVBMWRAHEhAKDENfRU5URVJfR0FNRRAIEhAKDFNfRU5URVJfR0FNRRAJ",
-            "EhEKDVNfUExBWUVSX0xJU1QQChIcChhTX0JST0FEQ0FTVF9QTEFZRVJfRU5U",
-            "RVIQCxIQCgxDX0xFQVZFX0dBTUUQDBIQCgxTX0xFQVZFX0dBTUUQDRIcChhT",
-            "X0JST0FEQ0FTVF9QTEFZRVJfTEVBVkUQDhIZChVDX1BMQVlFUl9NT1ZFX1JF",
-            "UVVFU1QQDxIXChNTX1BMQVlFUl9NT1ZFX1JFUExZEBASGwoXU19CUk9BRENB",
-            "U1RfUExBWUVSX01PVkUQERIXChNTX0NIQU5HRV9ST09NX0JFR0lOEBISFwoT",
-            "Q19DSEFOR0VfUk9PTV9SRUFEWRATEhgKFFNfQ0hBTkdFX1JPT01fQ09NTUlU",
-            "EBQSEwoPU19TUEFXTl9NT05TVEVSEBUSFQoRU19ERVNQQVdOX01PTlNURVIQ",
-            "FhIcChhTX0JST0FEQ0FTVF9NT05TVEVSX01PVkUQFxIeChpTX0JST0FEQ0FT",
-            "VF9NT05TVEVSX0FUVEFDSxAYEh0KGVNfQlJPQURDQVNUX01PTlNURVJfREVB",
-            "VEgQGRIbChdDX1BMQVlFUl9BVFRBQ0tfUkVRVUVTVBAaEh0KGVNfQlJPQURD",
-            "QVNUX1BMQVlFUl9BVFRBQ0sQGxIXChNDX0lOVkVOVE9SWV9SRVFVRVNUEBwS",
-            "FQoRU19JTlZFTlRPUllfUkVQTFkQHRIWChJDX0lURU1fVVNFX1JFUVVFU1QQ",
-            "HhIUChBTX0lURU1fVVNFX1JFUExZEB8SFgoSU19JTlZFTlRPUllfVVBEQVRF",
-            "ECASFAoQU19TWVNURU1fTUVTU0FHRRAhEhIKDlNfTU9OU1RFUl9MSVNUECIS",
-            "GgoWQ19OUENfSU5URVJBQ1RfUkVRVUVTVBAjEhgKFFNfTlBDX0lOVEVSQUNU",
-            "X1JFUExZECQSEwoPU19OUENfU0hPUF9PUEVOECUSGgoWQ19OUENfU0hPUF9C",
-            "VVlfUkVRVUVTVBAmEhgKFFNfTlBDX1NIT1BfQlVZX1JFUExZECcSEQoNU19Q",
-            "TEFZRVJfU1RBVBAoEiEKHVNfQlJPQURDQVNUX1BMQVlFUl9UUllfQVRUQUNL",
-            "ECkSIQodU19CUk9BRENBU1RfUExBWUVSX0hQX0NIQU5HRUQQKhIcChhTX0JS",
-            "T0FEQ0FTVF9QTEFZRVJfREVBVEgQKxIRCg1DX1BMQVlFUl9DSEFUECwSGwoX",
-            "U19CUk9BRENBU1RfUExBWUVSX0NIQVQQLSpTCgxFTG9naW5SZXN1bHQSCwoH",
-            "U1VDQ0VTUxAAEhEKDUlOVkFMSURfVE9LRU4QARIRCg1UT0tFTl9FWFBJUkVE",
-            "EAISEAoMU0VSVkVSX0VSUk9SEAMqPgoHRUdlbmRlchIPCgtHRU5ERVJfTk9O",
-            "RRAAEg8KC0dFTkRFUl9NQUxFEAESEQoNR0VOREVSX0ZFTUFMRRACKjoKB0VS",
-            "ZWdpb24SDwoLUkVHSU9OX05PTkUQABINCglSRUdJT05fR08QARIPCgtSRUdJ",
-            "T05fQkFDSxACKkMKCkVEaXJlY3Rpb24SCgoGRElSX1VQEAASDAoIRElSX0RP",
-            "V04QARIMCghESVJfTEVGVBACEg0KCURJUl9SSUdIVBADKnwKDEVMZWF2ZVJl",
-            "YXNvbhIRCg1MRUFWRV9VTktOT1dOEAASEAoMTEVBVkVfTE9HT1VUEAESFQoR",
-            "TEVBVkVfQ0hBTkdFX1JPT00QAhIaChZMRUFWRV9DSEFOR0VfQ0hBUkFDVEVS",
-            "EAMSFAoQTEVBVkVfRElTQ09OTkVDVBAEKl8KC0VNb3ZlUmVzdWx0EhAKDE1P",
-            "VkVfVU5LTk9XThAAEgsKB01PVkVfT0sQARIMCghNT1ZFX0RJUhACEhEKDU1P",
-            "VkVfQ09PTERPV04QAxIQCgxNT1ZFX0JMT0NLRUQQBCpJCgxFRW50ZXJSZWFz",
-            "b24SEQoNRU5URVJfVU5LTk9XThAAEg8KC0VOVEVSX0xPR0lOEAESFQoRRU5U",
-            "RVJfQ0hBTkdFX1JPT00QAio5Cg5FRGVzcGF3blJlYXNvbhITCg9ERVNQQVdO",
-            "X1VOS05PV04QABISCg5ERVNQQVdOX0tJTExFRBABKn4KCUVJdGVtVHlwZRIV",
-            "ChFJVEVNX1RZUEVfVU5LTk9XThAAEhgKFElURU1fVFlQRV9DT05TVU1BQkxF",
-            "EAESFwoTSVRFTV9UWVBFX0VRVUlQTUVOVBACEhMKD0lURU1fVFlQRV9RVUVT",
-            "VBADEhIKDklURU1fVFlQRV9NSVNDEAQqYQoMRU1lc3NhZ2VUeXBlEhAKDE1F",
-            "U1NBR0VfSU5GTxAAEhMKD01FU1NBR0VfV0FSTklORxABEhEKDU1FU1NBR0Vf",
-            "RVJST1IQAhIXChNNRVNTQUdFX0RST1BfRkFJTEVEEAMqKAoJRUNoYXRUeXBl",
-            "Eg0KCUNIQVRfUk9PTRAAEgwKCENIQVRfQUxMEAFCG6oCGEdvb2dsZS5Qcm90",
-            "b2J1Zi5Qcm90b2NvbGIGcHJvdG8z"));
+            "ckNoYXRJbmZvIjIKEUNfR2l2ZUl0ZW1SZXF1ZXN0Eg4KBml0ZW1JZBgBIAEo",
+            "BRINCgVjb3VudBgCIAEoBSJoCg9TX0dpdmVJdGVtUmVwbHkSDwoHc3VjY2Vz",
+            "cxgBIAEoCBIUCgxlcnJvck1lc3NhZ2UYAiABKAkSLgoJYWRkZWRTbG90GAMg",
+            "ASgLMhsuUHJvdG9jb2wuSW52ZW50b3J5U2xvdEluZm8iIwoLVmVjdG9yMklu",
+            "Zm8SCQoBeBgBIAEoBRIJCgF5GAIgASgFIpkBCg5QbGF5ZXJNb3ZlSW5mbxIQ",
+            "CghwbGF5ZXJJZBgBIAEoBRInCglkaXJlY3Rpb24YAiABKA4yFC5Qcm90b2Nv",
+            "bC5FRGlyZWN0aW9uEiUKBm5ld1BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3Rv",
+            "cjJJbmZvEiUKBnJlc3VsdBgEIAEoDjIVLlByb3RvY29sLkVNb3ZlUmVzdWx0",
+            "In0KFENoYXJhY3RlclN1bW1hcnlJbmZvEhAKCHVzZXJuYW1lGAEgASgJEg0K",
+            "BWxldmVsGAIgASgFEiEKBmdlbmRlchgDIAEoDjIRLlByb3RvY29sLkVHZW5k",
+            "ZXISIQoGcmVnaW9uGAQgASgOMhEuUHJvdG9jb2wuRVJlZ2lvbiJ3CgpQbGF5",
+            "ZXJJbmZvEgoKAmlkGAEgASgFEhAKCHVzZXJuYW1lGAIgASgJEiIKA3BvcxgD",
+            "IAEoCzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEicKCWRpcmVjdGlvbhgEIAEo",
+            "DjIULlByb3RvY29sLkVEaXJlY3Rpb24iWgoRSW52ZW50b3J5U2xvdEluZm8S",
+            "EQoJc2xvdEluZGV4GAEgASgFEg4KBml0ZW1JZBgCIAEoBRINCgVjb3VudBgD",
+            "IAEoBRITCgtpc1F1aWNrc2xvdBgEIAEoCCKEAQoLTW9uc3RlckluZm8SEQoJ",
+            "bW9uc3RlcklkGAEgASgFEhUKDW1vbnN0ZXJUeXBlSWQYAiABKAUSIgoDcG9z",
+            "GAMgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8SJwoJZGlyZWN0aW9uGAQg",
+            "ASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiI/CgxTaG9wSXRlbUluZm8SDgoG",
+            "aXRlbUlkGAEgASgFEhAKCHF1YW50aXR5GAIgASgFEg0KBXByaWNlGAMgASgF",
+            "ImkKDlBsYXllclN0YXRJbmZvEg0KBW1heEhwGAEgASgFEgoKAmhwGAIgASgF",
+            "Eg4KBmN1ckV4cBgDIAEoBRIOCgZtYXhFeHAYBCABKAUSDQoFbGV2ZWwYBSAB",
+            "KAUSDQoFbW9uZXkYBiABKAUihAEKDlBsYXllckNoYXRJbmZvEhQKCk5vbmVQ",
+            "bGF5ZXIYASABKAhIABISCghwbGF5ZXJJZBgCIAEoBUgAEg8KB21lc3NhZ2UY",
+            "AyABKAkSJQoIY2hhdFR5cGUYBCABKA4yEy5Qcm90b2NvbC5FQ2hhdFR5cGVC",
+            "EAoOcGxheWVySW5jbHVkZWQq3gkKBU1zZ0lkEhcKE0NfSldUX0xPR0lOX1JF",
+            "UVVFU1QQABIVChFTX0pXVF9MT0dJTl9SRVBMWRABEh4KGkNfQ1JFQVRFX0NI",
+            "QVJBQ1RFUl9SRVFVRVNUEAISHAoYU19DUkVBVEVfQ0hBUkFDVEVSX1JFUExZ",
+            "EAMSHAoYQ19DSEFSQUNURVJfTElTVF9SRVFVRVNUEAQSGgoWU19DSEFSQUNU",
+            "RVJfTElTVF9SRVBMWRAFEh4KGkNfREVMRVRFX0NIQVJBQ1RFUl9SRVFVRVNU",
+            "EAYSHAoYU19ERUxFVEVfQ0hBUkFDVEVSX1JFUExZEAcSEAoMQ19FTlRFUl9H",
+            "QU1FEAgSEAoMU19FTlRFUl9HQU1FEAkSEQoNU19QTEFZRVJfTElTVBAKEhwK",
+            "GFNfQlJPQURDQVNUX1BMQVlFUl9FTlRFUhALEhAKDENfTEVBVkVfR0FNRRAM",
+            "EhAKDFNfTEVBVkVfR0FNRRANEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9MRUFW",
+            "RRAOEhkKFUNfUExBWUVSX01PVkVfUkVRVUVTVBAPEhcKE1NfUExBWUVSX01P",
+            "VkVfUkVQTFkQEBIbChdTX0JST0FEQ0FTVF9QTEFZRVJfTU9WRRAREhcKE1Nf",
+            "Q0hBTkdFX1JPT01fQkVHSU4QEhIXChNDX0NIQU5HRV9ST09NX1JFQURZEBMS",
+            "GAoUU19DSEFOR0VfUk9PTV9DT01NSVQQFBITCg9TX1NQQVdOX01PTlNURVIQ",
+            "FRIVChFTX0RFU1BBV05fTU9OU1RFUhAWEhwKGFNfQlJPQURDQVNUX01PTlNU",
+            "RVJfTU9WRRAXEh4KGlNfQlJPQURDQVNUX01PTlNURVJfQVRUQUNLEBgSHQoZ",
+            "U19CUk9BRENBU1RfTU9OU1RFUl9ERUFUSBAZEhsKF0NfUExBWUVSX0FUVEFD",
+            "S19SRVFVRVNUEBoSHQoZU19CUk9BRENBU1RfUExBWUVSX0FUVEFDSxAbEhcK",
+            "E0NfSU5WRU5UT1JZX1JFUVVFU1QQHBIVChFTX0lOVkVOVE9SWV9SRVBMWRAd",
+            "EhYKEkNfSVRFTV9VU0VfUkVRVUVTVBAeEhQKEFNfSVRFTV9VU0VfUkVQTFkQ",
+            "HxIWChJTX0lOVkVOVE9SWV9VUERBVEUQIBIUChBTX1NZU1RFTV9NRVNTQUdF",
+            "ECESEgoOU19NT05TVEVSX0xJU1QQIhIaChZDX05QQ19JTlRFUkFDVF9SRVFV",
+            "RVNUECMSGAoUU19OUENfSU5URVJBQ1RfUkVQTFkQJBITCg9TX05QQ19TSE9Q",
+            "X09QRU4QJRIaChZDX05QQ19TSE9QX0JVWV9SRVFVRVNUECYSGAoUU19OUENf",
+            "U0hPUF9CVVlfUkVQTFkQJxIRCg1TX1BMQVlFUl9TVEFUECgSIQodU19CUk9B",
+            "RENBU1RfUExBWUVSX1RSWV9BVFRBQ0sQKRIhCh1TX0JST0FEQ0FTVF9QTEFZ",
+            "RVJfSFBfQ0hBTkdFRBAqEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9ERUFUSBAr",
+            "EhEKDUNfUExBWUVSX0NIQVQQLBIbChdTX0JST0FEQ0FTVF9QTEFZRVJfQ0hB",
+            "VBAtEhcKE0NfR0lWRV9JVEVNX1JFUVVFU1QQLhIVChFTX0dJVkVfSVRFTV9S",
+            "RVBMWRAvKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAASEQoNSU5WQUxJ",
+            "RF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJWRVJfRVJST1IQ",
+            "Ayo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VOREVSX01BTEUQ",
+            "ARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtSRUdJT05fTk9O",
+            "RRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIqQwoKRURpcmVj",
+            "dGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJUl9MRUZUEAIS",
+            "DQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxFQVZFX1VOS05P",
+            "V04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFOR0VfUk9PTRAC",
+            "EhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFWRV9ESVNDT05O",
+            "RUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dOEAASCwoHTU9W",
+            "RV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9XThADEhAKDE1P",
+            "VkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRFUl9VTktOT1dO",
+            "EAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0VfUk9PTRACKjkK",
+            "DkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAAEhIKDkRFU1BB",
+            "V05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQRV9VTktOT1dO",
+            "EAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVNX1RZUEVfRVFV",
+            "SVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRFTV9UWVBFX01J",
+            "U0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZPEAASEwoPTUVT",
+            "U0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcKE01FU1NBR0Vf",
+            "RFJPUF9GQUlMRUQQAyooCglFQ2hhdFR5cGUSDQoJQ0hBVF9ST09NEAASDAoI",
+            "Q0hBVF9BTEwQAUIbqgIYR29vZ2xlLlByb3RvYnVmLlByb3RvY29sYgZwcm90",
+            "bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), typeof(global::Google.Protobuf.Protocol.EChatType), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -210,6 +215,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath), global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath.Parser, new[]{ "PlayerId", "KillerMonsterId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_PlayerChat), global::Google.Protobuf.Protocol.C_PlayerChat.Parser, new[]{ "PlayerChatInfo" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerChat), global::Google.Protobuf.Protocol.S_BroadcastPlayerChat.Parser, new[]{ "PlayerChatInfos" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_GiveItemRequest), global::Google.Protobuf.Protocol.C_GiveItemRequest.Parser, new[]{ "ItemId", "Count" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_GiveItemReply), global::Google.Protobuf.Protocol.S_GiveItemReply.Parser, new[]{ "Success", "ErrorMessage", "AddedSlot" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.Vector2Info), global::Google.Protobuf.Protocol.Vector2Info.Parser, new[]{ "X", "Y" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerMoveInfo), global::Google.Protobuf.Protocol.PlayerMoveInfo.Parser, new[]{ "PlayerId", "Direction", "NewPos", "Result" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.CharacterSummaryInfo), global::Google.Protobuf.Protocol.CharacterSummaryInfo.Parser, new[]{ "Username", "Level", "Gender", "Region" }, null, null, null, null),
@@ -272,6 +279,8 @@ namespace Google.Protobuf.Protocol {
     [pbr::OriginalName("S_BROADCAST_PLAYER_DEATH")] SBroadcastPlayerDeath = 43,
     [pbr::OriginalName("C_PLAYER_CHAT")] CPlayerChat = 44,
     [pbr::OriginalName("S_BROADCAST_PLAYER_CHAT")] SBroadcastPlayerChat = 45,
+    [pbr::OriginalName("C_GIVE_ITEM_REQUEST")] CGiveItemRequest = 46,
+    [pbr::OriginalName("S_GIVE_ITEM_REPLY")] SGiveItemReply = 47,
   }
 
   public enum ELoginResult {
@@ -10409,6 +10418,510 @@ namespace Google.Protobuf.Protocol {
 
   }
 
+  /// <summary>
+  /// (46) 클라 -> 서버 : 테스트용 아이템 지급 요청
+  /// </summary>
+  public sealed partial class C_GiveItemRequest : pb::IMessage<C_GiveItemRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<C_GiveItemRequest> _parser = new pb::MessageParser<C_GiveItemRequest>(() => new C_GiveItemRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<C_GiveItemRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_GiveItemRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_GiveItemRequest(C_GiveItemRequest other) : this() {
+      itemId_ = other.itemId_;
+      count_ = other.count_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_GiveItemRequest Clone() {
+      return new C_GiveItemRequest(this);
+    }
+
+    /// <summary>Field number for the "itemId" field.</summary>
+    public const int ItemIdFieldNumber = 1;
+    private int itemId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int ItemId {
+      get { return itemId_; }
+      set {
+        itemId_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "count" field.</summary>
+    public const int CountFieldNumber = 2;
+    private int count_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int Count {
+      get { return count_; }
+      set {
+        count_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as C_GiveItemRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(C_GiveItemRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ItemId != other.ItemId) return false;
+      if (Count != other.Count) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ItemId != 0) hash ^= ItemId.GetHashCode();
+      if (Count != 0) hash ^= Count.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (ItemId != 0) {
+        output.WriteRawTag(8);
+        output.WriteInt32(ItemId);
+      }
+      if (Count != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Count);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (ItemId != 0) {
+        output.WriteRawTag(8);
+        output.WriteInt32(ItemId);
+      }
+      if (Count != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Count);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (ItemId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(ItemId);
+      }
+      if (Count != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Count);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(C_GiveItemRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ItemId != 0) {
+        ItemId = other.ItemId;
+      }
+      if (other.Count != 0) {
+        Count = other.Count;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            ItemId = input.ReadInt32();
+            break;
+          }
+          case 16: {
+            Count = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            ItemId = input.ReadInt32();
+            break;
+          }
+          case 16: {
+            Count = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// (47) 서버 -> 클라 : 아이템 지급 결과 응답
+  /// </summary>
+  public sealed partial class S_GiveItemReply : pb::IMessage<S_GiveItemReply>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<S_GiveItemReply> _parser = new pb::MessageParser<S_GiveItemReply>(() => new S_GiveItemReply());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<S_GiveItemReply> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_GiveItemReply() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_GiveItemReply(S_GiveItemReply other) : this() {
+      success_ = other.success_;
+      errorMessage_ = other.errorMessage_;
+      addedSlot_ = other.addedSlot_ != null ? other.addedSlot_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_GiveItemReply Clone() {
+      return new S_GiveItemReply(this);
+    }
+
+    /// <summary>Field number for the "success" field.</summary>
+    public const int SuccessFieldNumber = 1;
+    private bool success_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Success {
+      get { return success_; }
+      set {
+        success_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "errorMessage" field.</summary>
+    public const int ErrorMessageFieldNumber = 2;
+    private string errorMessage_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ErrorMessage {
+      get { return errorMessage_; }
+      set {
+        errorMessage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "addedSlot" field.</summary>
+    public const int AddedSlotFieldNumber = 3;
+    private global::Google.Protobuf.Protocol.InventorySlotInfo addedSlot_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.Protocol.InventorySlotInfo AddedSlot {
+      get { return addedSlot_; }
+      set {
+        addedSlot_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as S_GiveItemReply);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(S_GiveItemReply other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Success != other.Success) return false;
+      if (ErrorMessage != other.ErrorMessage) return false;
+      if (!object.Equals(AddedSlot, other.AddedSlot)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Success != false) hash ^= Success.GetHashCode();
+      if (ErrorMessage.Length != 0) hash ^= ErrorMessage.GetHashCode();
+      if (addedSlot_ != null) hash ^= AddedSlot.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Success != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(Success);
+      }
+      if (ErrorMessage.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(ErrorMessage);
+      }
+      if (addedSlot_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(AddedSlot);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Success != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(Success);
+      }
+      if (ErrorMessage.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(ErrorMessage);
+      }
+      if (addedSlot_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(AddedSlot);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Success != false) {
+        size += 1 + 1;
+      }
+      if (ErrorMessage.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ErrorMessage);
+      }
+      if (addedSlot_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(AddedSlot);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(S_GiveItemReply other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Success != false) {
+        Success = other.Success;
+      }
+      if (other.ErrorMessage.Length != 0) {
+        ErrorMessage = other.ErrorMessage;
+      }
+      if (other.addedSlot_ != null) {
+        if (addedSlot_ == null) {
+          AddedSlot = new global::Google.Protobuf.Protocol.InventorySlotInfo();
+        }
+        AddedSlot.MergeFrom(other.AddedSlot);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            ErrorMessage = input.ReadString();
+            break;
+          }
+          case 26: {
+            if (addedSlot_ == null) {
+              AddedSlot = new global::Google.Protobuf.Protocol.InventorySlotInfo();
+            }
+            input.ReadMessage(AddedSlot);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            ErrorMessage = input.ReadString();
+            break;
+          }
+          case 26: {
+            if (addedSlot_ == null) {
+              AddedSlot = new global::Google.Protobuf.Protocol.InventorySlotInfo();
+            }
+            input.ReadMessage(AddedSlot);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
   public sealed partial class Vector2Info : pb::IMessage<Vector2Info>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -10423,7 +10936,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10649,7 +11162,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10958,7 +11471,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11258,7 +11771,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11567,7 +12080,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[52]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11867,7 +12380,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[53]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12182,7 +12695,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[52]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[54]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12451,7 +12964,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[53]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[55]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12825,7 +13338,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[54]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[56]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/DummyClientCS/SessionManager.cs
+++ b/DummyClientCS/SessionManager.cs
@@ -377,5 +377,25 @@ namespace DummyClientCS
                 }
             }
         }
+
+        // 테스트용 아이템 지급 요청
+        public async Task SendGiveItemRequest(int itemId, int count)
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_GiveItemRequest
+                    {
+                        ItemId = itemId,
+                        Count = count
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.WriteLine($"🎁 아이템 지급 요청 전송: ItemID={itemId}, Count={count}");
+                }
+            }
+        }
     }
 }

--- a/GameServer/ClientPacketHandler.cpp
+++ b/GameServer/ClientPacketHandler.cpp
@@ -375,11 +375,19 @@ bool Handle_C_ItemUseRequest(PacketSessionRef& session, Protocol::C_ItemUseReque
 		return false;
 
 	int slotIndex = pkt.slotindex();
-	
+
 	GConsoleLogger->WriteStdOut(Color::GREEN, L"[C_ItemUseRequest]: Player가 슬롯[%d] 아이템 사용 요청함 \n", slotIndex);
 
+	// 아이템 정보를 사용 전에 미리 저장 (RemoveItem으로 정보가 변경되기 전)
+	int itemId = player->GetItemIdFromSlot(slotIndex);
+
 	// 아이템 사용 처리
-	EUseItemResult result = player->UseItem(slotIndex);
+	EUseItemResult result = player->UseItem(slotIndex); // 여기서 감소까지 처리
+
+	// 성공 시 아이템 효과 적용
+	if (result == EUseItemResult::Success && itemId > 0) {
+		ItemManager::Instance().ApplyItemEffect(itemId, 1, player);
+	}
 
 	Protocol::S_ItemUseReply replyPkt;
 	replyPkt.set_success(result == EUseItemResult::Success);
@@ -485,4 +493,69 @@ bool Handle_C_PlayerChat(PacketSessionRef& session, Protocol::C_PlayerChat& pkt)
 			ASSERT_CRASH("WRONG VALUE");
 	}
 
+	return true;
+}
+
+bool Handle_C_GiveItemRequest(PacketSessionRef& session, Protocol::C_GiveItemRequest& pkt)
+{
+	GameSessionRef gameSession = static_pointer_cast<GameSession>(session);
+
+	if (gameSession->GetState() != GameSession::State::InRoom)
+		return false;
+
+	PlayerRef player = gameSession->_currentPlayer;
+	if (!player)
+		return false;
+
+	Protocol::S_GiveItemReply replyPkt;
+
+	// 아이템 유효성 검사
+	int itemId = pkt.itemid();
+	int count = pkt.count();
+
+	if (itemId <= 0 || count <= 0)
+	{
+		replyPkt.set_success(false);
+		replyPkt.set_errormessage("잘못된 아이템 정보입니다.");
+	}
+	else
+	{
+		// 아이템 지급 시도
+		auto result = player->AddItem(itemId, count);
+		if (result == EAddItemResult::Success)
+		{
+			replyPkt.set_success(true);
+			replyPkt.set_errormessage("");
+
+			// 인벤토리 업데이트 브로드캐스트
+			Protocol::S_InventoryUpdate updatePkt;
+			auto slots = player->GetInventory().ToProtocolSlots();
+			for (const auto& slot : slots)
+			{
+				if (slot.itemid() == itemId)
+				{
+					*updatePkt.add_changedslots() = slot;
+					*replyPkt.mutable_addedslot() = slot;
+					break;
+				}
+			}
+
+			auto updateBuffer = ClientPacketHandler::MakeSendBuffer(updatePkt);
+			session->Send(updateBuffer);
+
+			GConsoleLogger->WriteStdOut(Color::GREEN,
+				L"[테스트] 플레이어 %d에게 아이템 %d개 %d개 지급 완료\n",
+				player->playerId, itemId, count);
+		}
+		else
+		{
+			replyPkt.set_success(false);
+			replyPkt.set_errormessage("아이템 지급에 실패했습니다. (인벤토리 부족 등)");
+		}
+	}
+
+	auto replyBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+	session->Send(replyBuffer);
+
+	return true;
 }

--- a/GameServer/ClientPacketHandler.h
+++ b/GameServer/ClientPacketHandler.h
@@ -53,6 +53,8 @@ enum : uint16
 	PKT_S_BroadcastPlayerDeath = 43,
 	PKT_C_PlayerChat = 44,
 	PKT_S_BroadcastPlayerChat = 45,
+	PKT_C_GiveItemRequest = 46,
+	PKT_S_GiveItemReply = 47,
 
 };
 
@@ -73,6 +75,7 @@ bool Handle_C_ItemUseRequest(PacketSessionRef& session, Protocol::C_ItemUseReque
 bool Handle_C_NpcInteractRequest(PacketSessionRef& session, Protocol::C_NpcInteractRequest& pkt);
 bool Handle_C_NpcShopBuyRequest(PacketSessionRef& session, Protocol::C_NpcShopBuyRequest& pkt);
 bool Handle_C_PlayerChat(PacketSessionRef& session, Protocol::C_PlayerChat& pkt);
+bool Handle_C_GiveItemRequest(PacketSessionRef& session, Protocol::C_GiveItemRequest& pkt);
 
 class ClientPacketHandler
 {
@@ -98,6 +101,7 @@ public:
 		GPacketHandler[PKT_C_NpcInteractRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_NpcInteractRequest>(Handle_C_NpcInteractRequest, session, buffer, len); };
 		GPacketHandler[PKT_C_NpcShopBuyRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_NpcShopBuyRequest>(Handle_C_NpcShopBuyRequest, session, buffer, len); };
 		GPacketHandler[PKT_C_PlayerChat] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PlayerChat>(Handle_C_PlayerChat, session, buffer, len); };
+		GPacketHandler[PKT_C_GiveItemRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_GiveItemRequest>(Handle_C_GiveItemRequest, session, buffer, len); };
 		
 	}
 	static bool HandlePacket(PacketSessionRef& session, BYTE* buffer, int32 len)
@@ -137,6 +141,7 @@ public:
 	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPlayerHpChanged& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPlayerHpChanged); };
 	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPlayerDeath& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPlayerDeath); };
 	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPlayerChat& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPlayerChat); };
+	static SendBufferRef MakeSendBuffer(Protocol::S_GiveItemReply& pkt) { return MakeSendBuffer(pkt, PKT_S_GiveItemReply); };
 
 private:
 	template<typename PacketType, typename ProcessFunc>

--- a/GameServer/EditorConfig/.editorconfig
+++ b/GameServer/EditorConfig/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
-charset = utf-8
+charset = utf-8-nobom
 
 # Visual C++ 코드 스타일 설정
 

--- a/GameServer/GameDB.xml
+++ b/GameServer/GameDB.xml
@@ -172,18 +172,6 @@
   
   
   <!--===== 아이템, 인벤토리 관련 DB =====-->
-  <Table name="ItemData">
-    <Column name="itemId" type="int" notnull="true"/>
-    <Column name="name" type="nvarchar(64)" notnull="true"/>
-    <Column name="description" type="nvarchar(256)" notnull="false"/>
-    <Column name="isStackable" type="int" notnull="true" default="0"/>
-    <Column name="maxStack" type="int" notnull="true" default="99"/>
-    <Column name="itemType" type="int" notnull="true" default="0"/>
-    <Index type="clustered">
-      <PrimaryKey/>
-      <Column name="itemId"/>
-    </Index>
-  </Table>
   <Table name="CharacterInventory">
     <Column name="characterId" type="int" notnull="true"/>
     <Column name="slotIndex" type="int" notnull="true"/>
@@ -201,12 +189,6 @@
             onUpdate="NO_ACTION">
       <Column local="characterId" ref="characterId"/>
     </ForeignKey>
-    <ForeignKey name="FK_CharacterInventory_itemId_ItemData_itemId"
-            refTable="ItemData"
-            onDelete="NO_ACTION"
-            onUpdate="NO_ACTION">
-     <Column local="itemId" ref="itemId"/>
-    </ForeignKey>
   </Table>
   <!-- ===== 드랍 시스템 관련 DB===== -->
   <Table name="MonsterDropItem">
@@ -220,13 +202,7 @@
     <Index type="clustered">
       <PrimaryKey/>
       <Column name="id"/>
-    </Index>
-    <ForeignKey name="FK_MonsterDropItem_itemId_ItemData_itemId"
-            refTable="ItemData"
-            onDelete="NO_ACTION"
-            onUpdate="NO_ACTION">
-      <Column local="itemId" ref="itemId"/>
-    </ForeignKey>    
+    </Index>  
   </Table>
   <Procedure name="spGetMonsterDropItems">
     <Body>

--- a/GameServer/GameServer.vcxproj
+++ b/GameServer/GameServer.vcxproj
@@ -187,6 +187,7 @@ xcopy "$(ProjectDir)Resources\*" "$(OutDir)Resources\" /E /I /Y /H</Command>
     <ClCompile Include="DropTableRepository.cpp" />
     <ClCompile Include="InventoryRepository.cpp" />
     <ClCompile Include="InventorySystem.cpp" />
+    <ClCompile Include="ItemDataParser.cpp" />
     <ClCompile Include="ItemManager.cpp" />
     <ClCompile Include="JsonFileUtils.cpp" />
     <ClCompile Include="JsonDataParser.cpp" />
@@ -250,6 +251,7 @@ xcopy "$(ProjectDir)Resources\*" "$(OutDir)Resources\" /E /I /Y /H</Command>
     <ClInclude Include="InventoryCore.h" />
     <ClInclude Include="InventoryRepository.h" />
     <ClInclude Include="InventorySystem.h" />
+    <ClInclude Include="ItemDataParser.h" />
     <ClInclude Include="ItemManager.h" />
     <ClInclude Include="JsonFileUtils.h" />
     <ClInclude Include="JsonDataParser.h" />

--- a/GameServer/GameServer.vcxproj.filters
+++ b/GameServer/GameServer.vcxproj.filters
@@ -222,6 +222,7 @@
     <ClCompile Include="SpawnPointDataParser.cpp">
       <Filter>DataParser</Filter>
     </ClCompile>
+    <ClCompile Include="ItemDataParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -395,6 +396,7 @@
     <ClInclude Include="SpawnPointDataParser.h">
       <Filter>DataParser</Filter>
     </ClInclude>
+    <ClInclude Include="ItemDataParser.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="appsettings.json">

--- a/GameServer/InventorySystem.cpp
+++ b/GameServer/InventorySystem.cpp
@@ -114,10 +114,7 @@ EUseItemResult InventorySystem::UseItem(int slotIndex)
     if (!itemData || itemData->itemType != Protocol::EItemType::ITEM_TYPE_CONSUMABLE)
         return EUseItemResult::ItemNotUsable;
 
-    // 아이템 효과 적용
-    ApplyItemEffect(slot.itemId, 1);
-
-    // 소비형 아이템은 사용 후 제거
+    // 소비형 아이템은 사용 후 제거 (효과 적용은 Player에서 처리)
     RemoveItem(slotIndex, 1);
 
     return EUseItemResult::Success;
@@ -338,9 +335,3 @@ int InventorySystem::GetMaxStackSize(int itemId) const
     return itemData ? itemData->maxStack : 1;
 }
 
-void InventorySystem::ApplyItemEffect(int itemId, int count)
-{
-    // TODO: 아이템 효과 시스템 구현
-    // 포션 사용 시 HP 회복 등의 효과를 여기서 처리
-    std::cout << "Applied effect for item " << itemId << " (count: " << count << ")" << std::endl;
-}

--- a/GameServer/InventorySystem.h
+++ b/GameServer/InventorySystem.h
@@ -57,8 +57,6 @@ private:
     bool CanStackItem(int itemId, int slotIndex, int additionalCount) const;
     int GetMaxStackSize(int itemId) const;
 
-    // 아이템 효과 처리
-    void ApplyItemEffect(int itemId, int count);
 
 private:
     std::array<ItemSlot, INVENTORY_TOTAL_SLOTS> _slots;

--- a/GameServer/ItemDataParser.cpp
+++ b/GameServer/ItemDataParser.cpp
@@ -1,0 +1,83 @@
+﻿#include "pch.h"
+#include "ItemDataParser.h"
+
+std::unordered_map<int, ItemData> ItemDataParser::LoadItemData()
+{
+    try
+    {
+        GConsoleLogger->WriteStdOut(Color::GREEN, L"아이템 데이터 로딩 시작: Item_data.json\n");
+
+        auto itemDatas = JsonDataParser::ParseMapData<ItemData>(
+            "Item_data.json",
+            [](const rapidjson::Value& json) { return JsonToItemData(json); },
+            [](const rapidjson::Value& json) { return ExtractItemId(json); }
+        );
+
+        GConsoleLogger->WriteStdOut(Color::GREEN, L"아이템 데이터 로딩 완료: %d개의 아이템 개수\n", static_cast<int>(itemDatas.size()));
+
+        // 로드된 아이템 정보 출력
+        for (const auto& [itemId, data] : itemDatas)
+        {
+            GConsoleLogger->WriteStdOut(Color::WHITE,
+                L"  - Item[%d] %s: Description=%s, IsStackable=%s, MaxStack=%d, EItemType=%d\n",
+                data.itemId,
+                StrToWstr(data.name).c_str(),
+                StrToWstr(data.description).c_str(),
+                data.isStackable ? L"True" : L"False",
+                data.maxStack,
+                static_cast<int>(data.itemType) // int
+            );
+        }
+
+        return itemDatas;
+    }
+    catch (const std::exception& e)
+    {
+        GConsoleLogger->WriteStdOut(Color::RED, L"아이템 데이터 로딩 실패: %s\n", StrToWstr(e.what()).c_str());
+        throw;
+    }
+}
+
+ItemData ItemDataParser::JsonToItemData(const rapidjson::Value& json)
+{
+    ItemData itemData;
+
+    // Json 필드명 -> ItemData 필드 매핑
+    itemData.itemId         = JsonDataParser::SafeGetInt(json, "itemId");
+    itemData.name           = JsonDataParser::SafeGetString(json, "name");
+    itemData.description    = JsonDataParser::SafeGetString(json, "description");
+    itemData.isStackable    = JsonDataParser::SafeGetBool(json, "isStackable");
+    itemData.maxStack       = JsonDataParser::SafeGetInt(json, "maxStack");
+    itemData.itemType       = ItemDataParser::SafeGetItemType(json, "itemType");
+       
+    return itemData;
+}
+
+int ItemDataParser::ExtractItemId(const rapidjson::Value& json)
+{
+    return JsonDataParser::SafeGetInt(json, "itemId");
+}
+
+Protocol::EItemType ItemDataParser::SafeGetItemType(const rapidjson::Value& value, const std::string& fieldName)
+{
+    if (!value.HasMember(fieldName.c_str()))
+    {
+        throw std::runtime_error("JSON에서 필수 필드를 찾을 수 없습니다. " + fieldName);
+    }
+
+    const auto& field = value[fieldName.c_str()];
+
+    if (!field.IsString())
+    {
+        throw std::runtime_error("잘못된 데이터 타입 (필드: " + fieldName + ", 문자열이 아님)");
+    }
+
+    auto fieldStr = static_cast<string>(field.GetString());
+    
+    if      (fieldStr == "UNKNOWN")     return Protocol::EItemType::ITEM_TYPE_UNKNOWN;
+    else if (fieldStr == "CONSUMABLE")  return Protocol::EItemType::ITEM_TYPE_CONSUMABLE;
+    else if (fieldStr == "EQUIPMENT")   return Protocol::EItemType::ITEM_TYPE_EQUIPMENT;
+    else if (fieldStr == "QUEST")       return Protocol::EItemType::ITEM_TYPE_QUEST;
+    else if (fieldStr == "MISC")        return Protocol::EItemType::ITEM_TYPE_MISC;
+
+}

--- a/GameServer/ItemDataParser.h
+++ b/GameServer/ItemDataParser.h
@@ -1,0 +1,27 @@
+﻿#pragma once
+#include "JsonDataParser.h"
+#include "InventoryCore.h"
+
+/*--------------------------
+	Item_data.json을 파싱하는 특화 클래스
+	Google Sheets에서 생성된 아이템 데이터를 ItemData 구조체로 변환
+--------------------------*/
+class ItemDataParser
+{
+public:
+	// Item_data.json파일에서 모든 데이터를 로드
+	// ItemId를 Key로하는 ItemDataMap 반환
+	static std::unordered_map<int, ItemData> LoadItemData();
+
+
+	// Json Value에서 ItemData로 변환
+	// LoadItemData는 이 함수를 호출함
+	static ItemData JsonToItemData(const rapidjson::Value& json);
+
+private:
+	static int ExtractItemId(const rapidjson::Value& json);
+
+	// ItemDataParser Specific
+	static Protocol::EItemType SafeGetItemType(const rapidjson::Value& value, const std::string& fieldName);
+};
+

--- a/GameServer/ItemManager.cpp
+++ b/GameServer/ItemManager.cpp
@@ -1,7 +1,8 @@
-#include "pch.h"
+﻿#include "pch.h"
 #include "ItemManager.h"
 #include "Player.h"
 #include "GenProcedures.h"
+
 #include <iostream>
 #include <algorithm>
 
@@ -18,24 +19,12 @@ bool ItemManager::Initialize()
 
     GConsoleLogger->WriteStdOut(Color::YELLOW, L"ItemManager: Initializing...\n");
     
-    // 기본 아이템 데이터 추가 (DB 로드 실패 시 폴백용)
-    AddItemData(ItemData{1, "Health Potion", "Restores 50 HP", true, 99, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    AddItemData(ItemData{2, "Mana Potion", "Restores 30 MP", true, 99, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    AddItemData(ItemData{3, "Iron Sword", "A basic iron sword", false, 1, Protocol::EItemType::ITEM_TYPE_EQUIPMENT});
-    AddItemData(ItemData{4, "Quest Item", "Important quest item", false, 1, Protocol::EItemType::ITEM_TYPE_QUEST});
-    
-    // DB에서 아이템 데이터 로드 (동기 실행)
-    try {
-        auto future = LoadAllItemDataAsync();
-        bool loadSuccess = future.get(); // 결과 대기
-        
-        if (loadSuccess) {
-            GConsoleLogger->WriteStdOut(Color::GREEN, L"ItemManager: DB에서 아이템 데이터 로딩 성공\n");
-        } else {
-            GConsoleLogger->WriteStdOut(Color::YELLOW, L"ItemManager: DB 로딩 실패, 기본 데이터 사용\n");
-        }
-    } catch (const std::exception& e) {
-        GConsoleLogger->WriteStdOut(Color::RED, L"ItemManager: DB 로딩 중 예외 발생, 기본 데이터 사용\n");
+    // 아이템 Load From Json
+    auto itemDataMap = ItemDataParser::LoadItemData();
+
+    for (const auto& [itemId, itemData] : itemDataMap)
+    {
+        AddItemData(itemData);
     }
     
     _initialized = true;
@@ -57,51 +46,6 @@ void ItemManager::Shutdown()
     _initialized = false;
     
     GConsoleLogger->WriteStdOut(Color::GREEN, L"ItemManager: Shutdown complete.\n");
-}
-
-std::future<bool> ItemManager::LoadAllItemDataAsync()
-{
-    return DbDispatcher::EnqueueRet([this](DBConnection& c) {
-        LoadAllItemData_DB(c);
-        return true;
-    });
-}
-
-void ItemManager::LoadAllItemData_DB(DBConnection& conn)
-{
-    GConsoleLogger->WriteStdOut(Color::YELLOW, L"ItemManager: Loading items from database...\n");
-    
-    // inventory-test-data.sql 파일의 데이터와 동일하게 로드
-    _itemDataMap.clear();
-    
-    // 소비형 아이템 (포션류) - itemType 1 = ITEM_TYPE_CONSUMABLE
-    //AddItemData(ItemData{1, "체력 회복 포션", "HP를 50 회복시킵니다.", true, 99, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //AddItemData(ItemData{2, "마나 회복 포션", "MP를 30 회복시킵니다.", true, 99, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //AddItemData(ItemData{3, "고급 체력 포션", "HP를 100 회복시킵니다.", true, 50, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //AddItemData(ItemData{4, "전투 자극제", "공격력을 일시적으로 증가시킵니다.", true, 20, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //AddItemData(ItemData{5, "방어 물약", "방어력을 일시적으로 증가시킵니다.", true, 20, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //
-    //// 장비 아이템 - itemType 2 = ITEM_TYPE_EQUIPMENT
-    //AddItemData(ItemData{10, "초보자 검", "새로운 모험가를 위한 기본 검입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_EQUIPMENT});
-    //AddItemData(ItemData{11, "철검", "튼튼한 철로 제작된 검입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_EQUIPMENT});
-    //AddItemData(ItemData{12, "은검", "아름다운 은으로 제작된 검입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_EQUIPMENT});
-    //AddItemData(ItemData{13, "가죽 갑옷", "기본적인 방어력을 제공하는 가죽 갑옷입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_EQUIPMENT});
-    //AddItemData(ItemData{14, "철갑옷", "높은 방어력을 자랑하는 철갑옷입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_EQUIPMENT});
-    //AddItemData(ItemData{15, "마법 방패", "마법 공격을 막아주는 신비한 방패입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_EQUIPMENT});
-    //
-    //// 퀘스트 아이템 - itemType 3 = ITEM_TYPE_QUEST  
-    //AddItemData(ItemData{20, "잃어버린 편지", "중요한 내용이 담긴 편지입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_QUEST});
-    //AddItemData(ItemData{21, "고대 유물 조각", "고대 문명의 흔적이 담긴 신비한 조각입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_QUEST});
-    //AddItemData(ItemData{22, "수상한 열쇠", "어떤 문을 열 수 있을지 모르는 열쇠입니다.", false, 1, Protocol::EItemType::ITEM_TYPE_QUEST});
-    //
-    //// 기타 아이템 - itemType 4로 가정 (ITEM_TYPE_MISC 없으면 ITEM_TYPE_CONSUMABLE 사용)
-    //AddItemData(ItemData{30, "마을 귀환 주문서", "마을로 순간이동할 수 있는 주문서입니다.", true, 10, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //AddItemData(ItemData{31, "던전 입장권", "특별한 던전에 입장할 수 있는 티켓입니다.", true, 5, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //AddItemData(ItemData{32, "경험치 북", "사용하면 경험치를 획득할 수 있습니다.", true, 20, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //AddItemData(ItemData{33, "금화 주머니", "소량의 금화가 들어있는 주머니입니다.", true, 99, Protocol::EItemType::ITEM_TYPE_CONSUMABLE});
-    //
-    GConsoleLogger->WriteStdOut(Color::GREEN, L"ItemManager: Loaded %d items from database.\n", 
-                               static_cast<int>(_itemDataMap.size()));
 }
 
 const ItemData* ItemManager::GetItemData(int itemId) const
@@ -143,7 +87,7 @@ bool ItemManager::CanUseItem(int itemId) const
     return data->itemType == Protocol::EItemType::ITEM_TYPE_CONSUMABLE;
 }
 
-void ItemManager::ApplyItemEffect(int itemId, int count, Player* player)
+void ItemManager::ApplyItemEffect(int itemId, int count, PlayerRef player)
 {
     if (!player)
         return;
@@ -155,16 +99,12 @@ void ItemManager::ApplyItemEffect(int itemId, int count, Player* player)
     // 아이템 종류별 효과 적용
     switch (itemId)
     {
-        case 1: // Health Potion
-        case 5: // Super Health Potion  
+        case 10001: // Health Potion
+        case 10002: // 고급 Health Potion  
             ApplyHealthPotionEffect(itemId, count, player);
             break;
             
-        case 2: // Mana Potion
-            ApplyManaPotionEffect(itemId, count, player);
-            break;
-            
-        default:
+        [[unlikely]] default:
             GConsoleLogger->WriteStdOut(Color::YELLOW, L"ItemManager: No effect defined for item %d\n", itemId);
             break;
     }
@@ -205,17 +145,17 @@ size_t ItemManager::GetItemCount() const
 }
 
 // Private helper functions
-void ItemManager::ApplyHealthPotionEffect(int itemId, int count, Player* player)
+void ItemManager::ApplyHealthPotionEffect(int itemId, int count, PlayerRef player)
 {
     int healAmount = 0;
     
     switch (itemId)
     {
-        case 1: // Health Potion
-            healAmount = 50 * count;
+        case 10001: // Health Potion
+            healAmount = 30 * count;
             break;
-        case 5: // Super Health Potion
-            healAmount = 100 * count;
+        case 10002: // 고급 Health Potion
+            healAmount = 50 * count;
             break;
         default:
             return;
@@ -223,16 +163,16 @@ void ItemManager::ApplyHealthPotionEffect(int itemId, int count, Player* player)
     
     // 현재 HP에 회복량 추가 (최대 HP를 넘지 않도록)
     int currentHp = player->Hp();
-    int maxHp = player->_maxHp; // TODO: 나중에 getter로 변경
+    int maxHp = player->MaxHp();
     int newHp = std::min(currentHp + healAmount, maxHp);
     
-    player->_hp = newHp; // TODO: 나중에 setter로 변경
+    player->SetHp(newHp);
     
     GConsoleLogger->WriteStdOut(Color::GREEN, L"Player healed for %d HP (from %d to %d)\n", 
                                healAmount, currentHp, newHp);
 }
 
-void ItemManager::ApplyManaPotionEffect(int itemId, int count, Player* player)
+void ItemManager::ApplyManaPotionEffect(int itemId, int count, PlayerRef player)
 {
     // TODO: MP 시스템이 구현되면 활성화
     int manaAmount = 30 * count;

--- a/GameServer/ItemManager.h
+++ b/GameServer/ItemManager.h
@@ -1,6 +1,8 @@
-#pragma once
+﻿#pragma once
 #include "InventoryCore.h"
 #include "DBDisPatcher.h"
+
+#include "ItemDataParser.h"
 #include <unordered_map>
 #include <memory>
 #include <future>
@@ -15,10 +17,6 @@ public:
     bool Initialize();
     void Shutdown();
     
-    // 아이템 데이터 로딩
-    std::future<bool> LoadAllItemDataAsync();
-    void LoadAllItemData_DB(DBConnection& conn);
-    
     // 아이템 데이터 조회
     const ItemData* GetItemData(int itemId) const;
     bool IsValidItem(int itemId) const;
@@ -28,9 +26,9 @@ public:
     
     // 아이템 효과 처리
     bool CanUseItem(int itemId) const;
-    void ApplyItemEffect(int itemId, int count, class Player* player);
+    void ApplyItemEffect(int itemId, int count, PlayerRef player);
     
-    // 디버그 및 관리
+    // 디버그 및 관리 
     void AddItemData(const ItemData& itemData);
     void RemoveItemData(int itemId);
     void PrintAllItems() const;
@@ -45,8 +43,8 @@ private:
     ItemManager& operator=(const ItemManager&) = delete;
     
     // 아이템 효과 적용 헬퍼
-    void ApplyHealthPotionEffect(int itemId, int count, Player* player);
-    void ApplyManaPotionEffect(int itemId, int count, Player* player);
+    void ApplyHealthPotionEffect(int itemId, int count, PlayerRef player);
+    void ApplyManaPotionEffect(int itemId, int count, PlayerRef player);
     
 private:
     std::unordered_map<int, std::unique_ptr<ItemData>> _itemDataMap;

--- a/GameServer/JsonDataParser.cpp
+++ b/GameServer/JsonDataParser.cpp
@@ -1,4 +1,4 @@
-#include "pch.h"
+﻿#include "pch.h"
 #include "JsonDataParser.h"
 #include <iostream>
 
@@ -96,4 +96,28 @@ std::string JsonDataParser::SafeGetString(const rapidjson::Value& value, const s
     }
 
     return field.GetString();
+}
+
+bool JsonDataParser::SafeGetBool(const rapidjson::Value& value, const std::string& fieldName)
+{
+    if (!value.HasMember(fieldName.c_str()))
+    {
+        throw std::runtime_error("JSON에서 필수 필드를 찾을 수 없습니다. " + fieldName);
+    }
+
+    const auto& field = value[fieldName.c_str()];
+
+    if (!field.IsString())
+    {
+        throw std::runtime_error("잘못된 데이터 타입 (필드: " + fieldName + ", 문자열이 아님)");
+    }
+
+    auto fieldStr = static_cast<string>(field.GetString());
+
+    if(fieldStr == "TRUE") 
+        return true;
+    else if(fieldStr == "FALSE") 
+        return false;
+    else 
+        throw std::runtime_error("TRUE혹은 FASLE값이 아님 :" + string(fieldStr));
 }

--- a/GameServer/JsonDataParser.h
+++ b/GameServer/JsonDataParser.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <rapidjson/document.h>
 #include <rapidjson/filereadstream.h>
@@ -95,4 +95,9 @@ public:
      * JSON Value에서 문자열을 안전하게 추출
      */
     static std::string SafeGetString(const rapidjson::Value& value, const std::string& fieldName);
+
+    /**
+     * JSON Value에서 Bool 값 안전하게 추출
+     */
+    static bool SafeGetBool(const rapidjson::Value& value, const std::string& fieldName);
 };

--- a/GameServer/Player.h
+++ b/GameServer/Player.h
@@ -5,6 +5,7 @@
 #include "CharacterRepository.h"
 #include "InventorySystem.h"
 #include "InventoryRepository.h"
+#include "ItemManager.h"
 class Room; // 전방 선언
 
 struct PendingRoomChange {
@@ -150,6 +151,12 @@ public:
 			SaveSlotToDB(slotIndex);
 		}
 		return result;
+	}
+
+	// 아이템 사용을 위한 헬퍼 함수 (아이템 정보 반환)
+	int GetItemIdFromSlot(int slotIndex) const {
+		const ItemSlot& slot = _inventory.GetSlot(slotIndex);
+		return slot.IsEmpty() ? 0 : slot.itemId;
 	}
 
 private:

--- a/GameServer/Protocol.pb.cc
+++ b/GameServer/Protocol.pb.cc
@@ -648,6 +648,35 @@ struct S_BroadcastPlayerChatDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 S_BroadcastPlayerChatDefaultTypeInternal _S_BroadcastPlayerChat_default_instance_;
+PROTOBUF_CONSTEXPR C_GiveItemRequest::C_GiveItemRequest(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.itemid_)*/0
+  , /*decltype(_impl_.count_)*/0
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct C_GiveItemRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR C_GiveItemRequestDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~C_GiveItemRequestDefaultTypeInternal() {}
+  union {
+    C_GiveItemRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 C_GiveItemRequestDefaultTypeInternal _C_GiveItemRequest_default_instance_;
+PROTOBUF_CONSTEXPR S_GiveItemReply::S_GiveItemReply(
+    ::_pbi::ConstantInitialized): _impl_{
+    /*decltype(_impl_.errormessage_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.addedslot_)*/nullptr
+  , /*decltype(_impl_.success_)*/false
+  , /*decltype(_impl_._cached_size_)*/{}} {}
+struct S_GiveItemReplyDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR S_GiveItemReplyDefaultTypeInternal()
+      : _instance(::_pbi::ConstantInitialized{}) {}
+  ~S_GiveItemReplyDefaultTypeInternal() {}
+  union {
+    S_GiveItemReply _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 S_GiveItemReplyDefaultTypeInternal _S_GiveItemReply_default_instance_;
 PROTOBUF_CONSTEXPR Vector2Info::Vector2Info(
     ::_pbi::ConstantInitialized): _impl_{
     /*decltype(_impl_.x_)*/0
@@ -792,7 +821,7 @@ struct PlayerChatInfoDefaultTypeInternal {
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PlayerChatInfoDefaultTypeInternal _PlayerChatInfo_default_instance_;
 }  // namespace Protocol
-static ::_pb::Metadata file_level_metadata_Protocol_2eproto[55];
+static ::_pb::Metadata file_level_metadata_Protocol_2eproto[57];
 static const ::_pb::EnumDescriptor* file_level_enum_descriptors_Protocol_2eproto[12];
 static constexpr ::_pb::ServiceDescriptor const** file_level_service_descriptors_Protocol_2eproto = nullptr;
 
@@ -1153,6 +1182,23 @@ const uint32_t TableStruct_Protocol_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE
   ~0u,  // no _inlined_string_donated_
   PROTOBUF_FIELD_OFFSET(::Protocol::S_BroadcastPlayerChat, _impl_.playerchatinfos_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::Protocol::C_GiveItemRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::Protocol::C_GiveItemRequest, _impl_.itemid_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::C_GiveItemRequest, _impl_.count_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_GiveItemReply, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _inlined_string_donated_
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_GiveItemReply, _impl_.success_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_GiveItemReply, _impl_.errormessage_),
+  PROTOBUF_FIELD_OFFSET(::Protocol::S_GiveItemReply, _impl_.addedslot_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::Protocol::Vector2Info, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -1290,15 +1336,17 @@ static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protode
   { 333, -1, -1, sizeof(::Protocol::S_BroadcastPlayerDeath)},
   { 341, -1, -1, sizeof(::Protocol::C_PlayerChat)},
   { 348, -1, -1, sizeof(::Protocol::S_BroadcastPlayerChat)},
-  { 355, -1, -1, sizeof(::Protocol::Vector2Info)},
-  { 363, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
-  { 373, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
-  { 383, -1, -1, sizeof(::Protocol::PlayerInfo)},
-  { 393, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
-  { 403, -1, -1, sizeof(::Protocol::MonsterInfo)},
-  { 413, -1, -1, sizeof(::Protocol::ShopItemInfo)},
-  { 422, -1, -1, sizeof(::Protocol::PlayerStatInfo)},
-  { 434, -1, -1, sizeof(::Protocol::PlayerChatInfo)},
+  { 355, -1, -1, sizeof(::Protocol::C_GiveItemRequest)},
+  { 363, -1, -1, sizeof(::Protocol::S_GiveItemReply)},
+  { 372, -1, -1, sizeof(::Protocol::Vector2Info)},
+  { 380, -1, -1, sizeof(::Protocol::PlayerMoveInfo)},
+  { 390, -1, -1, sizeof(::Protocol::CharacterSummaryInfo)},
+  { 400, -1, -1, sizeof(::Protocol::PlayerInfo)},
+  { 410, -1, -1, sizeof(::Protocol::InventorySlotInfo)},
+  { 420, -1, -1, sizeof(::Protocol::MonsterInfo)},
+  { 430, -1, -1, sizeof(::Protocol::ShopItemInfo)},
+  { 439, -1, -1, sizeof(::Protocol::PlayerStatInfo)},
+  { 451, -1, -1, sizeof(::Protocol::PlayerChatInfo)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -1348,6 +1396,8 @@ static const ::_pb::Message* const file_default_instances[] = {
   &::Protocol::_S_BroadcastPlayerDeath_default_instance_._instance,
   &::Protocol::_C_PlayerChat_default_instance_._instance,
   &::Protocol::_S_BroadcastPlayerChat_default_instance_._instance,
+  &::Protocol::_C_GiveItemRequest_default_instance_._instance,
+  &::Protocol::_S_GiveItemReply_default_instance_._instance,
   &::Protocol::_Vector2Info_default_instance_._instance,
   &::Protocol::_PlayerMoveInfo_default_instance_._instance,
   &::Protocol::_CharacterSummaryInfo_default_instance_._instance,
@@ -1435,91 +1485,96 @@ const char descriptor_table_protodef_Protocol_2eproto[] PROTOBUF_SECTION_VARIABL
   "(\005\"@\n\014C_PlayerChat\0220\n\016playerChatInfo\030\001 \001"
   "(\0132\030.Protocol.PlayerChatInfo\"J\n\025S_Broadc"
   "astPlayerChat\0221\n\017playerChatInfos\030\001 \003(\0132\030"
-  ".Protocol.PlayerChatInfo\"#\n\013Vector2Info\022"
-  "\t\n\001x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\"\231\001\n\016PlayerMoveInfo"
-  "\022\020\n\010playerId\030\001 \001(\005\022\'\n\tdirection\030\002 \001(\0162\024."
-  "Protocol.EDirection\022%\n\006newPos\030\003 \001(\0132\025.Pr"
-  "otocol.Vector2Info\022%\n\006result\030\004 \001(\0162\025.Pro"
-  "tocol.EMoveResult\"}\n\024CharacterSummaryInf"
-  "o\022\020\n\010username\030\001 \001(\t\022\r\n\005level\030\002 \001(\005\022!\n\006ge"
-  "nder\030\003 \001(\0162\021.Protocol.EGender\022!\n\006region\030"
-  "\004 \001(\0162\021.Protocol.ERegion\"w\n\nPlayerInfo\022\n"
-  "\n\002id\030\001 \001(\005\022\020\n\010username\030\002 \001(\t\022\"\n\003pos\030\003 \001("
-  "\0132\025.Protocol.Vector2Info\022\'\n\tdirection\030\004 "
-  "\001(\0162\024.Protocol.EDirection\"Z\n\021InventorySl"
-  "otInfo\022\021\n\tslotIndex\030\001 \001(\005\022\016\n\006itemId\030\002 \001("
-  "\005\022\r\n\005count\030\003 \001(\005\022\023\n\013isQuickslot\030\004 \001(\010\"\204\001"
-  "\n\013MonsterInfo\022\021\n\tmonsterId\030\001 \001(\005\022\025\n\rmons"
-  "terTypeId\030\002 \001(\005\022\"\n\003pos\030\003 \001(\0132\025.Protocol."
-  "Vector2Info\022\'\n\tdirection\030\004 \001(\0162\024.Protoco"
-  "l.EDirection\"\?\n\014ShopItemInfo\022\016\n\006itemId\030\001"
-  " \001(\005\022\020\n\010quantity\030\002 \001(\005\022\r\n\005price\030\003 \001(\005\"i\n"
-  "\016PlayerStatInfo\022\r\n\005maxHp\030\001 \001(\005\022\n\n\002hp\030\002 \001"
-  "(\005\022\016\n\006curExp\030\003 \001(\005\022\016\n\006maxExp\030\004 \001(\005\022\r\n\005le"
-  "vel\030\005 \001(\005\022\r\n\005money\030\006 \001(\005\"\204\001\n\016PlayerChatI"
-  "nfo\022\024\n\nNonePlayer\030\001 \001(\010H\000\022\022\n\010playerId\030\002 "
-  "\001(\005H\000\022\017\n\007message\030\003 \001(\t\022%\n\010chatType\030\004 \001(\016"
-  "2\023.Protocol.EChatTypeB\020\n\016playerIncluded*"
-  "\256\t\n\005MsgId\022\027\n\023C_JWT_LOGIN_REQUEST\020\000\022\025\n\021S_"
-  "JWT_LOGIN_REPLY\020\001\022\036\n\032C_CREATE_CHARACTER_"
-  "REQUEST\020\002\022\034\n\030S_CREATE_CHARACTER_REPLY\020\003\022"
-  "\034\n\030C_CHARACTER_LIST_REQUEST\020\004\022\032\n\026S_CHARA"
-  "CTER_LIST_REPLY\020\005\022\036\n\032C_DELETE_CHARACTER_"
-  "REQUEST\020\006\022\034\n\030S_DELETE_CHARACTER_REPLY\020\007\022"
-  "\020\n\014C_ENTER_GAME\020\010\022\020\n\014S_ENTER_GAME\020\t\022\021\n\rS"
-  "_PLAYER_LIST\020\n\022\034\n\030S_BROADCAST_PLAYER_ENT"
-  "ER\020\013\022\020\n\014C_LEAVE_GAME\020\014\022\020\n\014S_LEAVE_GAME\020\r"
-  "\022\034\n\030S_BROADCAST_PLAYER_LEAVE\020\016\022\031\n\025C_PLAY"
-  "ER_MOVE_REQUEST\020\017\022\027\n\023S_PLAYER_MOVE_REPLY"
-  "\020\020\022\033\n\027S_BROADCAST_PLAYER_MOVE\020\021\022\027\n\023S_CHA"
-  "NGE_ROOM_BEGIN\020\022\022\027\n\023C_CHANGE_ROOM_READY\020"
-  "\023\022\030\n\024S_CHANGE_ROOM_COMMIT\020\024\022\023\n\017S_SPAWN_M"
-  "ONSTER\020\025\022\025\n\021S_DESPAWN_MONSTER\020\026\022\034\n\030S_BRO"
-  "ADCAST_MONSTER_MOVE\020\027\022\036\n\032S_BROADCAST_MON"
-  "STER_ATTACK\020\030\022\035\n\031S_BROADCAST_MONSTER_DEA"
-  "TH\020\031\022\033\n\027C_PLAYER_ATTACK_REQUEST\020\032\022\035\n\031S_B"
-  "ROADCAST_PLAYER_ATTACK\020\033\022\027\n\023C_INVENTORY_"
-  "REQUEST\020\034\022\025\n\021S_INVENTORY_REPLY\020\035\022\026\n\022C_IT"
-  "EM_USE_REQUEST\020\036\022\024\n\020S_ITEM_USE_REPLY\020\037\022\026"
-  "\n\022S_INVENTORY_UPDATE\020 \022\024\n\020S_SYSTEM_MESSA"
-  "GE\020!\022\022\n\016S_MONSTER_LIST\020\"\022\032\n\026C_NPC_INTERA"
-  "CT_REQUEST\020#\022\030\n\024S_NPC_INTERACT_REPLY\020$\022\023"
-  "\n\017S_NPC_SHOP_OPEN\020%\022\032\n\026C_NPC_SHOP_BUY_RE"
-  "QUEST\020&\022\030\n\024S_NPC_SHOP_BUY_REPLY\020\'\022\021\n\rS_P"
-  "LAYER_STAT\020(\022!\n\035S_BROADCAST_PLAYER_TRY_A"
-  "TTACK\020)\022!\n\035S_BROADCAST_PLAYER_HP_CHANGED"
-  "\020*\022\034\n\030S_BROADCAST_PLAYER_DEATH\020+\022\021\n\rC_PL"
-  "AYER_CHAT\020,\022\033\n\027S_BROADCAST_PLAYER_CHAT\020-"
-  "*S\n\014ELoginResult\022\013\n\007SUCCESS\020\000\022\021\n\rINVALID"
-  "_TOKEN\020\001\022\021\n\rTOKEN_EXPIRED\020\002\022\020\n\014SERVER_ER"
-  "ROR\020\003*>\n\007EGender\022\017\n\013GENDER_NONE\020\000\022\017\n\013GEN"
-  "DER_MALE\020\001\022\021\n\rGENDER_FEMALE\020\002*:\n\007ERegion"
-  "\022\017\n\013REGION_NONE\020\000\022\r\n\tREGION_GO\020\001\022\017\n\013REGI"
-  "ON_BACK\020\002*C\n\nEDirection\022\n\n\006DIR_UP\020\000\022\014\n\010D"
-  "IR_DOWN\020\001\022\014\n\010DIR_LEFT\020\002\022\r\n\tDIR_RIGHT\020\003*|"
-  "\n\014ELeaveReason\022\021\n\rLEAVE_UNKNOWN\020\000\022\020\n\014LEA"
-  "VE_LOGOUT\020\001\022\025\n\021LEAVE_CHANGE_ROOM\020\002\022\032\n\026LE"
-  "AVE_CHANGE_CHARACTER\020\003\022\024\n\020LEAVE_DISCONNE"
-  "CT\020\004*_\n\013EMoveResult\022\020\n\014MOVE_UNKNOWN\020\000\022\013\n"
-  "\007MOVE_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_COOLDOW"
-  "N\020\003\022\020\n\014MOVE_BLOCKED\020\004*I\n\014EEnterReason\022\021\n"
-  "\rENTER_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022\025\n\021ENT"
-  "ER_CHANGE_ROOM\020\002*9\n\016EDespawnReason\022\023\n\017DE"
-  "SPAWN_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020\001*~\n\tE"
-  "ItemType\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n\024ITEM_"
-  "TYPE_CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQUIPMENT"
-  "\020\002\022\023\n\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TYPE_MIS"
-  "C\020\004*a\n\014EMessageType\022\020\n\014MESSAGE_INFO\020\000\022\023\n"
-  "\017MESSAGE_WARNING\020\001\022\021\n\rMESSAGE_ERROR\020\002\022\027\n"
-  "\023MESSAGE_DROP_FAILED\020\003*(\n\tEChatType\022\r\n\tC"
-  "HAT_ROOM\020\000\022\014\n\010CHAT_ALL\020\001B\033\252\002\030Google.Prot"
-  "obuf.Protocolb\006proto3"
+  ".Protocol.PlayerChatInfo\"2\n\021C_GiveItemRe"
+  "quest\022\016\n\006itemId\030\001 \001(\005\022\r\n\005count\030\002 \001(\005\"h\n\017"
+  "S_GiveItemReply\022\017\n\007success\030\001 \001(\010\022\024\n\014erro"
+  "rMessage\030\002 \001(\t\022.\n\taddedSlot\030\003 \001(\0132\033.Prot"
+  "ocol.InventorySlotInfo\"#\n\013Vector2Info\022\t\n"
+  "\001x\030\001 \001(\005\022\t\n\001y\030\002 \001(\005\"\231\001\n\016PlayerMoveInfo\022\020"
+  "\n\010playerId\030\001 \001(\005\022\'\n\tdirection\030\002 \001(\0162\024.Pr"
+  "otocol.EDirection\022%\n\006newPos\030\003 \001(\0132\025.Prot"
+  "ocol.Vector2Info\022%\n\006result\030\004 \001(\0162\025.Proto"
+  "col.EMoveResult\"}\n\024CharacterSummaryInfo\022"
+  "\020\n\010username\030\001 \001(\t\022\r\n\005level\030\002 \001(\005\022!\n\006gend"
+  "er\030\003 \001(\0162\021.Protocol.EGender\022!\n\006region\030\004 "
+  "\001(\0162\021.Protocol.ERegion\"w\n\nPlayerInfo\022\n\n\002"
+  "id\030\001 \001(\005\022\020\n\010username\030\002 \001(\t\022\"\n\003pos\030\003 \001(\0132"
+  "\025.Protocol.Vector2Info\022\'\n\tdirection\030\004 \001("
+  "\0162\024.Protocol.EDirection\"Z\n\021InventorySlot"
+  "Info\022\021\n\tslotIndex\030\001 \001(\005\022\016\n\006itemId\030\002 \001(\005\022"
+  "\r\n\005count\030\003 \001(\005\022\023\n\013isQuickslot\030\004 \001(\010\"\204\001\n\013"
+  "MonsterInfo\022\021\n\tmonsterId\030\001 \001(\005\022\025\n\rmonste"
+  "rTypeId\030\002 \001(\005\022\"\n\003pos\030\003 \001(\0132\025.Protocol.Ve"
+  "ctor2Info\022\'\n\tdirection\030\004 \001(\0162\024.Protocol."
+  "EDirection\"\?\n\014ShopItemInfo\022\016\n\006itemId\030\001 \001"
+  "(\005\022\020\n\010quantity\030\002 \001(\005\022\r\n\005price\030\003 \001(\005\"i\n\016P"
+  "layerStatInfo\022\r\n\005maxHp\030\001 \001(\005\022\n\n\002hp\030\002 \001(\005"
+  "\022\016\n\006curExp\030\003 \001(\005\022\016\n\006maxExp\030\004 \001(\005\022\r\n\005leve"
+  "l\030\005 \001(\005\022\r\n\005money\030\006 \001(\005\"\204\001\n\016PlayerChatInf"
+  "o\022\024\n\nNonePlayer\030\001 \001(\010H\000\022\022\n\010playerId\030\002 \001("
+  "\005H\000\022\017\n\007message\030\003 \001(\t\022%\n\010chatType\030\004 \001(\0162\023"
+  ".Protocol.EChatTypeB\020\n\016playerIncluded*\336\t"
+  "\n\005MsgId\022\027\n\023C_JWT_LOGIN_REQUEST\020\000\022\025\n\021S_JW"
+  "T_LOGIN_REPLY\020\001\022\036\n\032C_CREATE_CHARACTER_RE"
+  "QUEST\020\002\022\034\n\030S_CREATE_CHARACTER_REPLY\020\003\022\034\n"
+  "\030C_CHARACTER_LIST_REQUEST\020\004\022\032\n\026S_CHARACT"
+  "ER_LIST_REPLY\020\005\022\036\n\032C_DELETE_CHARACTER_RE"
+  "QUEST\020\006\022\034\n\030S_DELETE_CHARACTER_REPLY\020\007\022\020\n"
+  "\014C_ENTER_GAME\020\010\022\020\n\014S_ENTER_GAME\020\t\022\021\n\rS_P"
+  "LAYER_LIST\020\n\022\034\n\030S_BROADCAST_PLAYER_ENTER"
+  "\020\013\022\020\n\014C_LEAVE_GAME\020\014\022\020\n\014S_LEAVE_GAME\020\r\022\034"
+  "\n\030S_BROADCAST_PLAYER_LEAVE\020\016\022\031\n\025C_PLAYER"
+  "_MOVE_REQUEST\020\017\022\027\n\023S_PLAYER_MOVE_REPLY\020\020"
+  "\022\033\n\027S_BROADCAST_PLAYER_MOVE\020\021\022\027\n\023S_CHANG"
+  "E_ROOM_BEGIN\020\022\022\027\n\023C_CHANGE_ROOM_READY\020\023\022"
+  "\030\n\024S_CHANGE_ROOM_COMMIT\020\024\022\023\n\017S_SPAWN_MON"
+  "STER\020\025\022\025\n\021S_DESPAWN_MONSTER\020\026\022\034\n\030S_BROAD"
+  "CAST_MONSTER_MOVE\020\027\022\036\n\032S_BROADCAST_MONST"
+  "ER_ATTACK\020\030\022\035\n\031S_BROADCAST_MONSTER_DEATH"
+  "\020\031\022\033\n\027C_PLAYER_ATTACK_REQUEST\020\032\022\035\n\031S_BRO"
+  "ADCAST_PLAYER_ATTACK\020\033\022\027\n\023C_INVENTORY_RE"
+  "QUEST\020\034\022\025\n\021S_INVENTORY_REPLY\020\035\022\026\n\022C_ITEM"
+  "_USE_REQUEST\020\036\022\024\n\020S_ITEM_USE_REPLY\020\037\022\026\n\022"
+  "S_INVENTORY_UPDATE\020 \022\024\n\020S_SYSTEM_MESSAGE"
+  "\020!\022\022\n\016S_MONSTER_LIST\020\"\022\032\n\026C_NPC_INTERACT"
+  "_REQUEST\020#\022\030\n\024S_NPC_INTERACT_REPLY\020$\022\023\n\017"
+  "S_NPC_SHOP_OPEN\020%\022\032\n\026C_NPC_SHOP_BUY_REQU"
+  "EST\020&\022\030\n\024S_NPC_SHOP_BUY_REPLY\020\'\022\021\n\rS_PLA"
+  "YER_STAT\020(\022!\n\035S_BROADCAST_PLAYER_TRY_ATT"
+  "ACK\020)\022!\n\035S_BROADCAST_PLAYER_HP_CHANGED\020*"
+  "\022\034\n\030S_BROADCAST_PLAYER_DEATH\020+\022\021\n\rC_PLAY"
+  "ER_CHAT\020,\022\033\n\027S_BROADCAST_PLAYER_CHAT\020-\022\027"
+  "\n\023C_GIVE_ITEM_REQUEST\020.\022\025\n\021S_GIVE_ITEM_R"
+  "EPLY\020/*S\n\014ELoginResult\022\013\n\007SUCCESS\020\000\022\021\n\rI"
+  "NVALID_TOKEN\020\001\022\021\n\rTOKEN_EXPIRED\020\002\022\020\n\014SER"
+  "VER_ERROR\020\003*>\n\007EGender\022\017\n\013GENDER_NONE\020\000\022"
+  "\017\n\013GENDER_MALE\020\001\022\021\n\rGENDER_FEMALE\020\002*:\n\007E"
+  "Region\022\017\n\013REGION_NONE\020\000\022\r\n\tREGION_GO\020\001\022\017"
+  "\n\013REGION_BACK\020\002*C\n\nEDirection\022\n\n\006DIR_UP\020"
+  "\000\022\014\n\010DIR_DOWN\020\001\022\014\n\010DIR_LEFT\020\002\022\r\n\tDIR_RIG"
+  "HT\020\003*|\n\014ELeaveReason\022\021\n\rLEAVE_UNKNOWN\020\000\022"
+  "\020\n\014LEAVE_LOGOUT\020\001\022\025\n\021LEAVE_CHANGE_ROOM\020\002"
+  "\022\032\n\026LEAVE_CHANGE_CHARACTER\020\003\022\024\n\020LEAVE_DI"
+  "SCONNECT\020\004*_\n\013EMoveResult\022\020\n\014MOVE_UNKNOW"
+  "N\020\000\022\013\n\007MOVE_OK\020\001\022\014\n\010MOVE_DIR\020\002\022\021\n\rMOVE_C"
+  "OOLDOWN\020\003\022\020\n\014MOVE_BLOCKED\020\004*I\n\014EEnterRea"
+  "son\022\021\n\rENTER_UNKNOWN\020\000\022\017\n\013ENTER_LOGIN\020\001\022"
+  "\025\n\021ENTER_CHANGE_ROOM\020\002*9\n\016EDespawnReason"
+  "\022\023\n\017DESPAWN_UNKNOWN\020\000\022\022\n\016DESPAWN_KILLED\020"
+  "\001*~\n\tEItemType\022\025\n\021ITEM_TYPE_UNKNOWN\020\000\022\030\n"
+  "\024ITEM_TYPE_CONSUMABLE\020\001\022\027\n\023ITEM_TYPE_EQU"
+  "IPMENT\020\002\022\023\n\017ITEM_TYPE_QUEST\020\003\022\022\n\016ITEM_TY"
+  "PE_MISC\020\004*a\n\014EMessageType\022\020\n\014MESSAGE_INF"
+  "O\020\000\022\023\n\017MESSAGE_WARNING\020\001\022\021\n\rMESSAGE_ERRO"
+  "R\020\002\022\027\n\023MESSAGE_DROP_FAILED\020\003*(\n\tEChatTyp"
+  "e\022\r\n\tCHAT_ROOM\020\000\022\014\n\010CHAT_ALL\020\001B\033\252\002\030Googl"
+  "e.Protobuf.Protocolb\006proto3"
   ;
 static ::_pbi::once_flag descriptor_table_Protocol_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_Protocol_2eproto = {
-    false, false, 6141, descriptor_table_protodef_Protocol_2eproto,
+    false, false, 6347, descriptor_table_protodef_Protocol_2eproto,
     "Protocol.proto",
-    &descriptor_table_Protocol_2eproto_once, nullptr, 0, 55,
+    &descriptor_table_Protocol_2eproto_once, nullptr, 0, 57,
     schemas, file_default_instances, TableStruct_Protocol_2eproto::offsets,
     file_level_metadata_Protocol_2eproto, file_level_enum_descriptors_Protocol_2eproto,
     file_level_service_descriptors_Protocol_2eproto,
@@ -1583,6 +1638,8 @@ bool MsgId_IsValid(int value) {
     case 43:
     case 44:
     case 45:
+    case 46:
+    case 47:
       return true;
     default:
       return false;
@@ -10831,6 +10888,493 @@ void S_BroadcastPlayerChat::InternalSwap(S_BroadcastPlayerChat* other) {
 
 // ===================================================================
 
+class C_GiveItemRequest::_Internal {
+ public:
+};
+
+C_GiveItemRequest::C_GiveItemRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:Protocol.C_GiveItemRequest)
+}
+C_GiveItemRequest::C_GiveItemRequest(const C_GiveItemRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  C_GiveItemRequest* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.itemid_){}
+    , decltype(_impl_.count_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::memcpy(&_impl_.itemid_, &from._impl_.itemid_,
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.count_) -
+    reinterpret_cast<char*>(&_impl_.itemid_)) + sizeof(_impl_.count_));
+  // @@protoc_insertion_point(copy_constructor:Protocol.C_GiveItemRequest)
+}
+
+inline void C_GiveItemRequest::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.itemid_){0}
+    , decltype(_impl_.count_){0}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+}
+
+C_GiveItemRequest::~C_GiveItemRequest() {
+  // @@protoc_insertion_point(destructor:Protocol.C_GiveItemRequest)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void C_GiveItemRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+}
+
+void C_GiveItemRequest::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void C_GiveItemRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:Protocol.C_GiveItemRequest)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.itemid_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&_impl_.count_) -
+      reinterpret_cast<char*>(&_impl_.itemid_)) + sizeof(_impl_.count_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* C_GiveItemRequest::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // int32 itemId = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _impl_.itemid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // int32 count = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 16)) {
+          _impl_.count_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* C_GiveItemRequest::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:Protocol.C_GiveItemRequest)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // int32 itemId = 1;
+  if (this->_internal_itemid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteInt32ToArray(1, this->_internal_itemid(), target);
+  }
+
+  // int32 count = 2;
+  if (this->_internal_count() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteInt32ToArray(2, this->_internal_count(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:Protocol.C_GiveItemRequest)
+  return target;
+}
+
+size_t C_GiveItemRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:Protocol.C_GiveItemRequest)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // int32 itemId = 1;
+  if (this->_internal_itemid() != 0) {
+    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_itemid());
+  }
+
+  // int32 count = 2;
+  if (this->_internal_count() != 0) {
+    total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(this->_internal_count());
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData C_GiveItemRequest::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    C_GiveItemRequest::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*C_GiveItemRequest::GetClassData() const { return &_class_data_; }
+
+
+void C_GiveItemRequest::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<C_GiveItemRequest*>(&to_msg);
+  auto& from = static_cast<const C_GiveItemRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:Protocol.C_GiveItemRequest)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_itemid() != 0) {
+    _this->_internal_set_itemid(from._internal_itemid());
+  }
+  if (from._internal_count() != 0) {
+    _this->_internal_set_count(from._internal_count());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void C_GiveItemRequest::CopyFrom(const C_GiveItemRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:Protocol.C_GiveItemRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool C_GiveItemRequest::IsInitialized() const {
+  return true;
+}
+
+void C_GiveItemRequest::InternalSwap(C_GiveItemRequest* other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(C_GiveItemRequest, _impl_.count_)
+      + sizeof(C_GiveItemRequest::_impl_.count_)
+      - PROTOBUF_FIELD_OFFSET(C_GiveItemRequest, _impl_.itemid_)>(
+          reinterpret_cast<char*>(&_impl_.itemid_),
+          reinterpret_cast<char*>(&other->_impl_.itemid_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata C_GiveItemRequest::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
+      file_level_metadata_Protocol_2eproto[46]);
+}
+
+// ===================================================================
+
+class S_GiveItemReply::_Internal {
+ public:
+  static const ::Protocol::InventorySlotInfo& addedslot(const S_GiveItemReply* msg);
+};
+
+const ::Protocol::InventorySlotInfo&
+S_GiveItemReply::_Internal::addedslot(const S_GiveItemReply* msg) {
+  return *msg->_impl_.addedslot_;
+}
+S_GiveItemReply::S_GiveItemReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                         bool is_message_owned)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena, is_message_owned) {
+  SharedCtor(arena, is_message_owned);
+  // @@protoc_insertion_point(arena_constructor:Protocol.S_GiveItemReply)
+}
+S_GiveItemReply::S_GiveItemReply(const S_GiveItemReply& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  S_GiveItemReply* const _this = this; (void)_this;
+  new (&_impl_) Impl_{
+      decltype(_impl_.errormessage_){}
+    , decltype(_impl_.addedslot_){nullptr}
+    , decltype(_impl_.success_){}
+    , /*decltype(_impl_._cached_size_)*/{}};
+
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  _impl_.errormessage_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.errormessage_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_errormessage().empty()) {
+    _this->_impl_.errormessage_.Set(from._internal_errormessage(), 
+      _this->GetArenaForAllocation());
+  }
+  if (from._internal_has_addedslot()) {
+    _this->_impl_.addedslot_ = new ::Protocol::InventorySlotInfo(*from._impl_.addedslot_);
+  }
+  _this->_impl_.success_ = from._impl_.success_;
+  // @@protoc_insertion_point(copy_constructor:Protocol.S_GiveItemReply)
+}
+
+inline void S_GiveItemReply::SharedCtor(
+    ::_pb::Arena* arena, bool is_message_owned) {
+  (void)arena;
+  (void)is_message_owned;
+  new (&_impl_) Impl_{
+      decltype(_impl_.errormessage_){}
+    , decltype(_impl_.addedslot_){nullptr}
+    , decltype(_impl_.success_){false}
+    , /*decltype(_impl_._cached_size_)*/{}
+  };
+  _impl_.errormessage_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.errormessage_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+}
+
+S_GiveItemReply::~S_GiveItemReply() {
+  // @@protoc_insertion_point(destructor:Protocol.S_GiveItemReply)
+  if (auto *arena = _internal_metadata_.DeleteReturnArena<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>()) {
+  (void)arena;
+    return;
+  }
+  SharedDtor();
+}
+
+inline void S_GiveItemReply::SharedDtor() {
+  GOOGLE_DCHECK(GetArenaForAllocation() == nullptr);
+  _impl_.errormessage_.Destroy();
+  if (this != internal_default_instance()) delete _impl_.addedslot_;
+}
+
+void S_GiveItemReply::SetCachedSize(int size) const {
+  _impl_._cached_size_.Set(size);
+}
+
+void S_GiveItemReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:Protocol.S_GiveItemReply)
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.errormessage_.ClearToEmpty();
+  if (GetArenaForAllocation() == nullptr && _impl_.addedslot_ != nullptr) {
+    delete _impl_.addedslot_;
+  }
+  _impl_.addedslot_ = nullptr;
+  _impl_.success_ = false;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* S_GiveItemReply::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    uint32_t tag;
+    ptr = ::_pbi::ReadTag(ptr, &tag);
+    switch (tag >> 3) {
+      // bool success = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 8)) {
+          _impl_.success_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      // string errorMessage = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 18)) {
+          auto str = _internal_mutable_errormessage();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "Protocol.S_GiveItemReply.errorMessage"));
+        } else
+          goto handle_unusual;
+        continue;
+      // .Protocol.InventorySlotInfo addedSlot = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_addedslot(), ptr);
+          CHK_(ptr);
+        } else
+          goto handle_unusual;
+        continue;
+      default:
+        goto handle_unusual;
+    }  // switch
+  handle_unusual:
+    if ((tag == 0) || ((tag & 7) == 4)) {
+      CHK_(ptr);
+      ctx->SetLastTag(tag);
+      goto message_done;
+    }
+    ptr = UnknownFieldParse(
+        tag,
+        _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+        ptr, ctx);
+    CHK_(ptr != nullptr);
+  }  // while
+message_done:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto message_done;
+#undef CHK_
+}
+
+uint8_t* S_GiveItemReply::_InternalSerialize(
+    uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:Protocol.S_GiveItemReply)
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool success = 1;
+  if (this->_internal_success() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(1, this->_internal_success(), target);
+  }
+
+  // string errorMessage = 2;
+  if (!this->_internal_errormessage().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_errormessage().data(), static_cast<int>(this->_internal_errormessage().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "Protocol.S_GiveItemReply.errorMessage");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_errormessage(), target);
+  }
+
+  // .Protocol.InventorySlotInfo addedSlot = 3;
+  if (this->_internal_has_addedslot()) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(3, _Internal::addedslot(this),
+        _Internal::addedslot(this).GetCachedSize(), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:Protocol.S_GiveItemReply)
+  return target;
+}
+
+size_t S_GiveItemReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:Protocol.S_GiveItemReply)
+  size_t total_size = 0;
+
+  uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string errorMessage = 2;
+  if (!this->_internal_errormessage().empty()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_errormessage());
+  }
+
+  // .Protocol.InventorySlotInfo addedSlot = 3;
+  if (this->_internal_has_addedslot()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *_impl_.addedslot_);
+  }
+
+  // bool success = 1;
+  if (this->_internal_success() != 0) {
+    total_size += 1 + 1;
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData S_GiveItemReply::_class_data_ = {
+    ::PROTOBUF_NAMESPACE_ID::Message::CopyWithSourceCheck,
+    S_GiveItemReply::MergeImpl
+};
+const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*S_GiveItemReply::GetClassData() const { return &_class_data_; }
+
+
+void S_GiveItemReply::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg) {
+  auto* const _this = static_cast<S_GiveItemReply*>(&to_msg);
+  auto& from = static_cast<const S_GiveItemReply&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:Protocol.S_GiveItemReply)
+  GOOGLE_DCHECK_NE(&from, _this);
+  uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_errormessage().empty()) {
+    _this->_internal_set_errormessage(from._internal_errormessage());
+  }
+  if (from._internal_has_addedslot()) {
+    _this->_internal_mutable_addedslot()->::Protocol::InventorySlotInfo::MergeFrom(
+        from._internal_addedslot());
+  }
+  if (from._internal_success() != 0) {
+    _this->_internal_set_success(from._internal_success());
+  }
+  _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void S_GiveItemReply::CopyFrom(const S_GiveItemReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:Protocol.S_GiveItemReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool S_GiveItemReply::IsInitialized() const {
+  return true;
+}
+
+void S_GiveItemReply::InternalSwap(S_GiveItemReply* other) {
+  using std::swap;
+  auto* lhs_arena = GetArenaForAllocation();
+  auto* rhs_arena = other->GetArenaForAllocation();
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.errormessage_, lhs_arena,
+      &other->_impl_.errormessage_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(S_GiveItemReply, _impl_.success_)
+      + sizeof(S_GiveItemReply::_impl_.success_)
+      - PROTOBUF_FIELD_OFFSET(S_GiveItemReply, _impl_.addedslot_)>(
+          reinterpret_cast<char*>(&_impl_.addedslot_),
+          reinterpret_cast<char*>(&other->_impl_.addedslot_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata S_GiveItemReply::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
+      file_level_metadata_Protocol_2eproto[47]);
+}
+
+// ===================================================================
+
 class Vector2Info::_Internal {
  public:
 };
@@ -11037,7 +11581,7 @@ void Vector2Info::InternalSwap(Vector2Info* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata Vector2Info::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[46]);
+      file_level_metadata_Protocol_2eproto[48]);
 }
 
 // ===================================================================
@@ -11319,7 +11863,7 @@ void PlayerMoveInfo::InternalSwap(PlayerMoveInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PlayerMoveInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[47]);
+      file_level_metadata_Protocol_2eproto[49]);
 }
 
 // ===================================================================
@@ -11612,7 +12156,7 @@ void CharacterSummaryInfo::InternalSwap(CharacterSummaryInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata CharacterSummaryInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[48]);
+      file_level_metadata_Protocol_2eproto[50]);
 }
 
 // ===================================================================
@@ -11919,7 +12463,7 @@ void PlayerInfo::InternalSwap(PlayerInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PlayerInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[49]);
+      file_level_metadata_Protocol_2eproto[51]);
 }
 
 // ===================================================================
@@ -12178,7 +12722,7 @@ void InventorySlotInfo::InternalSwap(InventorySlotInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata InventorySlotInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[50]);
+      file_level_metadata_Protocol_2eproto[52]);
 }
 
 // ===================================================================
@@ -12457,7 +13001,7 @@ void MonsterInfo::InternalSwap(MonsterInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata MonsterInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[51]);
+      file_level_metadata_Protocol_2eproto[53]);
 }
 
 // ===================================================================
@@ -12692,7 +13236,7 @@ void ShopItemInfo::InternalSwap(ShopItemInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata ShopItemInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[52]);
+      file_level_metadata_Protocol_2eproto[54]);
 }
 
 // ===================================================================
@@ -12999,7 +13543,7 @@ void PlayerStatInfo::InternalSwap(PlayerStatInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PlayerStatInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[53]);
+      file_level_metadata_Protocol_2eproto[55]);
 }
 
 // ===================================================================
@@ -13332,7 +13876,7 @@ void PlayerChatInfo::InternalSwap(PlayerChatInfo* other) {
 ::PROTOBUF_NAMESPACE_ID::Metadata PlayerChatInfo::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_Protocol_2eproto_getter, &descriptor_table_Protocol_2eproto_once,
-      file_level_metadata_Protocol_2eproto[54]);
+      file_level_metadata_Protocol_2eproto[56]);
 }
 
 // @@protoc_insertion_point(namespace_scope)
@@ -13521,6 +14065,14 @@ Arena::CreateMaybeMessage< ::Protocol::C_PlayerChat >(Arena* arena) {
 template<> PROTOBUF_NOINLINE ::Protocol::S_BroadcastPlayerChat*
 Arena::CreateMaybeMessage< ::Protocol::S_BroadcastPlayerChat >(Arena* arena) {
   return Arena::CreateMessageInternal< ::Protocol::S_BroadcastPlayerChat >(arena);
+}
+template<> PROTOBUF_NOINLINE ::Protocol::C_GiveItemRequest*
+Arena::CreateMaybeMessage< ::Protocol::C_GiveItemRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::Protocol::C_GiveItemRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::Protocol::S_GiveItemReply*
+Arena::CreateMaybeMessage< ::Protocol::S_GiveItemReply >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::Protocol::S_GiveItemReply >(arena);
 }
 template<> PROTOBUF_NOINLINE ::Protocol::Vector2Info*
 Arena::CreateMaybeMessage< ::Protocol::Vector2Info >(Arena* arena) {

--- a/GameServer/Protocol.pb.h
+++ b/GameServer/Protocol.pb.h
@@ -62,6 +62,9 @@ extern C_DeleteCharacterRequestDefaultTypeInternal _C_DeleteCharacterRequest_def
 class C_EnterGame;
 struct C_EnterGameDefaultTypeInternal;
 extern C_EnterGameDefaultTypeInternal _C_EnterGame_default_instance_;
+class C_GiveItemRequest;
+struct C_GiveItemRequestDefaultTypeInternal;
+extern C_GiveItemRequestDefaultTypeInternal _C_GiveItemRequest_default_instance_;
 class C_InventoryRequest;
 struct C_InventoryRequestDefaultTypeInternal;
 extern C_InventoryRequestDefaultTypeInternal _C_InventoryRequest_default_instance_;
@@ -164,6 +167,9 @@ extern S_DespawnMonsterDefaultTypeInternal _S_DespawnMonster_default_instance_;
 class S_EnterGame;
 struct S_EnterGameDefaultTypeInternal;
 extern S_EnterGameDefaultTypeInternal _S_EnterGame_default_instance_;
+class S_GiveItemReply;
+struct S_GiveItemReplyDefaultTypeInternal;
+extern S_GiveItemReplyDefaultTypeInternal _S_GiveItemReply_default_instance_;
 class S_InventoryReply;
 struct S_InventoryReplyDefaultTypeInternal;
 extern S_InventoryReplyDefaultTypeInternal _S_InventoryReply_default_instance_;
@@ -219,6 +225,7 @@ template<> ::Protocol::C_CharacterListRequest* Arena::CreateMaybeMessage<::Proto
 template<> ::Protocol::C_CreateCharacterRequest* Arena::CreateMaybeMessage<::Protocol::C_CreateCharacterRequest>(Arena*);
 template<> ::Protocol::C_DeleteCharacterRequest* Arena::CreateMaybeMessage<::Protocol::C_DeleteCharacterRequest>(Arena*);
 template<> ::Protocol::C_EnterGame* Arena::CreateMaybeMessage<::Protocol::C_EnterGame>(Arena*);
+template<> ::Protocol::C_GiveItemRequest* Arena::CreateMaybeMessage<::Protocol::C_GiveItemRequest>(Arena*);
 template<> ::Protocol::C_InventoryRequest* Arena::CreateMaybeMessage<::Protocol::C_InventoryRequest>(Arena*);
 template<> ::Protocol::C_ItemUseRequest* Arena::CreateMaybeMessage<::Protocol::C_ItemUseRequest>(Arena*);
 template<> ::Protocol::C_JwtLoginRequest* Arena::CreateMaybeMessage<::Protocol::C_JwtLoginRequest>(Arena*);
@@ -253,6 +260,7 @@ template<> ::Protocol::S_CreateCharacterReply* Arena::CreateMaybeMessage<::Proto
 template<> ::Protocol::S_DeleteCharacterReply* Arena::CreateMaybeMessage<::Protocol::S_DeleteCharacterReply>(Arena*);
 template<> ::Protocol::S_DespawnMonster* Arena::CreateMaybeMessage<::Protocol::S_DespawnMonster>(Arena*);
 template<> ::Protocol::S_EnterGame* Arena::CreateMaybeMessage<::Protocol::S_EnterGame>(Arena*);
+template<> ::Protocol::S_GiveItemReply* Arena::CreateMaybeMessage<::Protocol::S_GiveItemReply>(Arena*);
 template<> ::Protocol::S_InventoryReply* Arena::CreateMaybeMessage<::Protocol::S_InventoryReply>(Arena*);
 template<> ::Protocol::S_InventoryUpdate* Arena::CreateMaybeMessage<::Protocol::S_InventoryUpdate>(Arena*);
 template<> ::Protocol::S_ItemUseReply* Arena::CreateMaybeMessage<::Protocol::S_ItemUseReply>(Arena*);
@@ -319,12 +327,14 @@ enum MsgId : int {
   S_BROADCAST_PLAYER_DEATH = 43,
   C_PLAYER_CHAT = 44,
   S_BROADCAST_PLAYER_CHAT = 45,
+  C_GIVE_ITEM_REQUEST = 46,
+  S_GIVE_ITEM_REPLY = 47,
   MsgId_INT_MIN_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::min(),
   MsgId_INT_MAX_SENTINEL_DO_NOT_USE_ = std::numeric_limits<int32_t>::max()
 };
 bool MsgId_IsValid(int value);
 constexpr MsgId MsgId_MIN = C_JWT_LOGIN_REQUEST;
-constexpr MsgId MsgId_MAX = S_BROADCAST_PLAYER_CHAT;
+constexpr MsgId MsgId_MAX = S_GIVE_ITEM_REPLY;
 constexpr int MsgId_ARRAYSIZE = MsgId_MAX + 1;
 
 const ::PROTOBUF_NAMESPACE_ID::EnumDescriptor* MsgId_descriptor();
@@ -7912,6 +7922,349 @@ class S_BroadcastPlayerChat final :
 };
 // -------------------------------------------------------------------
 
+class C_GiveItemRequest final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:Protocol.C_GiveItemRequest) */ {
+ public:
+  inline C_GiveItemRequest() : C_GiveItemRequest(nullptr) {}
+  ~C_GiveItemRequest() override;
+  explicit PROTOBUF_CONSTEXPR C_GiveItemRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  C_GiveItemRequest(const C_GiveItemRequest& from);
+  C_GiveItemRequest(C_GiveItemRequest&& from) noexcept
+    : C_GiveItemRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline C_GiveItemRequest& operator=(const C_GiveItemRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline C_GiveItemRequest& operator=(C_GiveItemRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const C_GiveItemRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const C_GiveItemRequest* internal_default_instance() {
+    return reinterpret_cast<const C_GiveItemRequest*>(
+               &_C_GiveItemRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    46;
+
+  friend void swap(C_GiveItemRequest& a, C_GiveItemRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(C_GiveItemRequest* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(C_GiveItemRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  C_GiveItemRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<C_GiveItemRequest>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const C_GiveItemRequest& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const C_GiveItemRequest& from) {
+    C_GiveItemRequest::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(C_GiveItemRequest* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "Protocol.C_GiveItemRequest";
+  }
+  protected:
+  explicit C_GiveItemRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kItemIdFieldNumber = 1,
+    kCountFieldNumber = 2,
+  };
+  // int32 itemId = 1;
+  void clear_itemid();
+  int32_t itemid() const;
+  void set_itemid(int32_t value);
+  private:
+  int32_t _internal_itemid() const;
+  void _internal_set_itemid(int32_t value);
+  public:
+
+  // int32 count = 2;
+  void clear_count();
+  int32_t count() const;
+  void set_count(int32_t value);
+  private:
+  int32_t _internal_count() const;
+  void _internal_set_count(int32_t value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:Protocol.C_GiveItemRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    int32_t itemid_;
+    int32_t count_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_Protocol_2eproto;
+};
+// -------------------------------------------------------------------
+
+class S_GiveItemReply final :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:Protocol.S_GiveItemReply) */ {
+ public:
+  inline S_GiveItemReply() : S_GiveItemReply(nullptr) {}
+  ~S_GiveItemReply() override;
+  explicit PROTOBUF_CONSTEXPR S_GiveItemReply(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  S_GiveItemReply(const S_GiveItemReply& from);
+  S_GiveItemReply(S_GiveItemReply&& from) noexcept
+    : S_GiveItemReply() {
+    *this = ::std::move(from);
+  }
+
+  inline S_GiveItemReply& operator=(const S_GiveItemReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline S_GiveItemReply& operator=(S_GiveItemReply&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetOwningArena() == from.GetOwningArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetOwningArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const S_GiveItemReply& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const S_GiveItemReply* internal_default_instance() {
+    return reinterpret_cast<const S_GiveItemReply*>(
+               &_S_GiveItemReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    47;
+
+  friend void swap(S_GiveItemReply& a, S_GiveItemReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(S_GiveItemReply* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() != nullptr &&
+        GetOwningArena() == other->GetOwningArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetOwningArena() == other->GetOwningArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(S_GiveItemReply* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetOwningArena() == other->GetOwningArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  S_GiveItemReply* New(::PROTOBUF_NAMESPACE_ID::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<S_GiveItemReply>(arena);
+  }
+  using ::PROTOBUF_NAMESPACE_ID::Message::CopyFrom;
+  void CopyFrom(const S_GiveItemReply& from);
+  using ::PROTOBUF_NAMESPACE_ID::Message::MergeFrom;
+  void MergeFrom( const S_GiveItemReply& from) {
+    S_GiveItemReply::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTOBUF_NAMESPACE_ID::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  uint8_t* _InternalSerialize(
+      uint8_t* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::PROTOBUF_NAMESPACE_ID::Arena* arena, bool is_message_owned);
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(S_GiveItemReply* other);
+
+  private:
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "Protocol.S_GiveItemReply";
+  }
+  protected:
+  explicit S_GiveItemReply(::PROTOBUF_NAMESPACE_ID::Arena* arena,
+                       bool is_message_owned = false);
+  public:
+
+  static const ClassData _class_data_;
+  const ::PROTOBUF_NAMESPACE_ID::Message::ClassData*GetClassData() const final;
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kErrorMessageFieldNumber = 2,
+    kAddedSlotFieldNumber = 3,
+    kSuccessFieldNumber = 1,
+  };
+  // string errorMessage = 2;
+  void clear_errormessage();
+  const std::string& errormessage() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_errormessage(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_errormessage();
+  PROTOBUF_NODISCARD std::string* release_errormessage();
+  void set_allocated_errormessage(std::string* errormessage);
+  private:
+  const std::string& _internal_errormessage() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_errormessage(const std::string& value);
+  std::string* _internal_mutable_errormessage();
+  public:
+
+  // .Protocol.InventorySlotInfo addedSlot = 3;
+  bool has_addedslot() const;
+  private:
+  bool _internal_has_addedslot() const;
+  public:
+  void clear_addedslot();
+  const ::Protocol::InventorySlotInfo& addedslot() const;
+  PROTOBUF_NODISCARD ::Protocol::InventorySlotInfo* release_addedslot();
+  ::Protocol::InventorySlotInfo* mutable_addedslot();
+  void set_allocated_addedslot(::Protocol::InventorySlotInfo* addedslot);
+  private:
+  const ::Protocol::InventorySlotInfo& _internal_addedslot() const;
+  ::Protocol::InventorySlotInfo* _internal_mutable_addedslot();
+  public:
+  void unsafe_arena_set_allocated_addedslot(
+      ::Protocol::InventorySlotInfo* addedslot);
+  ::Protocol::InventorySlotInfo* unsafe_arena_release_addedslot();
+
+  // bool success = 1;
+  void clear_success();
+  bool success() const;
+  void set_success(bool value);
+  private:
+  bool _internal_success() const;
+  void _internal_set_success(bool value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:Protocol.S_GiveItemReply)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  struct Impl_ {
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr errormessage_;
+    ::Protocol::InventorySlotInfo* addedslot_;
+    bool success_;
+    mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_Protocol_2eproto;
+};
+// -------------------------------------------------------------------
+
 class Vector2Info final :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:Protocol.Vector2Info) */ {
  public:
@@ -7960,7 +8313,7 @@ class Vector2Info final :
                &_Vector2Info_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    46;
+    48;
 
   friend void swap(Vector2Info& a, Vector2Info& b) {
     a.Swap(&b);
@@ -8119,7 +8472,7 @@ class PlayerMoveInfo final :
                &_PlayerMoveInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    47;
+    49;
 
   friend void swap(PlayerMoveInfo& a, PlayerMoveInfo& b) {
     a.Swap(&b);
@@ -8309,7 +8662,7 @@ class CharacterSummaryInfo final :
                &_CharacterSummaryInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    48;
+    50;
 
   friend void swap(CharacterSummaryInfo& a, CharacterSummaryInfo& b) {
     a.Swap(&b);
@@ -8495,7 +8848,7 @@ class PlayerInfo final :
                &_PlayerInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    49;
+    51;
 
   friend void swap(PlayerInfo& a, PlayerInfo& b) {
     a.Swap(&b);
@@ -8690,7 +9043,7 @@ class InventorySlotInfo final :
                &_InventorySlotInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    50;
+    52;
 
   friend void swap(InventorySlotInfo& a, InventorySlotInfo& b) {
     a.Swap(&b);
@@ -8871,7 +9224,7 @@ class MonsterInfo final :
                &_MonsterInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    51;
+    53;
 
   friend void swap(MonsterInfo& a, MonsterInfo& b) {
     a.Swap(&b);
@@ -9061,7 +9414,7 @@ class ShopItemInfo final :
                &_ShopItemInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    52;
+    54;
 
   friend void swap(ShopItemInfo& a, ShopItemInfo& b) {
     a.Swap(&b);
@@ -9231,7 +9584,7 @@ class PlayerStatInfo final :
                &_PlayerStatInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    53;
+    55;
 
   friend void swap(PlayerStatInfo& a, PlayerStatInfo& b) {
     a.Swap(&b);
@@ -9440,7 +9793,7 @@ class PlayerChatInfo final :
                &_PlayerChatInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    54;
+    56;
 
   friend void swap(PlayerChatInfo& a, PlayerChatInfo& b) {
     a.Swap(&b);
@@ -12245,6 +12598,214 @@ S_BroadcastPlayerChat::playerchatinfos() const {
 
 // -------------------------------------------------------------------
 
+// C_GiveItemRequest
+
+// int32 itemId = 1;
+inline void C_GiveItemRequest::clear_itemid() {
+  _impl_.itemid_ = 0;
+}
+inline int32_t C_GiveItemRequest::_internal_itemid() const {
+  return _impl_.itemid_;
+}
+inline int32_t C_GiveItemRequest::itemid() const {
+  // @@protoc_insertion_point(field_get:Protocol.C_GiveItemRequest.itemId)
+  return _internal_itemid();
+}
+inline void C_GiveItemRequest::_internal_set_itemid(int32_t value) {
+  
+  _impl_.itemid_ = value;
+}
+inline void C_GiveItemRequest::set_itemid(int32_t value) {
+  _internal_set_itemid(value);
+  // @@protoc_insertion_point(field_set:Protocol.C_GiveItemRequest.itemId)
+}
+
+// int32 count = 2;
+inline void C_GiveItemRequest::clear_count() {
+  _impl_.count_ = 0;
+}
+inline int32_t C_GiveItemRequest::_internal_count() const {
+  return _impl_.count_;
+}
+inline int32_t C_GiveItemRequest::count() const {
+  // @@protoc_insertion_point(field_get:Protocol.C_GiveItemRequest.count)
+  return _internal_count();
+}
+inline void C_GiveItemRequest::_internal_set_count(int32_t value) {
+  
+  _impl_.count_ = value;
+}
+inline void C_GiveItemRequest::set_count(int32_t value) {
+  _internal_set_count(value);
+  // @@protoc_insertion_point(field_set:Protocol.C_GiveItemRequest.count)
+}
+
+// -------------------------------------------------------------------
+
+// S_GiveItemReply
+
+// bool success = 1;
+inline void S_GiveItemReply::clear_success() {
+  _impl_.success_ = false;
+}
+inline bool S_GiveItemReply::_internal_success() const {
+  return _impl_.success_;
+}
+inline bool S_GiveItemReply::success() const {
+  // @@protoc_insertion_point(field_get:Protocol.S_GiveItemReply.success)
+  return _internal_success();
+}
+inline void S_GiveItemReply::_internal_set_success(bool value) {
+  
+  _impl_.success_ = value;
+}
+inline void S_GiveItemReply::set_success(bool value) {
+  _internal_set_success(value);
+  // @@protoc_insertion_point(field_set:Protocol.S_GiveItemReply.success)
+}
+
+// string errorMessage = 2;
+inline void S_GiveItemReply::clear_errormessage() {
+  _impl_.errormessage_.ClearToEmpty();
+}
+inline const std::string& S_GiveItemReply::errormessage() const {
+  // @@protoc_insertion_point(field_get:Protocol.S_GiveItemReply.errorMessage)
+  return _internal_errormessage();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void S_GiveItemReply::set_errormessage(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.errormessage_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:Protocol.S_GiveItemReply.errorMessage)
+}
+inline std::string* S_GiveItemReply::mutable_errormessage() {
+  std::string* _s = _internal_mutable_errormessage();
+  // @@protoc_insertion_point(field_mutable:Protocol.S_GiveItemReply.errorMessage)
+  return _s;
+}
+inline const std::string& S_GiveItemReply::_internal_errormessage() const {
+  return _impl_.errormessage_.Get();
+}
+inline void S_GiveItemReply::_internal_set_errormessage(const std::string& value) {
+  
+  _impl_.errormessage_.Set(value, GetArenaForAllocation());
+}
+inline std::string* S_GiveItemReply::_internal_mutable_errormessage() {
+  
+  return _impl_.errormessage_.Mutable(GetArenaForAllocation());
+}
+inline std::string* S_GiveItemReply::release_errormessage() {
+  // @@protoc_insertion_point(field_release:Protocol.S_GiveItemReply.errorMessage)
+  return _impl_.errormessage_.Release();
+}
+inline void S_GiveItemReply::set_allocated_errormessage(std::string* errormessage) {
+  if (errormessage != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.errormessage_.SetAllocated(errormessage, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.errormessage_.IsDefault()) {
+    _impl_.errormessage_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:Protocol.S_GiveItemReply.errorMessage)
+}
+
+// .Protocol.InventorySlotInfo addedSlot = 3;
+inline bool S_GiveItemReply::_internal_has_addedslot() const {
+  return this != internal_default_instance() && _impl_.addedslot_ != nullptr;
+}
+inline bool S_GiveItemReply::has_addedslot() const {
+  return _internal_has_addedslot();
+}
+inline void S_GiveItemReply::clear_addedslot() {
+  if (GetArenaForAllocation() == nullptr && _impl_.addedslot_ != nullptr) {
+    delete _impl_.addedslot_;
+  }
+  _impl_.addedslot_ = nullptr;
+}
+inline const ::Protocol::InventorySlotInfo& S_GiveItemReply::_internal_addedslot() const {
+  const ::Protocol::InventorySlotInfo* p = _impl_.addedslot_;
+  return p != nullptr ? *p : reinterpret_cast<const ::Protocol::InventorySlotInfo&>(
+      ::Protocol::_InventorySlotInfo_default_instance_);
+}
+inline const ::Protocol::InventorySlotInfo& S_GiveItemReply::addedslot() const {
+  // @@protoc_insertion_point(field_get:Protocol.S_GiveItemReply.addedSlot)
+  return _internal_addedslot();
+}
+inline void S_GiveItemReply::unsafe_arena_set_allocated_addedslot(
+    ::Protocol::InventorySlotInfo* addedslot) {
+  if (GetArenaForAllocation() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(_impl_.addedslot_);
+  }
+  _impl_.addedslot_ = addedslot;
+  if (addedslot) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:Protocol.S_GiveItemReply.addedSlot)
+}
+inline ::Protocol::InventorySlotInfo* S_GiveItemReply::release_addedslot() {
+  
+  ::Protocol::InventorySlotInfo* temp = _impl_.addedslot_;
+  _impl_.addedslot_ = nullptr;
+#ifdef PROTOBUF_FORCE_COPY_IN_RELEASE
+  auto* old =  reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(temp);
+  temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  if (GetArenaForAllocation() == nullptr) { delete old; }
+#else  // PROTOBUF_FORCE_COPY_IN_RELEASE
+  if (GetArenaForAllocation() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+#endif  // !PROTOBUF_FORCE_COPY_IN_RELEASE
+  return temp;
+}
+inline ::Protocol::InventorySlotInfo* S_GiveItemReply::unsafe_arena_release_addedslot() {
+  // @@protoc_insertion_point(field_release:Protocol.S_GiveItemReply.addedSlot)
+  
+  ::Protocol::InventorySlotInfo* temp = _impl_.addedslot_;
+  _impl_.addedslot_ = nullptr;
+  return temp;
+}
+inline ::Protocol::InventorySlotInfo* S_GiveItemReply::_internal_mutable_addedslot() {
+  
+  if (_impl_.addedslot_ == nullptr) {
+    auto* p = CreateMaybeMessage<::Protocol::InventorySlotInfo>(GetArenaForAllocation());
+    _impl_.addedslot_ = p;
+  }
+  return _impl_.addedslot_;
+}
+inline ::Protocol::InventorySlotInfo* S_GiveItemReply::mutable_addedslot() {
+  ::Protocol::InventorySlotInfo* _msg = _internal_mutable_addedslot();
+  // @@protoc_insertion_point(field_mutable:Protocol.S_GiveItemReply.addedSlot)
+  return _msg;
+}
+inline void S_GiveItemReply::set_allocated_addedslot(::Protocol::InventorySlotInfo* addedslot) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArenaForAllocation();
+  if (message_arena == nullptr) {
+    delete _impl_.addedslot_;
+  }
+  if (addedslot) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+        ::PROTOBUF_NAMESPACE_ID::Arena::InternalGetOwningArena(addedslot);
+    if (message_arena != submessage_arena) {
+      addedslot = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, addedslot, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  _impl_.addedslot_ = addedslot;
+  // @@protoc_insertion_point(field_set_allocated:Protocol.S_GiveItemReply.addedSlot)
+}
+
+// -------------------------------------------------------------------
+
 // Vector2Info
 
 // int32 x = 1;
@@ -13327,6 +13888,10 @@ inline PlayerChatInfo::PlayerIncludedCase PlayerChatInfo::playerIncluded_case() 
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/GameServer/Resources/Data/Item_data.json
+++ b/GameServer/Resources/Data/Item_data.json
@@ -1,0 +1,18 @@
+[
+  {
+    "itemId": "10001",
+    "name": "체력 포션",
+    "description": "HP를 30 회복 시킵니다.",
+    "isStackable": "TRUE",
+    "maxStack": "99",
+    "itemType": "CONSUMABLE"
+  },
+  {
+    "itemId": "10002",
+    "name": "고급 체력 포션",
+    "description": "HP를 50 회복 시킵니다.",
+    "isStackable": "TRUE",
+    "maxStack": "99",
+    "itemType": "CONSUMABLE"
+  }
+]

--- a/Protocol/Protocol.proto
+++ b/Protocol/Protocol.proto
@@ -51,6 +51,8 @@ enum MsgId
 	S_BROADCAST_PLAYER_DEATH = 43;
 	C_PLAYER_CHAT = 44;
 	S_BROADCAST_PLAYER_CHAT = 45;
+	C_GIVE_ITEM_REQUEST = 46;
+	S_GIVE_ITEM_REPLY = 47;
 }
 
 // 클라 -> 게임 서버 jwt 로그인 인증 (0)
@@ -339,7 +341,22 @@ message C_PlayerChat
 // (45) 서버 -> 클라 : S_BroadcastPlayerChat : Room-Tick마다 Server가 Player에게 모아둔 채팅 송신
 message S_BroadcastPlayerChat
 {
-	repeated PlayerChatInfo playerChatInfos = 1; 
+	repeated PlayerChatInfo playerChatInfos = 1;
+}
+
+// (46) 클라 -> 서버 : 테스트용 아이템 지급 요청
+message C_GiveItemRequest
+{
+	int32 itemId = 1;
+	int32 count = 2;
+}
+
+// (47) 서버 -> 클라 : 아이템 지급 결과 응답
+message S_GiveItemReply
+{
+	bool success = 1;
+	string errorMessage = 2;
+	InventorySlotInfo addedSlot = 3;
 }
 
 enum ELoginResult

--- a/TestClientUnity/Assets/@Scripts/Packet/ServerPacketManager.cs
+++ b/TestClientUnity/Assets/@Scripts/Packet/ServerPacketManager.cs
@@ -54,6 +54,8 @@ namespace Packet
 	    PKT_S_BroadcastPlayerDeath = 43,
 	    PKT_C_PlayerChat = 44,
 	    PKT_S_BroadcastPlayerChat = 45,
+	    PKT_C_GiveItemRequest = 46,
+	    PKT_S_GiveItemReply = 47,
     }
     public class ServerPacketManager
     {
@@ -93,6 +95,7 @@ namespace Packet
         public static ArraySegment<byte> MakeSendBuffer(C_NpcInteractRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcInteractRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_NpcShopBuyRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_NpcShopBuyRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_PlayerChat pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PlayerChat);
+        public static ArraySegment<byte> MakeSendBuffer(C_GiveItemRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_GiveItemRequest);
 
         void Register()
         {
@@ -132,6 +135,7 @@ namespace Packet
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerHpChanged, ServerPacketHandler.HANDLE_S_BroadcastPlayerHpChanged, S_BroadcastPlayerHpChanged.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerDeath, ServerPacketHandler.HANDLE_S_BroadcastPlayerDeath, S_BroadcastPlayerDeath.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPlayerChat, ServerPacketHandler.HANDLE_S_BroadcastPlayerChat, S_BroadcastPlayerChat.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_GiveItemReply, ServerPacketHandler.HANDLE_S_GiveItemReply, S_GiveItemReply.Parser);
             
                   
         }

--- a/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
+++ b/TestClientUnity/Assets/@Scripts/Protocol/Protocol.cs
@@ -91,76 +91,81 @@ namespace Google.Protobuf.Protocol {
             "KAUiQAoMQ19QbGF5ZXJDaGF0EjAKDnBsYXllckNoYXRJbmZvGAEgASgLMhgu",
             "UHJvdG9jb2wuUGxheWVyQ2hhdEluZm8iSgoVU19Ccm9hZGNhc3RQbGF5ZXJD",
             "aGF0EjEKD3BsYXllckNoYXRJbmZvcxgBIAMoCzIYLlByb3RvY29sLlBsYXll",
-            "ckNoYXRJbmZvIiMKC1ZlY3RvcjJJbmZvEgkKAXgYASABKAUSCQoBeRgCIAEo",
-            "BSKZAQoOUGxheWVyTW92ZUluZm8SEAoIcGxheWVySWQYASABKAUSJwoJZGly",
-            "ZWN0aW9uGAIgASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbhIlCgZuZXdQb3MY",
-            "AyABKAsyFS5Qcm90b2NvbC5WZWN0b3IySW5mbxIlCgZyZXN1bHQYBCABKA4y",
-            "FS5Qcm90b2NvbC5FTW92ZVJlc3VsdCJ9ChRDaGFyYWN0ZXJTdW1tYXJ5SW5m",
-            "bxIQCgh1c2VybmFtZRgBIAEoCRINCgVsZXZlbBgCIAEoBRIhCgZnZW5kZXIY",
-            "AyABKA4yES5Qcm90b2NvbC5FR2VuZGVyEiEKBnJlZ2lvbhgEIAEoDjIRLlBy",
-            "b3RvY29sLkVSZWdpb24idwoKUGxheWVySW5mbxIKCgJpZBgBIAEoBRIQCgh1",
-            "c2VybmFtZRgCIAEoCRIiCgNwb3MYAyABKAsyFS5Qcm90b2NvbC5WZWN0b3Iy",
-            "SW5mbxInCglkaXJlY3Rpb24YBCABKA4yFC5Qcm90b2NvbC5FRGlyZWN0aW9u",
-            "IloKEUludmVudG9yeVNsb3RJbmZvEhEKCXNsb3RJbmRleBgBIAEoBRIOCgZp",
-            "dGVtSWQYAiABKAUSDQoFY291bnQYAyABKAUSEwoLaXNRdWlja3Nsb3QYBCAB",
-            "KAgihAEKC01vbnN0ZXJJbmZvEhEKCW1vbnN0ZXJJZBgBIAEoBRIVCg1tb25z",
-            "dGVyVHlwZUlkGAIgASgFEiIKA3BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3Rv",
-            "cjJJbmZvEicKCWRpcmVjdGlvbhgEIAEoDjIULlByb3RvY29sLkVEaXJlY3Rp",
-            "b24iPwoMU2hvcEl0ZW1JbmZvEg4KBml0ZW1JZBgBIAEoBRIQCghxdWFudGl0",
-            "eRgCIAEoBRINCgVwcmljZRgDIAEoBSJpCg5QbGF5ZXJTdGF0SW5mbxINCgVt",
-            "YXhIcBgBIAEoBRIKCgJocBgCIAEoBRIOCgZjdXJFeHAYAyABKAUSDgoGbWF4",
-            "RXhwGAQgASgFEg0KBWxldmVsGAUgASgFEg0KBW1vbmV5GAYgASgFIoQBCg5Q",
-            "bGF5ZXJDaGF0SW5mbxIUCgpOb25lUGxheWVyGAEgASgISAASEgoIcGxheWVy",
-            "SWQYAiABKAVIABIPCgdtZXNzYWdlGAMgASgJEiUKCGNoYXRUeXBlGAQgASgO",
-            "MhMuUHJvdG9jb2wuRUNoYXRUeXBlQhAKDnBsYXllckluY2x1ZGVkKq4JCgVN",
-            "c2dJZBIXChNDX0pXVF9MT0dJTl9SRVFVRVNUEAASFQoRU19KV1RfTE9HSU5f",
-            "UkVQTFkQARIeChpDX0NSRUFURV9DSEFSQUNURVJfUkVRVUVTVBACEhwKGFNf",
-            "Q1JFQVRFX0NIQVJBQ1RFUl9SRVBMWRADEhwKGENfQ0hBUkFDVEVSX0xJU1Rf",
-            "UkVRVUVTVBAEEhoKFlNfQ0hBUkFDVEVSX0xJU1RfUkVQTFkQBRIeChpDX0RF",
-            "TEVURV9DSEFSQUNURVJfUkVRVUVTVBAGEhwKGFNfREVMRVRFX0NIQVJBQ1RF",
-            "Ul9SRVBMWRAHEhAKDENfRU5URVJfR0FNRRAIEhAKDFNfRU5URVJfR0FNRRAJ",
-            "EhEKDVNfUExBWUVSX0xJU1QQChIcChhTX0JST0FEQ0FTVF9QTEFZRVJfRU5U",
-            "RVIQCxIQCgxDX0xFQVZFX0dBTUUQDBIQCgxTX0xFQVZFX0dBTUUQDRIcChhT",
-            "X0JST0FEQ0FTVF9QTEFZRVJfTEVBVkUQDhIZChVDX1BMQVlFUl9NT1ZFX1JF",
-            "UVVFU1QQDxIXChNTX1BMQVlFUl9NT1ZFX1JFUExZEBASGwoXU19CUk9BRENB",
-            "U1RfUExBWUVSX01PVkUQERIXChNTX0NIQU5HRV9ST09NX0JFR0lOEBISFwoT",
-            "Q19DSEFOR0VfUk9PTV9SRUFEWRATEhgKFFNfQ0hBTkdFX1JPT01fQ09NTUlU",
-            "EBQSEwoPU19TUEFXTl9NT05TVEVSEBUSFQoRU19ERVNQQVdOX01PTlNURVIQ",
-            "FhIcChhTX0JST0FEQ0FTVF9NT05TVEVSX01PVkUQFxIeChpTX0JST0FEQ0FT",
-            "VF9NT05TVEVSX0FUVEFDSxAYEh0KGVNfQlJPQURDQVNUX01PTlNURVJfREVB",
-            "VEgQGRIbChdDX1BMQVlFUl9BVFRBQ0tfUkVRVUVTVBAaEh0KGVNfQlJPQURD",
-            "QVNUX1BMQVlFUl9BVFRBQ0sQGxIXChNDX0lOVkVOVE9SWV9SRVFVRVNUEBwS",
-            "FQoRU19JTlZFTlRPUllfUkVQTFkQHRIWChJDX0lURU1fVVNFX1JFUVVFU1QQ",
-            "HhIUChBTX0lURU1fVVNFX1JFUExZEB8SFgoSU19JTlZFTlRPUllfVVBEQVRF",
-            "ECASFAoQU19TWVNURU1fTUVTU0FHRRAhEhIKDlNfTU9OU1RFUl9MSVNUECIS",
-            "GgoWQ19OUENfSU5URVJBQ1RfUkVRVUVTVBAjEhgKFFNfTlBDX0lOVEVSQUNU",
-            "X1JFUExZECQSEwoPU19OUENfU0hPUF9PUEVOECUSGgoWQ19OUENfU0hPUF9C",
-            "VVlfUkVRVUVTVBAmEhgKFFNfTlBDX1NIT1BfQlVZX1JFUExZECcSEQoNU19Q",
-            "TEFZRVJfU1RBVBAoEiEKHVNfQlJPQURDQVNUX1BMQVlFUl9UUllfQVRUQUNL",
-            "ECkSIQodU19CUk9BRENBU1RfUExBWUVSX0hQX0NIQU5HRUQQKhIcChhTX0JS",
-            "T0FEQ0FTVF9QTEFZRVJfREVBVEgQKxIRCg1DX1BMQVlFUl9DSEFUECwSGwoX",
-            "U19CUk9BRENBU1RfUExBWUVSX0NIQVQQLSpTCgxFTG9naW5SZXN1bHQSCwoH",
-            "U1VDQ0VTUxAAEhEKDUlOVkFMSURfVE9LRU4QARIRCg1UT0tFTl9FWFBJUkVE",
-            "EAISEAoMU0VSVkVSX0VSUk9SEAMqPgoHRUdlbmRlchIPCgtHRU5ERVJfTk9O",
-            "RRAAEg8KC0dFTkRFUl9NQUxFEAESEQoNR0VOREVSX0ZFTUFMRRACKjoKB0VS",
-            "ZWdpb24SDwoLUkVHSU9OX05PTkUQABINCglSRUdJT05fR08QARIPCgtSRUdJ",
-            "T05fQkFDSxACKkMKCkVEaXJlY3Rpb24SCgoGRElSX1VQEAASDAoIRElSX0RP",
-            "V04QARIMCghESVJfTEVGVBACEg0KCURJUl9SSUdIVBADKnwKDEVMZWF2ZVJl",
-            "YXNvbhIRCg1MRUFWRV9VTktOT1dOEAASEAoMTEVBVkVfTE9HT1VUEAESFQoR",
-            "TEVBVkVfQ0hBTkdFX1JPT00QAhIaChZMRUFWRV9DSEFOR0VfQ0hBUkFDVEVS",
-            "EAMSFAoQTEVBVkVfRElTQ09OTkVDVBAEKl8KC0VNb3ZlUmVzdWx0EhAKDE1P",
-            "VkVfVU5LTk9XThAAEgsKB01PVkVfT0sQARIMCghNT1ZFX0RJUhACEhEKDU1P",
-            "VkVfQ09PTERPV04QAxIQCgxNT1ZFX0JMT0NLRUQQBCpJCgxFRW50ZXJSZWFz",
-            "b24SEQoNRU5URVJfVU5LTk9XThAAEg8KC0VOVEVSX0xPR0lOEAESFQoRRU5U",
-            "RVJfQ0hBTkdFX1JPT00QAio5Cg5FRGVzcGF3blJlYXNvbhITCg9ERVNQQVdO",
-            "X1VOS05PV04QABISCg5ERVNQQVdOX0tJTExFRBABKn4KCUVJdGVtVHlwZRIV",
-            "ChFJVEVNX1RZUEVfVU5LTk9XThAAEhgKFElURU1fVFlQRV9DT05TVU1BQkxF",
-            "EAESFwoTSVRFTV9UWVBFX0VRVUlQTUVOVBACEhMKD0lURU1fVFlQRV9RVUVT",
-            "VBADEhIKDklURU1fVFlQRV9NSVNDEAQqYQoMRU1lc3NhZ2VUeXBlEhAKDE1F",
-            "U1NBR0VfSU5GTxAAEhMKD01FU1NBR0VfV0FSTklORxABEhEKDU1FU1NBR0Vf",
-            "RVJST1IQAhIXChNNRVNTQUdFX0RST1BfRkFJTEVEEAMqKAoJRUNoYXRUeXBl",
-            "Eg0KCUNIQVRfUk9PTRAAEgwKCENIQVRfQUxMEAFCG6oCGEdvb2dsZS5Qcm90",
-            "b2J1Zi5Qcm90b2NvbGIGcHJvdG8z"));
+            "ckNoYXRJbmZvIjIKEUNfR2l2ZUl0ZW1SZXF1ZXN0Eg4KBml0ZW1JZBgBIAEo",
+            "BRINCgVjb3VudBgCIAEoBSJoCg9TX0dpdmVJdGVtUmVwbHkSDwoHc3VjY2Vz",
+            "cxgBIAEoCBIUCgxlcnJvck1lc3NhZ2UYAiABKAkSLgoJYWRkZWRTbG90GAMg",
+            "ASgLMhsuUHJvdG9jb2wuSW52ZW50b3J5U2xvdEluZm8iIwoLVmVjdG9yMklu",
+            "Zm8SCQoBeBgBIAEoBRIJCgF5GAIgASgFIpkBCg5QbGF5ZXJNb3ZlSW5mbxIQ",
+            "CghwbGF5ZXJJZBgBIAEoBRInCglkaXJlY3Rpb24YAiABKA4yFC5Qcm90b2Nv",
+            "bC5FRGlyZWN0aW9uEiUKBm5ld1BvcxgDIAEoCzIVLlByb3RvY29sLlZlY3Rv",
+            "cjJJbmZvEiUKBnJlc3VsdBgEIAEoDjIVLlByb3RvY29sLkVNb3ZlUmVzdWx0",
+            "In0KFENoYXJhY3RlclN1bW1hcnlJbmZvEhAKCHVzZXJuYW1lGAEgASgJEg0K",
+            "BWxldmVsGAIgASgFEiEKBmdlbmRlchgDIAEoDjIRLlByb3RvY29sLkVHZW5k",
+            "ZXISIQoGcmVnaW9uGAQgASgOMhEuUHJvdG9jb2wuRVJlZ2lvbiJ3CgpQbGF5",
+            "ZXJJbmZvEgoKAmlkGAEgASgFEhAKCHVzZXJuYW1lGAIgASgJEiIKA3BvcxgD",
+            "IAEoCzIVLlByb3RvY29sLlZlY3RvcjJJbmZvEicKCWRpcmVjdGlvbhgEIAEo",
+            "DjIULlByb3RvY29sLkVEaXJlY3Rpb24iWgoRSW52ZW50b3J5U2xvdEluZm8S",
+            "EQoJc2xvdEluZGV4GAEgASgFEg4KBml0ZW1JZBgCIAEoBRINCgVjb3VudBgD",
+            "IAEoBRITCgtpc1F1aWNrc2xvdBgEIAEoCCKEAQoLTW9uc3RlckluZm8SEQoJ",
+            "bW9uc3RlcklkGAEgASgFEhUKDW1vbnN0ZXJUeXBlSWQYAiABKAUSIgoDcG9z",
+            "GAMgASgLMhUuUHJvdG9jb2wuVmVjdG9yMkluZm8SJwoJZGlyZWN0aW9uGAQg",
+            "ASgOMhQuUHJvdG9jb2wuRURpcmVjdGlvbiI/CgxTaG9wSXRlbUluZm8SDgoG",
+            "aXRlbUlkGAEgASgFEhAKCHF1YW50aXR5GAIgASgFEg0KBXByaWNlGAMgASgF",
+            "ImkKDlBsYXllclN0YXRJbmZvEg0KBW1heEhwGAEgASgFEgoKAmhwGAIgASgF",
+            "Eg4KBmN1ckV4cBgDIAEoBRIOCgZtYXhFeHAYBCABKAUSDQoFbGV2ZWwYBSAB",
+            "KAUSDQoFbW9uZXkYBiABKAUihAEKDlBsYXllckNoYXRJbmZvEhQKCk5vbmVQ",
+            "bGF5ZXIYASABKAhIABISCghwbGF5ZXJJZBgCIAEoBUgAEg8KB21lc3NhZ2UY",
+            "AyABKAkSJQoIY2hhdFR5cGUYBCABKA4yEy5Qcm90b2NvbC5FQ2hhdFR5cGVC",
+            "EAoOcGxheWVySW5jbHVkZWQq3gkKBU1zZ0lkEhcKE0NfSldUX0xPR0lOX1JF",
+            "UVVFU1QQABIVChFTX0pXVF9MT0dJTl9SRVBMWRABEh4KGkNfQ1JFQVRFX0NI",
+            "QVJBQ1RFUl9SRVFVRVNUEAISHAoYU19DUkVBVEVfQ0hBUkFDVEVSX1JFUExZ",
+            "EAMSHAoYQ19DSEFSQUNURVJfTElTVF9SRVFVRVNUEAQSGgoWU19DSEFSQUNU",
+            "RVJfTElTVF9SRVBMWRAFEh4KGkNfREVMRVRFX0NIQVJBQ1RFUl9SRVFVRVNU",
+            "EAYSHAoYU19ERUxFVEVfQ0hBUkFDVEVSX1JFUExZEAcSEAoMQ19FTlRFUl9H",
+            "QU1FEAgSEAoMU19FTlRFUl9HQU1FEAkSEQoNU19QTEFZRVJfTElTVBAKEhwK",
+            "GFNfQlJPQURDQVNUX1BMQVlFUl9FTlRFUhALEhAKDENfTEVBVkVfR0FNRRAM",
+            "EhAKDFNfTEVBVkVfR0FNRRANEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9MRUFW",
+            "RRAOEhkKFUNfUExBWUVSX01PVkVfUkVRVUVTVBAPEhcKE1NfUExBWUVSX01P",
+            "VkVfUkVQTFkQEBIbChdTX0JST0FEQ0FTVF9QTEFZRVJfTU9WRRAREhcKE1Nf",
+            "Q0hBTkdFX1JPT01fQkVHSU4QEhIXChNDX0NIQU5HRV9ST09NX1JFQURZEBMS",
+            "GAoUU19DSEFOR0VfUk9PTV9DT01NSVQQFBITCg9TX1NQQVdOX01PTlNURVIQ",
+            "FRIVChFTX0RFU1BBV05fTU9OU1RFUhAWEhwKGFNfQlJPQURDQVNUX01PTlNU",
+            "RVJfTU9WRRAXEh4KGlNfQlJPQURDQVNUX01PTlNURVJfQVRUQUNLEBgSHQoZ",
+            "U19CUk9BRENBU1RfTU9OU1RFUl9ERUFUSBAZEhsKF0NfUExBWUVSX0FUVEFD",
+            "S19SRVFVRVNUEBoSHQoZU19CUk9BRENBU1RfUExBWUVSX0FUVEFDSxAbEhcK",
+            "E0NfSU5WRU5UT1JZX1JFUVVFU1QQHBIVChFTX0lOVkVOVE9SWV9SRVBMWRAd",
+            "EhYKEkNfSVRFTV9VU0VfUkVRVUVTVBAeEhQKEFNfSVRFTV9VU0VfUkVQTFkQ",
+            "HxIWChJTX0lOVkVOVE9SWV9VUERBVEUQIBIUChBTX1NZU1RFTV9NRVNTQUdF",
+            "ECESEgoOU19NT05TVEVSX0xJU1QQIhIaChZDX05QQ19JTlRFUkFDVF9SRVFV",
+            "RVNUECMSGAoUU19OUENfSU5URVJBQ1RfUkVQTFkQJBITCg9TX05QQ19TSE9Q",
+            "X09QRU4QJRIaChZDX05QQ19TSE9QX0JVWV9SRVFVRVNUECYSGAoUU19OUENf",
+            "U0hPUF9CVVlfUkVQTFkQJxIRCg1TX1BMQVlFUl9TVEFUECgSIQodU19CUk9B",
+            "RENBU1RfUExBWUVSX1RSWV9BVFRBQ0sQKRIhCh1TX0JST0FEQ0FTVF9QTEFZ",
+            "RVJfSFBfQ0hBTkdFRBAqEhwKGFNfQlJPQURDQVNUX1BMQVlFUl9ERUFUSBAr",
+            "EhEKDUNfUExBWUVSX0NIQVQQLBIbChdTX0JST0FEQ0FTVF9QTEFZRVJfQ0hB",
+            "VBAtEhcKE0NfR0lWRV9JVEVNX1JFUVVFU1QQLhIVChFTX0dJVkVfSVRFTV9S",
+            "RVBMWRAvKlMKDEVMb2dpblJlc3VsdBILCgdTVUNDRVNTEAASEQoNSU5WQUxJ",
+            "RF9UT0tFThABEhEKDVRPS0VOX0VYUElSRUQQAhIQCgxTRVJWRVJfRVJST1IQ",
+            "Ayo+CgdFR2VuZGVyEg8KC0dFTkRFUl9OT05FEAASDwoLR0VOREVSX01BTEUQ",
+            "ARIRCg1HRU5ERVJfRkVNQUxFEAIqOgoHRVJlZ2lvbhIPCgtSRUdJT05fTk9O",
+            "RRAAEg0KCVJFR0lPTl9HTxABEg8KC1JFR0lPTl9CQUNLEAIqQwoKRURpcmVj",
+            "dGlvbhIKCgZESVJfVVAQABIMCghESVJfRE9XThABEgwKCERJUl9MRUZUEAIS",
+            "DQoJRElSX1JJR0hUEAMqfAoMRUxlYXZlUmVhc29uEhEKDUxFQVZFX1VOS05P",
+            "V04QABIQCgxMRUFWRV9MT0dPVVQQARIVChFMRUFWRV9DSEFOR0VfUk9PTRAC",
+            "EhoKFkxFQVZFX0NIQU5HRV9DSEFSQUNURVIQAxIUChBMRUFWRV9ESVNDT05O",
+            "RUNUEAQqXwoLRU1vdmVSZXN1bHQSEAoMTU9WRV9VTktOT1dOEAASCwoHTU9W",
+            "RV9PSxABEgwKCE1PVkVfRElSEAISEQoNTU9WRV9DT09MRE9XThADEhAKDE1P",
+            "VkVfQkxPQ0tFRBAEKkkKDEVFbnRlclJlYXNvbhIRCg1FTlRFUl9VTktOT1dO",
+            "EAASDwoLRU5URVJfTE9HSU4QARIVChFFTlRFUl9DSEFOR0VfUk9PTRACKjkK",
+            "DkVEZXNwYXduUmVhc29uEhMKD0RFU1BBV05fVU5LTk9XThAAEhIKDkRFU1BB",
+            "V05fS0lMTEVEEAEqfgoJRUl0ZW1UeXBlEhUKEUlURU1fVFlQRV9VTktOT1dO",
+            "EAASGAoUSVRFTV9UWVBFX0NPTlNVTUFCTEUQARIXChNJVEVNX1RZUEVfRVFV",
+            "SVBNRU5UEAISEwoPSVRFTV9UWVBFX1FVRVNUEAMSEgoOSVRFTV9UWVBFX01J",
+            "U0MQBCphCgxFTWVzc2FnZVR5cGUSEAoMTUVTU0FHRV9JTkZPEAASEwoPTUVT",
+            "U0FHRV9XQVJOSU5HEAESEQoNTUVTU0FHRV9FUlJPUhACEhcKE01FU1NBR0Vf",
+            "RFJPUF9GQUlMRUQQAyooCglFQ2hhdFR5cGUSDQoJQ0hBVF9ST09NEAASDAoI",
+            "Q0hBVF9BTEwQAUIbqgIYR29vZ2xlLlByb3RvYnVmLlByb3RvY29sYgZwcm90",
+            "bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::Google.Protobuf.Protocol.MsgId), typeof(global::Google.Protobuf.Protocol.ELoginResult), typeof(global::Google.Protobuf.Protocol.EGender), typeof(global::Google.Protobuf.Protocol.ERegion), typeof(global::Google.Protobuf.Protocol.EDirection), typeof(global::Google.Protobuf.Protocol.ELeaveReason), typeof(global::Google.Protobuf.Protocol.EMoveResult), typeof(global::Google.Protobuf.Protocol.EEnterReason), typeof(global::Google.Protobuf.Protocol.EDespawnReason), typeof(global::Google.Protobuf.Protocol.EItemType), typeof(global::Google.Protobuf.Protocol.EMessageType), typeof(global::Google.Protobuf.Protocol.EChatType), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -210,6 +215,8 @@ namespace Google.Protobuf.Protocol {
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath), global::Google.Protobuf.Protocol.S_BroadcastPlayerDeath.Parser, new[]{ "PlayerId", "KillerMonsterId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_PlayerChat), global::Google.Protobuf.Protocol.C_PlayerChat.Parser, new[]{ "PlayerChatInfo" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_BroadcastPlayerChat), global::Google.Protobuf.Protocol.S_BroadcastPlayerChat.Parser, new[]{ "PlayerChatInfos" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.C_GiveItemRequest), global::Google.Protobuf.Protocol.C_GiveItemRequest.Parser, new[]{ "ItemId", "Count" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.S_GiveItemReply), global::Google.Protobuf.Protocol.S_GiveItemReply.Parser, new[]{ "Success", "ErrorMessage", "AddedSlot" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.Vector2Info), global::Google.Protobuf.Protocol.Vector2Info.Parser, new[]{ "X", "Y" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.PlayerMoveInfo), global::Google.Protobuf.Protocol.PlayerMoveInfo.Parser, new[]{ "PlayerId", "Direction", "NewPos", "Result" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Google.Protobuf.Protocol.CharacterSummaryInfo), global::Google.Protobuf.Protocol.CharacterSummaryInfo.Parser, new[]{ "Username", "Level", "Gender", "Region" }, null, null, null, null),
@@ -272,6 +279,8 @@ namespace Google.Protobuf.Protocol {
     [pbr::OriginalName("S_BROADCAST_PLAYER_DEATH")] SBroadcastPlayerDeath = 43,
     [pbr::OriginalName("C_PLAYER_CHAT")] CPlayerChat = 44,
     [pbr::OriginalName("S_BROADCAST_PLAYER_CHAT")] SBroadcastPlayerChat = 45,
+    [pbr::OriginalName("C_GIVE_ITEM_REQUEST")] CGiveItemRequest = 46,
+    [pbr::OriginalName("S_GIVE_ITEM_REPLY")] SGiveItemReply = 47,
   }
 
   public enum ELoginResult {
@@ -10409,6 +10418,510 @@ namespace Google.Protobuf.Protocol {
 
   }
 
+  /// <summary>
+  /// (46) 클라 -> 서버 : 테스트용 아이템 지급 요청
+  /// </summary>
+  public sealed partial class C_GiveItemRequest : pb::IMessage<C_GiveItemRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<C_GiveItemRequest> _parser = new pb::MessageParser<C_GiveItemRequest>(() => new C_GiveItemRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<C_GiveItemRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_GiveItemRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_GiveItemRequest(C_GiveItemRequest other) : this() {
+      itemId_ = other.itemId_;
+      count_ = other.count_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public C_GiveItemRequest Clone() {
+      return new C_GiveItemRequest(this);
+    }
+
+    /// <summary>Field number for the "itemId" field.</summary>
+    public const int ItemIdFieldNumber = 1;
+    private int itemId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int ItemId {
+      get { return itemId_; }
+      set {
+        itemId_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "count" field.</summary>
+    public const int CountFieldNumber = 2;
+    private int count_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int Count {
+      get { return count_; }
+      set {
+        count_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as C_GiveItemRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(C_GiveItemRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ItemId != other.ItemId) return false;
+      if (Count != other.Count) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ItemId != 0) hash ^= ItemId.GetHashCode();
+      if (Count != 0) hash ^= Count.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (ItemId != 0) {
+        output.WriteRawTag(8);
+        output.WriteInt32(ItemId);
+      }
+      if (Count != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Count);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (ItemId != 0) {
+        output.WriteRawTag(8);
+        output.WriteInt32(ItemId);
+      }
+      if (Count != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Count);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (ItemId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(ItemId);
+      }
+      if (Count != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Count);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(C_GiveItemRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ItemId != 0) {
+        ItemId = other.ItemId;
+      }
+      if (other.Count != 0) {
+        Count = other.Count;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            ItemId = input.ReadInt32();
+            break;
+          }
+          case 16: {
+            Count = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            ItemId = input.ReadInt32();
+            break;
+          }
+          case 16: {
+            Count = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  /// <summary>
+  /// (47) 서버 -> 클라 : 아이템 지급 결과 응답
+  /// </summary>
+  public sealed partial class S_GiveItemReply : pb::IMessage<S_GiveItemReply>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<S_GiveItemReply> _parser = new pb::MessageParser<S_GiveItemReply>(() => new S_GiveItemReply());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<S_GiveItemReply> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_GiveItemReply() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_GiveItemReply(S_GiveItemReply other) : this() {
+      success_ = other.success_;
+      errorMessage_ = other.errorMessage_;
+      addedSlot_ = other.addedSlot_ != null ? other.addedSlot_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public S_GiveItemReply Clone() {
+      return new S_GiveItemReply(this);
+    }
+
+    /// <summary>Field number for the "success" field.</summary>
+    public const int SuccessFieldNumber = 1;
+    private bool success_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Success {
+      get { return success_; }
+      set {
+        success_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "errorMessage" field.</summary>
+    public const int ErrorMessageFieldNumber = 2;
+    private string errorMessage_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ErrorMessage {
+      get { return errorMessage_; }
+      set {
+        errorMessage_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "addedSlot" field.</summary>
+    public const int AddedSlotFieldNumber = 3;
+    private global::Google.Protobuf.Protocol.InventorySlotInfo addedSlot_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::Google.Protobuf.Protocol.InventorySlotInfo AddedSlot {
+      get { return addedSlot_; }
+      set {
+        addedSlot_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as S_GiveItemReply);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(S_GiveItemReply other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Success != other.Success) return false;
+      if (ErrorMessage != other.ErrorMessage) return false;
+      if (!object.Equals(AddedSlot, other.AddedSlot)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Success != false) hash ^= Success.GetHashCode();
+      if (ErrorMessage.Length != 0) hash ^= ErrorMessage.GetHashCode();
+      if (addedSlot_ != null) hash ^= AddedSlot.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Success != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(Success);
+      }
+      if (ErrorMessage.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(ErrorMessage);
+      }
+      if (addedSlot_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(AddedSlot);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Success != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(Success);
+      }
+      if (ErrorMessage.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(ErrorMessage);
+      }
+      if (addedSlot_ != null) {
+        output.WriteRawTag(26);
+        output.WriteMessage(AddedSlot);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Success != false) {
+        size += 1 + 1;
+      }
+      if (ErrorMessage.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ErrorMessage);
+      }
+      if (addedSlot_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(AddedSlot);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(S_GiveItemReply other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Success != false) {
+        Success = other.Success;
+      }
+      if (other.ErrorMessage.Length != 0) {
+        ErrorMessage = other.ErrorMessage;
+      }
+      if (other.addedSlot_ != null) {
+        if (addedSlot_ == null) {
+          AddedSlot = new global::Google.Protobuf.Protocol.InventorySlotInfo();
+        }
+        AddedSlot.MergeFrom(other.AddedSlot);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            ErrorMessage = input.ReadString();
+            break;
+          }
+          case 26: {
+            if (addedSlot_ == null) {
+              AddedSlot = new global::Google.Protobuf.Protocol.InventorySlotInfo();
+            }
+            input.ReadMessage(AddedSlot);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Success = input.ReadBool();
+            break;
+          }
+          case 18: {
+            ErrorMessage = input.ReadString();
+            break;
+          }
+          case 26: {
+            if (addedSlot_ == null) {
+              AddedSlot = new global::Google.Protobuf.Protocol.InventorySlotInfo();
+            }
+            input.ReadMessage(AddedSlot);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
   public sealed partial class Vector2Info : pb::IMessage<Vector2Info>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -10423,7 +10936,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[46]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10649,7 +11162,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[47]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10958,7 +11471,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[48]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11258,7 +11771,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[49]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11567,7 +12080,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[50]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[52]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11867,7 +12380,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[51]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[53]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12182,7 +12695,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[52]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[54]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12451,7 +12964,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[53]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[55]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12825,7 +13338,7 @@ namespace Google.Protobuf.Protocol {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[54]; }
+      get { return global::Google.Protobuf.Protocol.ProtocolReflection.Descriptor.MessageTypes[56]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/TestClientUnity/Assets/Resources/Data/Item_data.json
+++ b/TestClientUnity/Assets/Resources/Data/Item_data.json
@@ -1,0 +1,18 @@
+[
+  {
+    "itemId": "10001",
+    "name": "체력 포션",
+    "description": "HP를 30 회복 시킵니다.",
+    "isStackable": "TRUE",
+    "maxStack": "99",
+    "itemType": "CONSUMABLE"
+  },
+  {
+    "itemId": "10002",
+    "name": "고급 체력 포션",
+    "description": "HP를 50 회복 시킵니다.",
+    "isStackable": "TRUE",
+    "maxStack": "99",
+    "itemType": "CONSUMABLE"
+  }
+]

--- a/Tools/SheetLoader/Program.cs
+++ b/Tools/SheetLoader/Program.cs
@@ -15,7 +15,7 @@ namespace SimpleGoogleSheetsExample
         // 여기에 실제 스프레드시트 ID 입력
         static SheetManager? _sheetManager;
         static List<string> sheetNameList = new List<string>{
-            "Monster", "SpawnPoint"
+            "Monster", "SpawnPoint", "Item"
         };
 
         static void Main(string[] args)

--- a/Tools/SheetLoader/resources/Item_data.json
+++ b/Tools/SheetLoader/resources/Item_data.json
@@ -1,0 +1,18 @@
+[
+  {
+    "itemId": "10001",
+    "name": "체력 포션",
+    "description": "HP를 30 회복 시킵니다.",
+    "isStackable": "TRUE",
+    "maxStack": "99",
+    "itemType": "CONSUMABLE"
+  },
+  {
+    "itemId": "10002",
+    "name": "고급 체력 포션",
+    "description": "HP를 50 회복 시킵니다.",
+    "isStackable": "TRUE",
+    "maxStack": "99",
+    "itemType": "CONSUMABLE"
+  }
+]


### PR DESCRIPTION
아이템 사용 시 실제 효과가 적용되도록 로직을 개선하고 테스트 기능을 추가했습니다.

주요 변경사항:
- 아이템 사용 시 실제 HP 회복 등의 효과가 정상적으로 적용되도록 수정
- InventorySystem의 빈 ApplyItemEffect 함수를 제거하여 혼란 방지  
- 아이템 효과 적용 플로우를 ClientPacketHandler → Player → ItemManager로 명확화
- 테스트용 아이템 지급 프로토콜 (C_GiveItemRequest/S_GiveItemReply) 추가
- DummyClient에 아이템 지급 테스트 인터페이스 ('g' 키) 및 채팅 테스트 기능 추가
- ItemDataParser 시스템 구현으로 JSON 기반 아이템 데이터 로딩 지원