### PR TITLE
feat(party): 파티 시스템 완전 구현 및 공개 파티 기능 추가

### DIFF
--- a/Doc/Packet/C_DeleteCharacterRequest_6.md
+++ b/Doc/Packet/C_DeleteCharacterRequest_6.md
@@ -1,0 +1,27 @@
+# C_DeleteCharacterRequest (6)
+
+### **캐릭터 삭제 요청**
+
+- 설명: 클라이언트가 자신의 계정에서 특정 캐릭터를 삭제하는 요청을 전송한다. Soft Delete 방식으로 isActive=false 설정.
+- 입력: `C_DeleteCharacterRequest`
+  ```protobuf
+  message C_DeleteCharacterRequest {
+      int32 characterIndex = 1;  // 삭제할 캐릭터의 인덱스
+  }
+  ```
+- 처리 로직:
+  - 세션 JwtVerified 상태 검증
+  - 계정 ID 조회 (JWT에서 추출)
+  - 해당 계정의 캐릭터 목록 조회
+  - characterIndex 범위 검증
+  - DB Soft Delete 실행 (isActive=false 설정)
+  - 캐릭터 리스트 재조회 및 캐시 갱신
+- 출력: `S_DeleteCharacterReply` (7번)
+  - `success`: 삭제 성공 여부
+  - `errorMessage`: 실패 시 에러 메시지
+- 데이터 구조:
+  - `GameDB.Character` 테이블: isActive 컬럼 업데이트
+  - 실제 데이터는 삭제되지 않음 (복구 가능)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`

--- a/Doc/Packet/C_GiveItemRequest_48.md
+++ b/Doc/Packet/C_GiveItemRequest_48.md
@@ -1,0 +1,39 @@
+# C_GiveItemRequest (48)
+
+### **아이템 지급 테스트 요청**
+
+- 설명: 클라이언트가 테스트 목적으로 아이템 지급을 요청한다. 개발/디버깅 용도.
+- 입력: `C_GiveItemRequest`
+  ```protobuf
+  message C_GiveItemRequest {
+      int32 itemId = 1;
+      int32 count = 2;
+  }
+  ```
+- 처리 로직:
+  - 세션 InRoom 상태 검증
+  - 플레이어 인벤토리 조회
+  - `InventorySystem::TryAddItem(itemId, count)` 호출
+  - 인벤토리에 아이템 추가
+  - DB 업데이트
+  - 클라이언트에게 결과 전송
+- 출력: `S_GiveItemReply` (49번)
+  - `success`: 지급 성공 여부
+  - `errorMessage`: 실패 시 에러 메시지
+  - `addedSlot`: 추가된 슬롯 정보
+- 데이터 구조:
+  - `Inventory`: 플레이어 인벤토리
+  - `InventorySlot`: 슬롯 정보
+  - `GameDB.Inventory` 테이블
+
+### 주의사항
+- **테스트 전용**: 실제 게임에서는 비활성화 필요
+- 인벤토리 가득 찬 경우 실패
+- 잘못된 itemId인 경우 실패
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`
+- `GameServer/InventorySystem.cpp`
+
+### 테스트 시나리오
+DummyClient에서 아이템 ID와 수량을 입력하여 인벤토리에 아이템 추가 테스트

--- a/Doc/Packet/C_NpcInteractRequest_35.md
+++ b/Doc/Packet/C_NpcInteractRequest_35.md
@@ -1,0 +1,27 @@
+# C_NpcInteractRequest (35)
+
+### **NPC 상호작용 요청**
+
+- 설명: 클라이언트가 NPC와 상호작용을 시작하는 요청을 전송한다. (현재 기본 구조만 구현, 실제 동작 로직 미완성)
+- 입력: `C_NpcInteractRequest`
+  ```protobuf
+  message C_NpcInteractRequest {
+      // 빈 메시지 (향후 npcId 추가 예정)
+  }
+  ```
+- 처리 로직:
+  - NPC 시스템 기본 구조만 존재
+  - Component-based NPC 시스템 설계 (Shop, Dialog, Quest)
+  - 실제 동작 로직 미구현
+- 출력: `S_NpcInteractReply` (36번)
+- 데이터 구조:
+  - `NPC`: NPC Entity (WIP)
+  - `ShopComponent`, `DialogComponent`, `QuestComponent` 인터페이스 설계
+
+### 현재 상태
+- 기본 인터페이스만 구현
+- 실제 NPC 인터랙션 로직 미완성
+- 향후 구현 예정
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (구현 stub)

--- a/Doc/Packet/C_NpcShopBuyRequest_38.md
+++ b/Doc/Packet/C_NpcShopBuyRequest_38.md
@@ -1,0 +1,19 @@
+# C_NpcShopBuyRequest (38)
+
+### **NPC 상점 아이템 구매 요청**
+
+- 설명: 클라이언트가 NPC 상점에서 아이템을 구매하는 요청을 전송한다. (WIP)
+- 입력: `C_NpcShopBuyRequest`
+  ```protobuf
+  message C_NpcShopBuyRequest {
+      int32 npcId = 1;
+      int32 itemId = 2;
+      int32 quantity = 3;
+  }
+  ```
+- 처리 로직: 미구현
+- 출력: `S_NpcShopBuyReply` (39번)
+- 데이터 구조: NPC Shop, Player Money (미구현)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`

--- a/Doc/Packet/C_PartyCreateRequest_56.md
+++ b/Doc/Packet/C_PartyCreateRequest_56.md
@@ -1,0 +1,43 @@
+# C_PartyCreateRequest (56)
+
+### **공개 파티 생성 요청**
+
+- 설명: 클라이언트가 파티명을 지정하여 공개 파티를 생성하는 요청을 전송한다. 파티명이 있는 파티는 다른 플레이어가 파티 목록에서 조회하고 가입 요청할 수 있다.
+- 입력: `C_PartyCreateRequest`
+  ```protobuf
+  message C_PartyCreateRequest {
+      string partyName = 1;  // 파티 이름
+  }
+  ```
+- 처리 로직:
+  - 세션 InRoom 상태 검증
+  - 플레이어 및 룸 유효성 확인
+  - 플레이어의 파티 소속 확인
+    - 이미 파티에 속해있으면 실패 응답
+  - `PartyManager::CreatePartyWithName(player, partyName)` 호출
+    - `_nextPartyId.fetch_add(1)`로 고유 파티 ID 생성 (atomic 연산)
+    - Party 객체 생성 (partyId, partyName, leader 설정)
+    - `_parties` 맵에 추가
+    - `_playerToParty` 맵에 플레이어→파티ID 매핑 추가
+    - 플레이어의 `SetPartyId()` 호출
+  - `PartyService::SendPartyStatusUpdate()` 호출
+    - `PARTY_UPDATE_MEMBER_JOIN` 브로드캐스트
+- 출력:
+  - `S_PartyCreateReply` (57번): 생성 결과
+    - `success`: 성공 여부
+    - `message`: "Party created" / "Already in party" / "Failed to create party"
+  - `S_BroadcastPartyUpdate` (55번): 생성자에게 파티 상태 전송
+- 데이터 구조:
+  - `Party`: 파티 객체 (partyId, partyName, leader, members)
+  - `PartyManager::_parties`: 전체 파티 맵
+  - `PartyManager::_playerToParty`: 플레이어→파티ID 맵
+  - `PartyManager::_nextPartyId`: atomic<int32> 파티 ID 생성기
+
+### 초대 전용 파티 vs 공개 파티
+- **초대 전용 파티**: `CreateParty()` 사용, partyName = ""
+- **공개 파티**: `CreatePartyWithName()` 사용, partyName 지정
+- 공개 파티는 `C_PartyList` (62번)로 조회 가능
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 708-744)
+- `GameServer/PartyManager.cpp` (Line 27-44)

--- a/Doc/Packet/C_PartyInviteRequest_50.md
+++ b/Doc/Packet/C_PartyInviteRequest_50.md
@@ -1,0 +1,33 @@
+# C_PartyInviteRequest (50)
+
+### **파티 초대 요청**
+
+- 설명: 클라이언트가 특정 플레이어를 자신의 파티에 초대하는 요청을 서버에 전송한다.
+- 입력: `C_PartyInviteRequest`
+  ```protobuf
+  message C_PartyInviteRequest {
+      int32 targetPid = 1;  // 초대할 대상 플레이어 ID
+  }
+  ```
+- 처리 로직:
+  - 세션이 InRoom 상태인지 검증
+  - 초대자의 플레이어 객체 유효성 확인
+  - 초대자의 파티 조회 또는 생성
+    - 파티가 없으면 `PartyManager::CreateParty()` 호출하여 새 파티 생성
+    - 파티가 있으면 기존 파티 반환
+  - 대상 플레이어를 전체 룸에서 검색 (`RoomManager::FindPlayerInAllRooms()`)
+  - 대상 플레이어의 유효성 및 룸 소속 여부 확인
+  - 대상 플레이어가 속한 Room의 JobQueue에 `HandlePartyInvite` 작업 큐잉
+  - Room에서 대상 플레이어에게 `S_PartyInviteNotify` 패킷 전송
+- 출력: `S_PartyInviteReply` (52번)
+  - `success`: 초대 요청 성공 여부
+  - `errorMessage`: 실패 시 에러 메시지 ("Player not found", "Player not in room")
+- 데이터 구조:
+  - `Party`: 파티 정보 (partyId, leader, members)
+  - `PartyManager`: 전역 파티 관리 (_parties, _playerToParty 맵)
+  - Room JobQueue: 파티 초대 알림 직렬화
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 584-635)
+- `GameServer/PartyManager.cpp` (Line 8-24)
+- `GameServer/Room.cpp` (Line 383-395)

--- a/Doc/Packet/C_PartyInviteResponse_53.md
+++ b/Doc/Packet/C_PartyInviteResponse_53.md
@@ -1,0 +1,39 @@
+# C_PartyInviteResponse (53)
+
+### **파티 초대 응답 (수락/거절)**
+
+- 설명: 초대받은 플레이어가 파티 초대를 수락하거나 거절하는 응답을 서버에 전송한다.
+- 입력: `C_PartyInviteResponse`
+  ```protobuf
+  message C_PartyInviteResponse {
+      int32 partyId = 1;    // 파티 ID
+      bool accept = 2;       // 수락 여부 (true=수락, false=거절)
+  }
+  ```
+- 처리 로직:
+  - 세션 InRoom 상태 검증
+  - 응답자(invitee) 플레이어 유효성 확인
+  - **거절 처리** (`accept == false`):
+    - 추가 처리 없이 종료
+  - **수락 처리** (`accept == true`):
+    - Room의 JobQueue에 `HandlePartyInviteResponse` 작업 큐잉
+    - `PartyManager::JoinParty(partyId, player)` 호출
+    - 파티 멤버 목록에 플레이어 추가
+    - 플레이어의 partyId 설정
+    - `PartyService::SendPartyStatusUpdate()` 자동 호출
+    - 파티원 전체에게 `S_BroadcastPartyUpdate` 브로드캐스트
+- 출력: `S_BroadcastPartyUpdate` (55번)
+  - `updateType`: `PARTY_UPDATE_MEMBER_JOIN`
+  - `members`: 현재 파티원 전체 상태
+- 데이터 구조:
+  - `Party::_members`: 파티 멤버 Vector
+  - `PartyManager::_playerToParty`: 플레이어→파티ID 맵
+
+### 에러 조건
+- 플레이어가 이미 다른 파티에 속해있는 경우 (`IsInParty()` 체크)
+- 파티가 가득 찬 경우 (`Party::IsFull()` 체크, MAX_MEMBERS=4)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 637-657)
+- `GameServer/Room.cpp` (Line 397-402)
+- `GameServer/PartyManager.cpp` (Line 72-88)

--- a/Doc/Packet/C_PartyJoinRequestList_64.md
+++ b/Doc/Packet/C_PartyJoinRequestList_64.md
@@ -1,0 +1,49 @@
+# C_PartyJoinRequestList (64)
+
+### **파티 가입 요청 리스트 조회 (리더 전용)**
+
+- 설명: 파티 리더가 자신의 파티에 대한 대기 중인 가입 요청 목록을 조회한다. 리스트 기반 선택 방식의 핵심 패킷으로, 리더는 이 목록을 보고 특정 요청자를 수락/거절할 수 있다.
+- 입력: `C_PartyJoinRequestList`
+  ```protobuf
+  message C_PartyJoinRequestList {
+      int32 partyId = 1;  // 조회할 파티 ID
+  }
+  ```
+- 처리 로직:
+  - 세션 및 플레이어 검증
+  - `PartyManager::FindParty(partyId)` 호출
+  - **리더 권한 확인**: `party->GetLeader() == player`
+    - 리더가 아니면 빈 목록 또는 에러 반환
+  - `PartyManager::GetJoinRequesters(partyId)` 호출
+    - `_partyJoinRequests[partyId]` 맵에서 Vector<PlayerRef> 조회
+    - 빈 벡터 반환 가능 (요청이 없는 경우)
+  - 각 요청자의 정보를 `PartyJoinRequesterInfo`로 변환
+    - playerId, playerName, level 수집
+- 출력: `S_PartyJoinRequestList` (65번)
+  - `partyId`: 파티 ID
+  - `repeated PartyJoinRequesterInfo requesters`: 요청자 목록
+- 데이터 구조:
+  - `PartyManager::_partyJoinRequests`: map<int32, Vector<PlayerRef>>
+  - `Player`: 요청자의 playerId, username, level
+
+### 리스트 기반 선택의 장점
+- **FIFO 방식의 문제점**: 먼저 온 요청부터 처리, 원하는 플레이어 선택 불가
+- **리스트 기반 방식**:
+  - 모든 대기 요청을 한 번에 확인
+  - PlayerId로 특정 요청자 지정하여 수락/거절
+  - 예: PlayerB, PlayerC가 요청 → 리더가 PlayerC만 수락 가능
+
+### 에러 조건
+- 파티가 존재하지 않는 경우
+- 요청자가 리더가 아닌 경우 (조회 권한 없음)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 876-914)
+- `GameServer/PartyManager.cpp` (Line 264-275)
+
+### 사용 플로우
+1. 리더가 `S_PartyJoinNotify` (60번) 알림 받음
+2. 리더가 `C_PartyJoinRequestList` 전송
+3. 서버가 `S_PartyJoinRequestList` 응답
+4. 리더가 목록에서 원하는 요청자 선택
+5. 리더가 `C_PartyJoinResponse` (61번)로 수락/거절

--- a/Doc/Packet/C_PartyJoinRequest_58.md
+++ b/Doc/Packet/C_PartyJoinRequest_58.md
@@ -1,0 +1,44 @@
+# C_PartyJoinRequest (58)
+
+### **공개 파티 가입 요청**
+
+- 설명: 클라이언트가 공개 파티 목록에서 선택한 파티에 가입 요청을 전송한다. 요청은 파티 리더에게 알림으로 전달되며, 리더가 수락/거절을 결정한다.
+- 입력: `C_PartyJoinRequest`
+  ```protobuf
+  message C_PartyJoinRequest {
+      int32 partyId = 1;  // 가입하려는 파티 ID
+  }
+  ```
+- 처리 로직:
+  - 세션, 플레이어, 룸 유효성 검증
+  - `PartyManager::FindParty(partyId)` 호출하여 파티 존재 확인
+  - `Party::IsFull()` 체크 (MAX_MEMBERS = 4)
+  - `PartyManager::AddJoinRequest(partyId, player)` 호출
+    - `_partyJoinRequests` 맵에 요청자 추가
+    - 중복 요청 방지 (이미 요청한 플레이어면 false 반환)
+  - 파티 리더의 세션 찾기
+  - 리더에게 `S_PartyJoinNotify` (60번) 패킷 전송
+- 출력:
+  - `S_PartyJoinReply` (59번): 요청자에게 결과 전송
+    - `success`: 요청 전송 성공 여부
+    - `message`: "Request sent to leader" / "Party not found" / "Party is full" / "Request already pending"
+  - `S_PartyJoinNotify` (60번): 파티 리더에게 알림
+- 데이터 구조:
+  - `Party`: 파티 정보 및 멤버 목록
+  - `PartyManager::_partyJoinRequests`: map<int32, Vector<PlayerRef>> (partyId → 요청자 목록)
+
+### 가입 플로우
+1. 플레이어가 `C_PartyList` (62번)로 파티 목록 조회
+2. 원하는 파티 선택 후 `C_PartyJoinRequest` 전송
+3. 서버가 리더에게 `S_PartyJoinNotify` 전송
+4. 리더가 `C_PartyJoinRequestList` (64번)로 대기 요청 목록 조회
+5. 리더가 `C_PartyJoinResponse` (61번)로 수락/거절
+
+### 에러 조건
+- 파티가 존재하지 않는 경우
+- 파티 인원이 가득 찬 경우 (4/4)
+- 이미 같은 파티에 요청을 보낸 경우
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 746-810)
+- `GameServer/PartyManager.cpp` (Line 182-199)

--- a/Doc/Packet/C_PartyJoinResponse_61.md
+++ b/Doc/Packet/C_PartyJoinResponse_61.md
@@ -1,0 +1,47 @@
+# C_PartyJoinResponse (61)
+
+### **파티 가입 요청 수락/거절 (리더 전용)**
+
+- 설명: 파티 리더가 대기 중인 가입 요청을 수락하거나 거절하는 응답을 전송한다. 리스트 기반 선택 방식으로, 특정 요청자의 PlayerId를 지정하여 처리한다.
+- 입력: `C_PartyJoinResponse`
+  ```protobuf
+  message C_PartyJoinResponse {
+      int32 partyId = 1;        // 파티 ID
+      int32 requesterPid = 2;   // 수락/거절할 요청자의 PlayerId
+      bool accept = 3;           // 수락 여부 (true=수락, false=거절)
+  }
+  ```
+- 처리 로직:
+  - 세션, 플레이어, 룸 검증
+  - `PartyManager::FindParty(partyId)` 호출
+  - **리더 권한 확인**: `party->GetLeader() == player`
+  - `PartyManager::FindRequesterById(partyId, requesterPid)` 호출
+    - `_partyJoinRequests` 맵에서 특정 요청자 검색
+  - **수락 처리** (`accept == true`):
+    - `PartyManager::JoinParty(partyId, requester)` 호출
+    - 성공 시 `PartyManager::RemoveJoinRequest()` 호출
+    - `PARTY_UPDATE_MEMBER_JOIN` 브로드캐스트
+    - 요청자에게 `S_PartyJoinReply` (success=true) 전송
+  - **거절 처리** (`accept == false`):
+    - `PartyManager::RemoveJoinRequest(partyId, requester)` 호출
+    - 요청자에게 `S_PartyJoinReply` (success=false) 전송
+- 출력:
+  - `S_PartyJoinReply` (59번): 요청자에게 결과 전송
+  - `S_BroadcastPartyUpdate` (55번): 수락 시 파티원들에게 브로드캐스트
+- 데이터 구조:
+  - `PartyManager::_partyJoinRequests`: map<int32, Vector<PlayerRef>>
+  - `Party::_members`: 파티 멤버 목록
+
+### FIFO vs 리스트 기반 선택
+- **이전 방식 (FIFO)**: 큐의 맨 앞 요청자만 처리
+- **현재 방식 (리스트 기반)**: requesterPid로 특정 요청자 지정
+- 리더가 `C_PartyJoinRequestList` (64번)로 전체 목록 조회 후 원하는 요청자 선택 가능
+
+### 에러 조건
+- 파티가 존재하지 않는 경우
+- 요청자가 리더가 아닌 경우
+- requesterPid에 해당하는 요청자를 찾을 수 없는 경우
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 812-859)
+- `GameServer/PartyManager.cpp` (Line 72-88, 212-240, 242-262)

--- a/Doc/Packet/C_PartyLeave_54.md
+++ b/Doc/Packet/C_PartyLeave_54.md
@@ -1,0 +1,60 @@
+# C_PartyLeave (54)
+
+### **파티 탈퇴 / 강퇴 요청**
+
+- 설명: 클라이언트가 자발적으로 파티를 탈퇴하거나, 리더가 다른 멤버를 강퇴하는 요청을 전송한다.
+- 입력: `C_PartyLeave`
+  ```protobuf
+  message C_PartyLeave {
+      oneof action {
+          bool selfLeave = 1;    // true면 자발적 탈퇴
+          int32 targetPid = 2;   // 값이 있으면 해당 플레이어 강퇴
+      }
+  }
+  ```
+- 처리 로직:
+
+  #### 자발적 탈퇴 (selfLeave = true)
+  - 세션 및 플레이어 검증
+  - Room의 JobQueue에 `HandlePartyLeave(player, true, playerId)` 작업 큐잉
+  - `PartyManager::LeaveParty(player)` 호출
+  - **리더인 경우**:
+    - `PartyManager::DisbandParty(partyId)` 호출
+    - 모든 파티원의 partyId 초기화
+    - `_parties` 맵에서 파티 제거
+    - `PARTY_UPDATE_DISBANDED` 브로드캐스트
+  - **일반 멤버인 경우**:
+    - `Party::RemoveMember(player)` 호출
+    - `_playerToParty` 맵에서 제거
+    - 플레이어의 partyId = 0 설정
+    - `PARTY_UPDATE_MEMBER_LEAVE` 브로드캐스트
+
+  #### 강퇴 (targetPid)
+  - 요청자의 파티 ID 확인
+  - 대상 플레이어를 전체 룸에서 검색 (`RoomManager::FindPlayerInAllRooms()`)
+  - Room의 JobQueue에 `HandlePartyLeave(player, false, targetPid)` 작업 큐잉
+  - `PartyManager::kickMember(partyId, kicker, target)` 호출
+  - **리더 권한 확인**: `party->GetLeader() == kicker`
+  - **같은 파티 확인**: `IsSameParty(kicker, target)`
+  - 대상 멤버 제거 및 partyId 초기화
+  - `PARTY_UPDATE_MEMBER_LEAVE` 브로드캐스트
+
+- 출력: `S_BroadcastPartyUpdate` (55번)
+  - 해산 시: `updateType = PARTY_UPDATE_DISBANDED`
+  - 탈퇴/강퇴 시: `updateType = PARTY_UPDATE_MEMBER_LEAVE`
+- 데이터 구조:
+  - `Party::_leader`: 파티 리더
+  - `Party::_members`: 파티 멤버 목록
+  - `PartyManager::_parties`: 전체 파티 맵
+  - `PartyManager::_playerToParty`: 플레이어→파티ID 맵
+
+### 에러 조건
+- 파티에 속해있지 않은 경우
+- 강퇴 시 리더가 아닌 경우
+- 대상 플레이어를 찾을 수 없는 경우
+- 같은 파티가 아닌 경우
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 659-706)
+- `GameServer/Room.cpp` (Line 404-445)
+- `GameServer/PartyManager.cpp` (Line 46-136)

--- a/Doc/Packet/C_PartyList_62.md
+++ b/Doc/Packet/C_PartyList_62.md
@@ -1,0 +1,41 @@
+# C_PartyList (62)
+
+### **전체 공개 파티 목록 조회**
+
+- 설명: 클라이언트가 서버에 생성된 모든 공개 파티의 목록을 요청한다.
+- 입력: `C_PartyList`
+  ```protobuf
+  message C_PartyList {
+      // 빈 메시지
+  }
+  ```
+- 처리 로직:
+  - `PartyManager::GetAllPublicParties()` 호출
+  - `_parties` 맵의 모든 파티 순회
+  - 각 파티의 `GetPartyInfo()` 메서드 호출
+    - partyId, partyName, 멤버 목록, 현재/최대 인원, 리더 ID 수집
+  - S_PartyList 패킷에 모든 파티 정보 추가
+- 출력: `S_PartyList` (63번)
+  - `repeated PartyInfo partyInfos`: 전체 파티 목록
+- 데이터 구조:
+  - `PartyManager::_parties`: unordered_map<int32, PartyRef>
+  - `Party`: 각 파티의 정보
+
+### 주의사항
+- 현재 구현은 **모든 파티**를 반환 (파티명 유무 관계없이)
+- 주석 처리된 코드: 파티명이 있는 파티만 필터링
+  ```cpp
+  // if (!party->GetPartyName().empty())
+  ```
+- 필요 시 파티명 필터링 활성화 가능
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 861-874)
+- `GameServer/PartyManager.cpp` (Line 159-180)
+
+### 클라이언트 처리
+받은 파티 목록을 UI에 표시:
+- 파티명
+- 현재 인원 / 최대 인원 (예: 3/4)
+- 리더 이름
+- "가입 요청" 버튼

--- a/Doc/Packet/C_PlayerChat_46.md
+++ b/Doc/Packet/C_PlayerChat_46.md
@@ -1,0 +1,49 @@
+# C_PlayerChat (46)
+
+### **플레이어 채팅 메시지 전송**
+
+- 설명: 클라이언트가 채팅 메시지를 서버에 전송한다. 룸 채팅과 전체 채팅 지원.
+- 입력: `C_PlayerChat`
+  ```protobuf
+  message C_PlayerChat {
+      PlayerChatInfo playerChatInfo = 1;
+  }
+
+  message PlayerChatInfo {
+      oneof playerIncluded {
+          bool NonePlayer = 1;     // 클라 → 서버 전송 시 사용
+          int32 playerId = 2;      // 서버 → 클라 전송 시 사용
+      }
+      string playerName = 3;
+      string message = 4;
+      EChatType chatType = 5;
+  }
+
+  enum EChatType {
+      CHAT_ROOM = 0;   // 현재 룸의 플레이어들에게만
+      CHAT_ALL = 1;    // 모든 룸의 플레이어들에게
+  }
+  ```
+- 처리 로직:
+  - 세션 및 플레이어 검증
+  - 채팅 타입 확인 (ROOM / ALL)
+  - Room의 채팅 큐에 추가 (`Room::_chatQueue`)
+  - Room Tick마다 모아둔 채팅을 배치 전송 (S_BroadcastPlayerChat)
+- 출력: `S_BroadcastPlayerChat` (47번)
+- 데이터 구조:
+  - `Room::_chatQueue`: deque<Protocol::PlayerChatInfo>
+
+### 채팅 타입
+- **CHAT_ROOM**: 같은 룸에 있는 플레이어들에게만 전송
+- **CHAT_ALL**: RoomManager::DoAsyncForAllRooms()로 전체 룸 브로드캐스트
+
+### 배치 전송
+- Room Tick마다 큐에 쌓인 채팅을 한 번에 전송
+- 네트워크 효율성 향상
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`
+- `GameServer/Room.cpp`
+
+### 클라이언트 처리
+채팅 UI에 메시지 표시

--- a/Doc/Packet/C_PlayerDeathReady_44.md
+++ b/Doc/Packet/C_PlayerDeathReady_44.md
@@ -1,0 +1,35 @@
+# C_PlayerDeathReady (44)
+
+### **플레이어 리스폰 준비 완료**
+
+- 설명: 사망한 플레이어가 리스폰 준비가 완료되었음을 서버에 알린다.
+- 입력: `C_PlayerDeathReady`
+  ```protobuf
+  message C_PlayerDeathReady {
+      // 빈 메시지
+  }
+  ```
+- 처리 로직:
+  - 플레이어의 사망 상태 확인
+  - 리스폰 처리:
+    - HP 초기화 (maxHp로 설정)
+    - 사망 상태 해제
+    - 스폰 지역 결정 (region에 따라)
+  - Room 전환 시작 (`S_ChangeRoomBegin` → `S_PlayerDeathCommit` → `S_ChangeRoomCommit`)
+- 출력:
+  - `S_PlayerDeathCommit` (45번): 리스폰 승인
+  - `S_ChangeRoomCommit` (20번): 스폰 지역으로 이동
+- 데이터 구조:
+  - `Player::_isDead`: 사망 상태
+  - `Player::region`: 스폰 지역 (고구려/백제)
+
+### 리스폰 로직
+- 고구려 캐릭터 → 고구려 스폰 지역
+- 백제 캐릭터 → 백제 스폰 지역
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`
+- `GameServer/Room.cpp`
+
+### 클라이언트 처리
+리스폰 애니메이션 재생, 캐릭터 위치 업데이트

--- a/Doc/Packet/S_BroadcastPartyUpdate_55.md
+++ b/Doc/Packet/S_BroadcastPartyUpdate_55.md
@@ -1,0 +1,54 @@
+# S_BroadcastPartyUpdate (55)
+
+### **파티 상태 업데이트 브로드캐스트**
+
+- 설명: 서버가 파티 상태 변경사항을 파티원 전체에게 브로드캐스트한다.
+- 입력: `PartyService::SendPartyStatusUpdate()` 호출
+- 처리 로직:
+  - 파티 ID로 파티 조회 (`PartyManager::FindParty()`)
+  - 파티의 온라인 멤버 목록 조회 (`Party::GetOnlineMembers()`)
+  - 각 멤버의 상태 정보 수집 (playerId, playerName, hp, maxHp, level, isLeader)
+  - S_BroadcastPartyUpdate 패킷 생성
+  - 모든 파티원의 세션에게 브로드캐스트 (`BroadcastToPartyMembers()`)
+- 출력: `S_BroadcastPartyUpdate`
+  ```protobuf
+  message S_BroadcastPartyUpdate {
+      EPartyUpdateType updateType = 1;
+      repeated PartyMemberStatusInfo members = 2;
+  }
+
+  message PartyMemberStatusInfo {
+      int32 playerId = 1;
+      string playerName = 2;
+      int32 hp = 3;
+      int32 maxHp = 4;
+      int32 level = 5;
+      bool isLeader = 6;
+  }
+
+  enum EPartyUpdateType {
+      PARTY_UPDATE_MEMBER_JOIN = 0;    // 멤버 가입
+      PARTY_UPDATE_MEMBER_LEAVE = 1;   // 멤버 탈퇴/강퇴
+      PARTY_UPDATE_STATUS = 2;         // 상태 업데이트 (HP, Level 변경)
+      PARTY_UPDATE_DISBANDED = 3;      // 파티 해산
+  }
+  ```
+- 데이터 구조:
+  - `Party::_members`: 파티 멤버 목록
+  - `Player`: 각 멤버의 상태 정보 (hp, maxHp, level)
+
+### 전송 시점
+1. 파티 생성 시 (`MEMBER_JOIN`)
+2. 파티원 가입 시 (`MEMBER_JOIN`)
+3. 파티원 탈퇴/강퇴 시 (`MEMBER_LEAVE`)
+4. 파티 해산 시 (`DISBANDED`)
+5. 주기적 상태 업데이트 (`STATUS`) - Room Tick마다 호출
+
+### 관련 파일
+- `GameServer/PartyService.cpp` (Line 49-80)
+
+### 클라이언트 처리
+- `MEMBER_JOIN`: 파티 UI에 새 멤버 추가
+- `MEMBER_LEAVE`: 파티 UI에서 멤버 제거
+- `STATUS`: 멤버의 HP/Level 정보 갱신
+- `DISBANDED`: 파티 UI 닫기

--- a/Doc/Packet/S_BroadcastPlayerChat_47.md
+++ b/Doc/Packet/S_BroadcastPlayerChat_47.md
@@ -1,0 +1,35 @@
+# S_BroadcastPlayerChat (47)
+
+### **채팅 메시지 브로드캐스트**
+
+- 설명: 서버가 Room Tick마다 모아둔 채팅 메시지들을 배치로 브로드캐스트한다.
+- 입력: Room Tick 처리 시
+- 처리 로직:
+  - Room의 `_chatQueue`에서 모든 채팅 수집
+  - playerId 필드 설정 (서버에서 추가)
+  - 채팅 타입에 따라 브로드캐스트 범위 결정
+  - S_BroadcastPlayerChat 패킷 전송
+  - 큐 비우기
+- 출력: `S_BroadcastPlayerChat`
+  ```protobuf
+  message S_BroadcastPlayerChat {
+      repeated PlayerChatInfo playerChatInfos = 1;
+  }
+  ```
+- 데이터 구조:
+  - `Room::_chatQueue`: deque<Protocol::PlayerChatInfo>
+
+### 배치 전송의 장점
+- 여러 채팅을 한 번에 전송하여 네트워크 오버헤드 감소
+- Room Tick 주기에 맞춰 안정적으로 전송
+- 채팅 순서 보장
+
+### 브로드캐스트 범위
+- **CHAT_ROOM**: 현재 룸의 플레이어들에게만
+- **CHAT_ALL**: 전체 룸의 플레이어들에게 (`RoomManager::DoAsyncForAllRooms()`)
+
+### 관련 파일
+- `GameServer/Room.cpp`
+
+### 클라이언트 처리
+받은 채팅 목록을 순서대로 UI에 표시

--- a/Doc/Packet/S_BroadcastPlayerDeath_43.md
+++ b/Doc/Packet/S_BroadcastPlayerDeath_43.md
@@ -1,0 +1,34 @@
+# S_BroadcastPlayerDeath (43)
+
+### **플레이어 사망 브로드캐스트**
+
+- 설명: 서버가 플레이어의 사망을 룸의 모든 플레이어에게 브로드캐스트한다.
+- 입력: 플레이어 HP가 0 이하로 떨어졌을 때
+- 처리 로직:
+  - 플레이어 사망 상태 설정
+  - 사망 브로드캐스트 전송
+  - 사망한 플레이어는 C_PlayerDeathReady (44번)로 리스폰 요청 대기
+- 출력: `S_BroadcastPlayerDeath`
+  ```protobuf
+  message S_BroadcastPlayerDeath {
+      int32 mapId = 1;
+      int32 playerId = 2;
+      int32 killerMonsterId = 3;  // 죽인 몬스터 ID
+  }
+  ```
+- 데이터 구조:
+  - `Player::_isDead`: 사망 상태 플래그
+
+### 사망 플로우
+1. HP 0 → `S_BroadcastPlayerDeath` 전송
+2. 클라이언트 사망 애니메이션 재생
+3. 클라이언트 `C_PlayerDeathReady` (44번) 전송
+4. 서버 `S_PlayerDeathCommit` (45번) + `S_ChangeRoomCommit` (20번) 전송
+5. 스폰 지역으로 이동, HP 초기화
+
+### 관련 파일
+- `GameServer/PlayerCombatSystem.cpp`
+- `GameServer/MonsterCombatSystem.cpp`
+
+### 클라이언트 처리
+사망 애니메이션 재생, 리스폰 UI 표시

--- a/Doc/Packet/S_BroadcastPlayerHpChanged_42.md
+++ b/Doc/Packet/S_BroadcastPlayerHpChanged_42.md
@@ -1,0 +1,31 @@
+# S_BroadcastPlayerHpChanged (42)
+
+### **플레이어 HP 변경 브로드캐스트**
+
+- 설명: 서버가 플레이어의 HP 변경사항을 룸의 모든 플레이어에게 브로드캐스트한다.
+- 입력: HP 변경 이벤트 발생 시 (공격받음, 포션 사용 등)
+- 처리 로직:
+  - HP 변경 감지
+  - 변경된 HP 값 브로드캐스트
+- 출력: `S_BroadcastPlayerHpChanged`
+  ```protobuf
+  message S_BroadcastPlayerHpChanged {
+      int32 playerId = 1;
+      int32 hp = 2;
+      int32 maxHp = 3;
+  }
+  ```
+- 데이터 구조:
+  - `Player::_statInfo`: HP 정보
+
+### 전송 시점
+- 몬스터에게 공격받았을 때
+- 포션 사용 시
+- 기타 HP 변경 이벤트
+
+### 관련 파일
+- `GameServer/PlayerCombatSystem.cpp`
+- `GameServer/InventorySystem.cpp`
+
+### 클라이언트 처리
+다른 플레이어의 HP바 UI 갱신

--- a/Doc/Packet/S_BroadcastPlayerTryAttack_41.md
+++ b/Doc/Packet/S_BroadcastPlayerTryAttack_41.md
@@ -1,0 +1,28 @@
+# S_BroadcastPlayerTryAttack (41)
+
+### **플레이어 공격 시도 브로드캐스트**
+
+- 설명: 서버가 플레이어의 공격 시도를 룸의 모든 플레이어에게 브로드캐스트한다. 공격 애니메이션 재생용.
+- 입력: `C_PlayerAttackRequest` 처리 시
+- 처리 로직:
+  - 플레이어의 공격 요청 검증
+  - 공격 애니메이션 브로드캐스트
+  - 실제 데미지 계산은 별도 로직
+- 출력: `S_BroadcastPlayerTryAttack`
+  ```protobuf
+  message S_BroadcastPlayerTryAttack {
+      int32 playerId = 1;  // 공격하는 플레이어 ID
+  }
+  ```
+- 데이터 구조: 없음
+
+### S_BroadcastPlayerAttack (27번)과의 차이
+- **TryAttack (41번)**: 공격 시도 (애니메이션 재생)
+- **PlayerAttack (27번)**: 공격 결과 (데미지, 대상)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`
+- `GameServer/PlayerCombatSystem.cpp`
+
+### 클라이언트 처리
+공격 애니메이션 재생

--- a/Doc/Packet/S_GiveItemReply_49.md
+++ b/Doc/Packet/S_GiveItemReply_49.md
@@ -1,0 +1,43 @@
+# S_GiveItemReply (49)
+
+### **아이템 지급 결과 응답**
+
+- 설명: 서버가 테스트용 아이템 지급 요청의 결과를 전송한다.
+- 입력: `C_GiveItemRequest` 처리 완료 후
+- 처리 로직:
+  - 아이템 추가 결과 확인
+  - 성공 시 추가된 슬롯 정보 포함
+- 출력: `S_GiveItemReply`
+  ```protobuf
+  message S_GiveItemReply {
+      bool success = 1;
+      string errorMessage = 2;
+      InventorySlotInfo addedSlot = 3;
+  }
+
+  message InventorySlotInfo {
+      int32 slotIndex = 1;
+      int32 itemId = 2;
+      int32 count = 3;
+      bool isQuickslot = 4;
+  }
+  ```
+- 데이터 구조:
+  - `InventorySlotInfo`: 추가된 슬롯 정보
+
+### 에러 메시지 종류
+- "Inventory is full": 인벤토리 가득 찬
+- "Invalid itemId": 잘못된 아이템 ID
+- "Failed to add item": 아이템 추가 실패
+
+### 성공 시
+- `success = true`
+- `addedSlot`: 아이템이 추가된 슬롯의 상세 정보
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`
+- `GameServer/InventorySystem.cpp`
+
+### 클라이언트 처리
+- 성공: 인벤토리 UI에 아이템 추가 표시
+- 실패: 에러 메시지 표시

--- a/Doc/Packet/S_MonsterList_34.md
+++ b/Doc/Packet/S_MonsterList_34.md
@@ -1,0 +1,37 @@
+# S_MonsterList (34)
+
+### **몬스터 리스트 스냅샷**
+
+- 설명: 서버가 클라이언트에게 현재 맵의 모든 몬스터 정보를 한 번에 전송한다. 주로 룸 입장 시 초기 스냅샷으로 사용.
+- 입력: 플레이어 룸 입장 시 (`S_EnterGame` 이후)
+- 처리 로직:
+  - Room의 모든 몬스터 조회
+  - 각 몬스터의 정보 수집 (monsterId, monsterTypeId, 위치, 방향)
+  - S_MonsterList 패킷 생성 및 전송
+- 출력: `S_MonsterList`
+  ```protobuf
+  message S_MonsterList {
+      int32 mapId = 1;
+      repeated MonsterInfo monsters = 2;
+  }
+
+  message MonsterInfo {
+      int32 monsterId = 1;        // Entity 고유 ID
+      int32 monsterTypeId = 2;    // 몬스터 타입 (Template ID)
+      Vector2Info pos = 3;         // 위치
+      EDirection direction = 4;    // 방향
+  }
+  ```
+- 데이터 구조:
+  - `Room::_monsters`: 룸의 몬스터 컨테이너
+  - `Monster`: 몬스터 Entity
+
+### 사용 시점
+1. `C_EnterGame` 처리 후 룸 입장 시
+2. `S_ChangeRoomCommit` 처리 후 룸 전환 시
+
+### 관련 파일
+- `GameServer/Room.cpp`
+
+### 클라이언트 처리
+받은 몬스터 정보를 기반으로 게임 월드에 몬스터 스폰

--- a/Doc/Packet/S_NpcInteractReply_36.md
+++ b/Doc/Packet/S_NpcInteractReply_36.md
@@ -1,0 +1,21 @@
+# S_NpcInteractReply (36)
+
+### **NPC 상호작용 응답**
+
+- 설명: 서버가 NPC 상호작용 요청에 대한 응답을 전송한다. (WIP)
+- 입력: `C_NpcInteractRequest` 처리 후
+- 처리 로직: 미구현
+- 출력: `S_NpcInteractReply`
+  ```protobuf
+  message S_NpcInteractReply {
+      repeated string dialogs = 1;       // 대화 텍스트 목록
+      int32 interactionType = 2;          // 0=Talk, 1=Shop, 2=Quest
+  }
+  ```
+- 데이터 구조: NPC 데이터 (미구현)
+
+### 현재 상태
+기본 구조만 정의, 실제 로직 미구현
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`

--- a/Doc/Packet/S_NpcShopBuyReply_39.md
+++ b/Doc/Packet/S_NpcShopBuyReply_39.md
@@ -1,0 +1,18 @@
+# S_NpcShopBuyReply (39)
+
+### **NPC 상점 구매 응답**
+
+- 설명: 서버가 아이템 구매 요청의 결과를 전송한다. (WIP)
+- 입력: `C_NpcShopBuyRequest` 처리 후
+- 처리 로직: 미구현
+- 출력: `S_NpcShopBuyReply`
+  ```protobuf
+  message S_NpcShopBuyReply {
+      bool success = 1;
+      string detail = 2;
+  }
+  ```
+- 데이터 구조: 없음
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`

--- a/Doc/Packet/S_NpcShopOpen_37.md
+++ b/Doc/Packet/S_NpcShopOpen_37.md
@@ -1,0 +1,24 @@
+# S_NpcShopOpen (37)
+
+### **NPC 상점 오픈**
+
+- 설명: 서버가 클라이언트에게 NPC 상점 정보를 전송한다. (WIP)
+- 입력: NPC Shop 인터랙션 시
+- 처리 로직: 미구현
+- 출력: `S_NpcShopOpen`
+  ```protobuf
+  message S_NpcShopOpen {
+      int32 npcId = 1;
+      repeated ShopItemInfo items = 2;
+  }
+
+  message ShopItemInfo {
+      int32 itemId = 1;
+      int32 quantity = 2;   // 수량
+      int32 price = 3;      // 1개당 가격
+  }
+  ```
+- 데이터 구조: NPC Shop 데이터 (미구현)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`

--- a/Doc/Packet/S_PartyCreateReply_57.md
+++ b/Doc/Packet/S_PartyCreateReply_57.md
@@ -1,0 +1,26 @@
+# S_PartyCreateReply (57)
+
+### **파티 생성 요청 결과**
+
+- 설명: 서버가 공개 파티 생성 요청의 성공/실패 결과를 전송한다.
+- 입력: `C_PartyCreateRequest` 처리 완료 후
+- 처리 로직:
+  - C_PartyCreateRequest 처리 결과에 따라 응답 생성
+  - 성공 시: success=true, message="Party created"
+  - 실패 시: success=false, message에 실패 사유
+- 출력: `S_PartyCreateReply`
+  ```protobuf
+  message S_PartyCreateReply {
+      bool success = 1;
+      string message = 2;
+  }
+  ```
+- 데이터 구조: 없음 (응답 패킷)
+
+### 메시지 종류
+- "Party created": 파티 생성 성공
+- "Already in party": 이미 다른 파티에 속해있음
+- "Failed to create party": 파티 생성 실패 (내부 에러)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 708-744)

--- a/Doc/Packet/S_PartyInviteNotify_51.md
+++ b/Doc/Packet/S_PartyInviteNotify_51.md
@@ -1,0 +1,30 @@
+# S_PartyInviteNotify (51)
+
+### **파티 초대 알림**
+
+- 설명: 서버가 파티 초대를 받은 플레이어에게 초대 알림을 전송한다.
+- 입력: `Room::HandlePartyInvite()` 내부 처리
+- 처리 로직:
+  - 초대자(inviter)와 초대받는 사람(invitee) 정보 확인
+  - 초대자의 파티 ID 조회
+  - S_PartyInviteNotify 패킷 생성
+  - 초대받는 사람의 세션에게만 전송
+- 출력: `S_PartyInviteNotify`
+  ```protobuf
+  message S_PartyInviteNotify {
+      int32 inviterPid = 1;      // 초대한 사람 플레이어 ID
+      string inviterName = 2;     // 초대한 사람 이름
+      int32 partyId = 3;          // 파티 ID
+  }
+  ```
+- 데이터 구조:
+  - `Player`: 초대자 및 초대받는 사람의 플레이어 정보
+  - `GameSession`: 초대받는 사람의 네트워크 세션
+
+### 관련 파일
+- `GameServer/Room.cpp` (Line 383-395)
+
+### 클라이언트 처리
+초대받은 플레이어는 UI 팝업을 표시하고 수락/거절 버튼을 제공해야 한다.
+- 수락: `C_PartyInviteResponse` (accept=true) 전송
+- 거절: `C_PartyInviteResponse` (accept=false) 전송

--- a/Doc/Packet/S_PartyInviteReply_52.md
+++ b/Doc/Packet/S_PartyInviteReply_52.md
@@ -1,0 +1,26 @@
+# S_PartyInviteReply (52)
+
+### **파티 초대 요청 결과**
+
+- 설명: 서버가 초대 요청자에게 초대 요청의 성공/실패 결과를 전송한다.
+- 입력: `C_PartyInviteRequest` 처리 완료 후
+- 처리 로직:
+  - C_PartyInviteRequest 처리 중 대상 플레이어 검색 결과에 따라 응답 생성
+  - 성공 시: success=true
+  - 실패 시: success=false, errorMessage 설정
+- 출력: `S_PartyInviteReply`
+  ```protobuf
+  message S_PartyInviteReply {
+      bool success = 1;          // 초대 요청 성공 여부
+      string errorMessage = 2;   // 실패 시 에러 메시지
+  }
+  ```
+- 데이터 구조: 없음 (응답 패킷)
+
+### 에러 메시지 종류
+- "Player not found": 대상 플레이어를 찾을 수 없음
+- "Player not in room": 대상 플레이어가 룸에 없음
+- "Target already in party": 대상이 이미 다른 파티에 속해있음 (예상 에러)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 584-635)

--- a/Doc/Packet/S_PartyJoinNotify_60.md
+++ b/Doc/Packet/S_PartyJoinNotify_60.md
@@ -1,0 +1,34 @@
+# S_PartyJoinNotify (60)
+
+### **파티 가입 요청 알림 (리더 전용)**
+
+- 설명: 서버가 파티 리더에게 누군가 파티 가입을 요청했음을 알린다.
+- 입력: `C_PartyJoinRequest` 처리 중
+- 처리 로직:
+  - 가입 요청이 성공적으로 큐에 추가되면 생성
+  - 파티 리더의 세션을 찾아 전송
+- 출력: `S_PartyJoinNotify`
+  ```protobuf
+  message S_PartyJoinNotify {
+      int32 joinPlayerId = 1;  // 요청자 플레이어 ID
+      int32 PartyId = 2;        // 파티 ID
+      int32 leaderId = 3;       // 리더 ID
+  }
+  ```
+- 데이터 구조:
+  - `Party::_leader`: 파티 리더
+  - `PartyManager::_partyJoinRequests`: 가입 요청 큐
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 746-810)
+
+### 클라이언트 처리
+리더는 이 알림을 받으면:
+1. UI에 알림 뱃지 표시 (예: "가입 요청 2건")
+2. `C_PartyJoinRequestList` (64번)로 전체 요청 목록 조회
+3. 각 요청자에 대해 `C_PartyJoinResponse` (61번)로 수락/거절
+
+### 특징
+- **리더에게만** 전송됨
+- 여러 명이 요청하면 각각에 대해 알림 전송
+- 요청은 큐에 저장되어 리더가 나중에 처리 가능

--- a/Doc/Packet/S_PartyJoinReply_59.md
+++ b/Doc/Packet/S_PartyJoinReply_59.md
@@ -1,0 +1,39 @@
+# S_PartyJoinReply (59)
+
+### **파티 가입 요청/응답 결과**
+
+- 설명: 서버가 파티 가입 요청 전송 결과 또는 리더의 수락/거절 결과를 전송한다.
+- 입력:
+  - `C_PartyJoinRequest` 처리 완료 후 (요청 전송 결과)
+  - `C_PartyJoinResponse` 처리 완료 후 (수락/거절 결과)
+- 처리 로직:
+  - 요청 전송 시: 요청이 리더에게 전달되었는지 여부
+  - 수락/거절 시: 리더의 응답에 따라 결과 메시지 생성
+- 출력: `S_PartyJoinReply`
+  ```protobuf
+  message S_PartyJoinReply {
+      bool success = 1;
+      string message = 2;
+  }
+  ```
+- 데이터 구조: 없음 (응답 패킷)
+
+### 메시지 종류
+
+#### 요청 전송 시
+- "Request sent to leader": 리더에게 요청 전달 성공
+- "Party not found": 파티가 존재하지 않음
+- "Party is full": 파티 인원이 가득 참 (4/4)
+- "Request already pending": 이미 대기 중인 요청이 있음
+
+#### 수락/거절 시
+- "Accepted": 리더가 가입 수락
+- "Rejected": 리더가 가입 거절
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 746-810, 812-859)
+
+### 클라이언트 처리
+- 요청 전송 결과: "가입 요청을 보냈습니다" 메시지 표시
+- 수락: 파티 UI 표시
+- 거절: "파티 가입이 거절되었습니다" 메시지 표시

--- a/Doc/Packet/S_PartyJoinRequestList_65.md
+++ b/Doc/Packet/S_PartyJoinRequestList_65.md
@@ -1,0 +1,51 @@
+# S_PartyJoinRequestList (65)
+
+### **파티 가입 요청 리스트 응답**
+
+- 설명: 서버가 파티 리더에게 대기 중인 가입 요청자들의 목록을 전송한다.
+- 입력: `C_PartyJoinRequestList` 처리 완료 후
+- 처리 로직:
+  - PartyManager에서 수집한 요청자 정보를 패킷에 담아 전송
+  - 빈 목록일 수 있음 (대기 요청이 없는 경우)
+- 출력: `S_PartyJoinRequestList`
+  ```protobuf
+  message S_PartyJoinRequestList {
+      int32 partyId = 1;
+      repeated PartyJoinRequesterInfo requesters = 2;
+  }
+
+  message PartyJoinRequesterInfo {
+      int32 playerId = 1;      // 요청자 플레이어 ID
+      string playerName = 2;    // 요청자 이름
+      int32 level = 3;          // 요청자 레벨
+  }
+  ```
+- 데이터 구조: `PartyJoinRequesterInfo` 배열
+
+### PartyJoinRequesterInfo 필드 설명
+- `playerId`: 요청자의 고유 ID (C_PartyJoinResponse의 requesterPid로 사용)
+- `playerName`: 요청자의 캐릭터 이름
+- `level`: 요청자의 레벨 (리더가 참고할 수 있는 정보)
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 876-914)
+
+### 클라이언트 UI 예시
+```
+[파티 가입 요청 (2건)]
+┌─────────────────────────────────┐
+│ PlayerB (Lv.8)                  │
+│ PlayerId: 100                   │
+│               [수락] [거절]      │
+├─────────────────────────────────┤
+│ PlayerC (Lv.12)                 │
+│ PlayerId: 101                   │
+│               [수락] [거절]      │
+└─────────────────────────────────┘
+```
+
+### 클라이언트 처리
+- `requesters.Count == 0`: "대기 중인 요청이 없습니다" 메시지 표시
+- `requesters.Count > 0`: 각 요청자 정보 표시 및 수락/거절 버튼
+- 수락 클릭 시: `C_PartyJoinResponse(partyId, playerId, true)` 전송
+- 거절 클릭 시: `C_PartyJoinResponse(partyId, playerId, false)` 전송

--- a/Doc/Packet/S_PartyList_63.md
+++ b/Doc/Packet/S_PartyList_63.md
@@ -1,0 +1,56 @@
+# S_PartyList (63)
+
+### **전체 공개 파티 목록 응답**
+
+- 설명: 서버가 클라이언트에게 현재 생성된 모든 공개 파티의 목록을 전송한다.
+- 입력: `C_PartyList` 처리 완료 후
+- 처리 로직:
+  - PartyManager에서 수집한 파티 정보를 패킷에 담아 전송
+- 출력: `S_PartyList`
+  ```protobuf
+  message S_PartyList {
+      repeated PartyInfo partyInfos = 1;
+  }
+
+  message PartyInfo {
+      int32 partyId = 1;
+      string partyName = 2;
+      repeated PartyMemberStatusInfo members = 3;
+      int32 curMemberCount = 4;
+      int32 maxMemberCount = 5;
+      int32 partyLeaderId = 6;
+  }
+
+  message PartyMemberStatusInfo {
+      int32 playerId = 1;
+      string playerName = 2;
+      int32 hp = 3;
+      int32 maxHp = 4;
+      int32 level = 5;
+      bool isLeader = 6;
+  }
+  ```
+- 데이터 구조: `PartyInfo` 배열
+
+### PartyInfo 필드 설명
+- `partyId`: 파티 고유 ID (가입 요청 시 사용)
+- `partyName`: 파티 이름
+- `members`: 현재 파티원 전체 상태 (PlayerId, 이름, HP, Level, 리더 여부)
+- `curMemberCount`: 현재 인원
+- `maxMemberCount`: 최대 인원 (4명)
+- `partyLeaderId`: 파티 리더의 PlayerId
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp` (Line 861-874)
+
+### 클라이언트 UI 예시
+```
+[파티 목록]
+┌─────────────────────────────────┐
+│ [1] 레이드 파티 (1/4)           │ [가입 요청]
+│     리더: PlayerA (Lv.10)       │
+├─────────────────────────────────┤
+│ [2] 던전 파티 (3/4)             │ [가입 요청]
+│     리더: PlayerB (Lv.15)       │
+└─────────────────────────────────┘
+```

--- a/Doc/Packet/S_PlayerDeathCommit_45.md
+++ b/Doc/Packet/S_PlayerDeathCommit_45.md
@@ -1,0 +1,25 @@
+# S_PlayerDeathCommit (45)
+
+### **플레이어 리스폰 승인**
+
+- 설명: 서버가 플레이어의 리스폰 요청을 승인하고 이동할 맵 정보를 전송한다.
+- 입력: `C_PlayerDeathReady` 처리 완료 후
+- 처리 로직:
+  - 리스폰 처리 완료
+  - 이동할 맵 ID 전송
+- 출력: `S_PlayerDeathCommit`
+  ```protobuf
+  message S_PlayerDeathCommit {
+      int32 mapId = 1;  // 리스폰될 맵 ID
+  }
+  ```
+- 데이터 구조: 없음
+
+### 패킷 순서
+1. `S_BroadcastPlayerDeath` (43번): 사망 알림
+2. `C_PlayerDeathReady` (44번): 클라이언트 준비 완료
+3. `S_PlayerDeathCommit` (45번): 서버 승인
+4. `S_ChangeRoomCommit` (20번): 실제 룸 전환
+
+### 관련 파일
+- `GameServer/ClientPacketHandler.cpp`

--- a/Doc/Packet/S_PlayerStat_40.md
+++ b/Doc/Packet/S_PlayerStat_40.md
@@ -1,0 +1,40 @@
+# S_PlayerStat (40)
+
+### **플레이어 스탯 정보 전송**
+
+- 설명: 서버가 플레이어의 현재 스탯 정보를 클라이언트에게 전송한다.
+- 입력: 플레이어 게임 입장 시, 스탯 변경 시
+- 처리 로직:
+  - 플레이어의 스탯 정보 수집
+  - PlayerStatInfo 패킷 생성 및 전송
+- 출력: `S_PlayerStat`
+  ```protobuf
+  message S_PlayerStat {
+      PlayerStatInfo statInfo = 1;
+  }
+
+  message PlayerStatInfo {
+      int32 maxHp = 1;
+      int32 hp = 2;
+      int32 curExp = 3;    // 현재 경험치
+      int32 maxExp = 4;    // 레벨업 필요 경험치
+      int32 level = 5;
+      int32 money = 6;
+  }
+  ```
+- 데이터 구조:
+  - `Player::_statInfo`: 플레이어 스탯
+
+### 전송 시점
+- 게임 입장 시
+- 레벨업 시
+- HP 변경 시
+- 경험치 획득 시
+- 돈 변경 시
+
+### 관련 파일
+- `GameServer/Player.cpp`
+- `GameServer/Room.cpp`
+
+### 클라이언트 처리
+UI에 플레이어 스탯 표시 (HP바, 경험치바, 레벨, 돈)

--- a/Doc/Packet/S_SystemMessage_33.md
+++ b/Doc/Packet/S_SystemMessage_33.md
@@ -1,0 +1,34 @@
+# S_SystemMessage (33)
+
+### **시스템 메시지**
+
+- 설명: 서버가 클라이언트에게 게임 내 시스템 메시지를 전송한다. 드롭 실패, 인벤토리 가득 참 등 다양한 상황에 사용.
+- 입력: 서버 내부 이벤트 발생 시
+- 처리 로직:
+  - 특정 이벤트 발생 시 메시지 생성
+  - 메시지 타입에 따라 클라이언트의 UI 표시 방식 다름
+- 출력: `S_SystemMessage`
+  ```protobuf
+  message S_SystemMessage {
+      string message = 1;
+      EMessageType type = 2;
+  }
+
+  enum EMessageType {
+      MESSAGE_INFO = 0;          // 일반 정보
+      MESSAGE_WARNING = 1;       // 경고
+      MESSAGE_ERROR = 2;         // 에러
+      MESSAGE_DROP_FAILED = 3;   // 드롭 실패
+  }
+  ```
+- 데이터 구조: 없음
+
+### 사용 예시
+- "인벤토리가 가득 찼습니다" (WARNING)
+- "아이템을 획득했습니다" (INFO)
+- "아이템 사용에 실패했습니다" (ERROR)
+- "아이템을 버릴 수 없습니다" (DROP_FAILED)
+
+### 관련 파일
+- `GameServer/InventorySystem.cpp`
+- `GameServer/ItemManager.cpp`

--- a/DummyClientCS/Packet/ServerPacketHandler.cs
+++ b/DummyClientCS/Packet/ServerPacketHandler.cs
@@ -511,11 +511,6 @@ namespace Packet
 
         internal static void HANDLE_S_BroadcastPartyUpdate(PacketSession session, S_BroadcastPartyUpdate update)
         {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("\n════════════════════════════════════════════════════════════════════════");
-            Console.WriteLine("[S_BroadcastPartyUpdate] 파티 상태 업데이트");
-            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
-
             string updateTypeStr = update.UpdateType switch
             {
                 EPartyUpdateType.PartyUpdateMemberJoin => "멤버 가입",
@@ -525,28 +520,127 @@ namespace Packet
                 _ => "알 수 없음"
             };
 
-            Console.WriteLine($"업데이트 타입: {updateTypeStr}");
-            Console.WriteLine($"현재 파티 인원: {update.Members.Count}명");
-            Console.WriteLine("");
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"[S_BroadcastPartyUpdate] {updateTypeStr} | 파티원: {update.Members.Count}명");
+            Console.ResetColor();
+        }
 
-            if (update.Members.Count > 0)
+        internal static void HANDLE_S_PartyCreateReply(PacketSession session, S_PartyCreateReply reply)
+        {
+            Console.ForegroundColor = reply.Success ? ConsoleColor.Green : ConsoleColor.Red;
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.WriteLine($"[S_PartyCreateReply] {(reply.Success ? "파티 생성 성공!" : "파티 생성 실패!")}");
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+
+            if (reply.Success)
             {
-                Console.WriteLine("파티원 목록:");
-                foreach (var member in update.Members)
-                {
-                    string leaderTag = member.IsLeader ? " [리더]" : "";
-                    string meTag = (member.PlayerId == NetDebug.MyPlayerId && NetDebug.MyPlayerId >= 0) ? " (나)" : "";
-
-                    Console.WriteLine($"  - PlayerId: {member.PlayerId}{meTag}{leaderTag}");
-                    Console.WriteLine($"    HP: {member.Hp}/{member.MaxHp} | Level: {member.Level}");
-                }
+                Console.WriteLine("파티가 성공적으로 생성되었습니다!");
+                Console.WriteLine("다른 플레이어들이 파티 리스트에서 확인할 수 있습니다.");
             }
             else
             {
-                Console.WriteLine("파티원이 없습니다. (파티가 해체되었을 수 있습니다)");
+                Console.WriteLine($"오류: {reply.Message}");
             }
 
             Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.ResetColor();
+        }
+
+        internal static void HANDLE_S_PartyJoinReply(PacketSession session, S_PartyJoinReply reply)
+        {
+            Console.ForegroundColor = reply.Success ? ConsoleColor.Green : ConsoleColor.Red;
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.WriteLine($"[S_PartyJoinReply] {(reply.Success ? "파티 가입 성공!" : "파티 가입 실패!")}");
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+
+            if (reply.Success)
+            {
+                Console.WriteLine("파티에 성공적으로 가입했습니다!");
+                Console.WriteLine("S_BroadcastPartyUpdate로 파티원 정보를 확인할 수 있습니다.");
+            }
+            else
+            {
+                Console.WriteLine($"메시지: {reply.Message}");
+            }
+
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.ResetColor();
+        }
+
+        internal static void HANDLE_S_PartyList(PacketSession session, S_PartyList list)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine("\n════════════════════════════════════════════════════════════════════════");
+            Console.WriteLine("[S_PartyList] 전체 파티 목록");
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+
+            if (list.PartyInfos.Count == 0)
+            {
+                Console.WriteLine("현재 생성된 파티가 없습니다.");
+            }
+            else
+            {
+                Console.WriteLine($"총 {list.PartyInfos.Count}개의 파티가 있습니다.\n");
+
+                foreach (var party in list.PartyInfos)
+                {
+                    Console.WriteLine($"────────────────────────────────────────");
+                    Console.WriteLine($"파티 ID: {party.PartyId}");
+                    Console.WriteLine($"파티명: {party.PartyName}");
+                    Console.WriteLine($"인원: {party.CurMemberCount}/{party.MaxMemberCount}");
+                    Console.WriteLine($"리더 ID: {party.PartyLeaderId}");
+
+                    if (party.Members.Count > 0)
+                    {
+                        Console.WriteLine($"멤버 목록:");
+                        foreach (var member in party.Members)
+                        {
+                            string leaderTag = member.IsLeader ? " [리더]" : "";
+                            string meTag = (member.PlayerId == NetDebug.MyPlayerId && NetDebug.MyPlayerId >= 0) ? " (나)" : "";
+                            Console.WriteLine($"  - PlayerId: {member.PlayerId}{meTag}{leaderTag} | Lv.{member.Level} | HP:{member.Hp}/{member.MaxHp}");
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.ResetColor();
+        }
+
+        internal static void HANDLE_S_PartyJoinNotify(PacketSession session, S_PartyJoinNotify notify)
+        {
+            Console.ForegroundColor = ConsoleColor.Magenta;
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.WriteLine("[S_PartyJoinNotify] 파티 가입 요청 알림 (리더 전용)");
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.WriteLine($"요청자 PlayerId: {notify.JoinPlayerId}");
+            Console.WriteLine($"파티 ID: {notify.PartyId}");
+            Console.WriteLine($"리더 ID: {notify.LeaderId}");
+            Console.WriteLine("");
+            Console.WriteLine($"가입 요청을 수락/거절하려면:");
+            Console.WriteLine($"  Program.cs에서 공개 파티 응답 기능을 사용하세요");
+            Console.WriteLine($"  (메뉴에서 리더 응답 기능 추가 필요)");
+            Console.WriteLine("════════════════════════════════════════════════════════════════════════");
+            Console.ResetColor();
+        }
+
+        internal static void HANDLE_S_PartyJoinRequestList(PacketSession session, S_PartyJoinRequestList list)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"\n[S_PartyJoinRequestList] 파티ID {list.PartyId} 가입 요청: {list.Requesters.Count}건");
+
+            if (list.Requesters.Count == 0)
+            {
+                Console.WriteLine("  → 대기 중인 요청이 없습니다.");
+            }
+            else
+            {
+                foreach (var requester in list.Requesters)
+                {
+                    Console.WriteLine($"  → [{requester.PlayerId}] {requester.PlayerName} (Lv.{requester.Level})");
+                }
+            }
+
             Console.ResetColor();
         }
     }

--- a/DummyClientCS/Packet/ServerPacketManager.cs
+++ b/DummyClientCS/Packet/ServerPacketManager.cs
@@ -64,6 +64,16 @@ namespace Packet
 	    PKT_C_PartyInviteResponse = 53,
 	    PKT_C_PartyLeave = 54,
 	    PKT_S_BroadcastPartyUpdate = 55,
+	    PKT_C_PartyCreateRequest = 56,
+	    PKT_S_PartyCreateReply = 57,
+	    PKT_C_PartyJoinRequest = 58,
+	    PKT_S_PartyJoinReply = 59,
+	    PKT_S_PartyJoinNotify = 60,
+	    PKT_C_PartyJoinResponse = 61,
+	    PKT_C_PartyList = 62,
+	    PKT_S_PartyList = 63,
+	    PKT_C_PartyJoinRequestList = 64,
+	    PKT_S_PartyJoinRequestList = 65,
     }
     public class ServerPacketManager
     {
@@ -108,6 +118,11 @@ namespace Packet
         public static ArraySegment<byte> MakeSendBuffer(C_PartyInviteRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyInviteRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_PartyInviteResponse pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyInviteResponse);
         public static ArraySegment<byte> MakeSendBuffer(C_PartyLeave pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyLeave);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyCreateRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyCreateRequest);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyJoinRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyJoinRequest);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyJoinResponse pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyJoinResponse);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyList pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyList);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyJoinRequestList pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyJoinRequestList);
 
         void Register()
         {
@@ -152,6 +167,11 @@ namespace Packet
             RegisterHandler((ushort)PacketID.PKT_S_PartyInviteNotify, ServerPacketHandler.HANDLE_S_PartyInviteNotify, S_PartyInviteNotify.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_PartyInviteReply, ServerPacketHandler.HANDLE_S_PartyInviteReply, S_PartyInviteReply.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPartyUpdate, ServerPacketHandler.HANDLE_S_BroadcastPartyUpdate, S_BroadcastPartyUpdate.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyCreateReply, ServerPacketHandler.HANDLE_S_PartyCreateReply, S_PartyCreateReply.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyJoinReply, ServerPacketHandler.HANDLE_S_PartyJoinReply, S_PartyJoinReply.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyJoinNotify, ServerPacketHandler.HANDLE_S_PartyJoinNotify, S_PartyJoinNotify.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyList, ServerPacketHandler.HANDLE_S_PartyList, S_PartyList.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyJoinRequestList, ServerPacketHandler.HANDLE_S_PartyJoinRequestList, S_PartyJoinRequestList.Parser);
             
                   
         }

--- a/DummyClientCS/Program.cs
+++ b/DummyClientCS/Program.cs
@@ -63,6 +63,13 @@ class Program
             Console.WriteLine("[f] 파티 초대 거절");
             Console.WriteLine("[q] 파티 탈퇴");
             Console.WriteLine("[w] 파티원 강퇴 (PlayerId 입력)");
+            Console.WriteLine("\n===== 공개 파티 시스템 (56-63번) =====");
+            Console.WriteLine("[v] 공개 파티 생성 (파티명 입력)");
+            Console.WriteLine("[b] 전체 파티 목록 조회");
+            Console.WriteLine("[n] 파티 가입 요청 (PartyId 입력)");
+            Console.WriteLine("[j] 리더: 가입 요청 리스트 조회");
+            Console.WriteLine("[m] 리더: 가입 요청 수락");
+            Console.WriteLine("[k] 리더: 가입 요청 거절");
             Console.WriteLine("\n===== 종료 로직 테스트 =====");
             Console.WriteLine("[x] 룸에서 나가기 (캐릭터 변경)");
             Console.WriteLine("[l] 로그아웃 테스트 (JWT 인증 상태로 복귀)");
@@ -508,6 +515,128 @@ class Program
                     }
 
                     await SessionManager.Instance.SendPartyKick(kickTargetPid);
+                    break;
+                case "v":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("생성할 파티명 입력: ");
+                    string? partyName = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(partyName))
+                    {
+                        Console.WriteLine("파티명을 입력해주세요!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendPartyCreateRequest(partyName);
+                    break;
+                case "b":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendPartyListRequest();
+                    break;
+                case "n":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("가입할 파티 ID 입력: ");
+                    string? joinPartyIdInput = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(joinPartyIdInput))
+                    {
+                        Console.WriteLine("파티 ID를 입력해주세요!");
+                        break;
+                    }
+                    if (!Int32.TryParse(joinPartyIdInput, out int joinPartyId))
+                    {
+                        Console.WriteLine("파티 ID는 숫자여야 합니다!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendPartyJoinRequest(joinPartyId);
+                    break;
+                case "j":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("[리더] 조회할 파티 ID 입력: ");
+                    string? queryPartyIdInput = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(queryPartyIdInput))
+                    {
+                        Console.WriteLine("파티 ID를 입력해주세요!");
+                        break;
+                    }
+                    if (!Int32.TryParse(queryPartyIdInput, out int queryPartyId))
+                    {
+                        Console.WriteLine("파티 ID는 숫자여야 합니다!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendPartyJoinRequestListQuery(queryPartyId);
+                    break;
+                case "m":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("[리더] 파티 ID 입력: ");
+                    string? acceptResponsePartyIdInput = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(acceptResponsePartyIdInput) || !Int32.TryParse(acceptResponsePartyIdInput, out int acceptResponsePartyId))
+                    {
+                        Console.WriteLine("올바른 파티 ID를 입력해주세요!");
+                        break;
+                    }
+
+                    Console.Write("[리더] 수락할 요청자 PlayerId 입력: ");
+                    string? acceptRequesterInput = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(acceptRequesterInput) || !Int32.TryParse(acceptRequesterInput, out int acceptRequesterPid))
+                    {
+                        Console.WriteLine("올바른 PlayerId를 입력해주세요!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendPartyJoinResponseWithPid(acceptResponsePartyId, acceptRequesterPid, true);
+                    break;
+                case "k":
+                    if (!_isInGame)
+                    {
+                        Console.WriteLine("먼저 게임 접속(8번)을 완료해야 합니다!");
+                        break;
+                    }
+                    Console.Write("[리더] 파티 ID 입력: ");
+                    string? rejectResponsePartyIdInput = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(rejectResponsePartyIdInput) || !Int32.TryParse(rejectResponsePartyIdInput, out int rejectResponsePartyId))
+                    {
+                        Console.WriteLine("올바른 파티 ID를 입력해주세요!");
+                        break;
+                    }
+
+                    Console.Write("[리더] 거절할 요청자 PlayerId 입력: ");
+                    string? rejectRequesterInput = Console.ReadLine();
+
+                    if (string.IsNullOrWhiteSpace(rejectRequesterInput) || !Int32.TryParse(rejectRequesterInput, out int rejectRequesterPid))
+                    {
+                        Console.WriteLine("올바른 PlayerId를 입력해주세요!");
+                        break;
+                    }
+
+                    await SessionManager.Instance.SendPartyJoinResponseWithPid(rejectResponsePartyId, rejectRequesterPid, false);
                     break;
                 case "x":
                     if (!_isInGame)

--- a/DummyClientCS/SessionManager.cs
+++ b/DummyClientCS/SessionManager.cs
@@ -498,7 +498,137 @@ namespace DummyClientCS
                     };
                     session.Send(ServerPacketManager.MakeSendBuffer(pkt));
                     Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine($"⚠️ [파티 강퇴] PlayerId {targetPid}를 강퇴합니다.");
+                    Console.WriteLine($"[파티 강퇴] PlayerId {targetPid}를 파티에서 강퇴했습니다.");
+                    Console.ResetColor();
+                }
+            }
+        }
+
+        // ========== 공개 파티 시스템 (56-63번 프로토콜) ==========
+
+        // 파티 생성 (파티명 지정)
+        public async Task SendPartyCreateRequest(string partyName)
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_PartyCreateRequest
+                    {
+                        PartyName = partyName
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.WriteLine($"[파티 생성] 파티명 '{partyName}'으로 파티 생성 요청을 보냈습니다.");
+                    Console.ResetColor();
+                }
+            }
+        }
+
+        // 전체 파티 리스트 조회
+        public async Task SendPartyListRequest()
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_PartyList
+                    {
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.WriteLine("[파티 리스트] 전체 파티 목록 조회 요청을 보냈습니다.");
+                    Console.ResetColor();
+                }
+            }
+        }
+
+        // 파티 가입 요청
+        public async Task SendPartyJoinRequest(int partyId)
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_PartyJoinRequest
+                    {
+                        PartyId = partyId
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.WriteLine($"[파티 가입 요청] 파티ID {partyId}에 가입 요청을 보냈습니다.");
+                    Console.ResetColor();
+                }
+            }
+        }
+
+        // 파티 가입 요청 응답 (리더 전용 - 수락/거절)
+        public async Task SendPartyJoinResponse(int partyId, bool accept)
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_PartyJoinResponse
+                    {
+                        PartyId = partyId,
+                        Accept = accept
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.ForegroundColor = accept ? ConsoleColor.Green : ConsoleColor.Red;
+                    Console.WriteLine($"[리더 응답] 파티ID {partyId}의 가입 요청을 {(accept ? "수락" : "거절")}했습니다.");
+                    Console.ResetColor();
+                }
+            }
+        }
+
+        // 파티 가입 요청 리스트 조회 (리더 전용)
+        public async Task SendPartyJoinRequestListQuery(int partyId)
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_PartyJoinRequestList
+                    {
+                        PartyId = partyId
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.ForegroundColor = ConsoleColor.Cyan;
+                    Console.WriteLine($"[요청 리스트 조회] 파티ID {partyId}의 가입 요청 목록을 조회합니다.");
+                    Console.ResetColor();
+                }
+            }
+        }
+
+        // 파티 가입 요청 응답 (리더 전용 - requesterPid 지정)
+        public async Task SendPartyJoinResponseWithPid(int partyId, int requesterPid, bool accept)
+        {
+            if (!_canSendPackets) return;
+
+            lock (_lock)
+            {
+                foreach (ServerSession session in _sessions)
+                {
+                    var pkt = new Google.Protobuf.Protocol.C_PartyJoinResponse
+                    {
+                        PartyId = partyId,
+                        RequesterPid = requesterPid,
+                        Accept = accept
+                    };
+                    session.Send(ServerPacketManager.MakeSendBuffer(pkt));
+                    Console.ForegroundColor = accept ? ConsoleColor.Green : ConsoleColor.Red;
+                    Console.WriteLine($"[리더 응답] PlayerId {requesterPid}의 가입 요청을 {(accept ? "수락" : "거절")}했습니다.");
                     Console.ResetColor();
                 }
             }

--- a/GameServer/ClientPacketHandler.cpp
+++ b/GameServer/ClientPacketHandler.cpp
@@ -704,3 +704,211 @@ bool Handle_C_PartyLeave(PacketSessionRef& session, Protocol::C_PartyLeave& pkt)
 	return true;
 
 }
+
+bool Handle_C_PartyCreateRequest(PacketSessionRef& session, Protocol::C_PartyCreateRequest& pkt)
+{
+	GameSessionRef gameSession = static_pointer_cast<GameSession>(session);
+
+	if (gameSession->GetState() != GameSession::State::InRoom)
+		return false;
+
+	PlayerRef player = gameSession->_currentPlayer;
+	if (!player)
+		return false;
+
+	RoomRef room = player->GetRoom();
+	if (!room)
+		return false;
+
+	if (!player || player->IsInParty())
+	{
+		Protocol::S_PartyCreateReply replyPkt;
+		replyPkt.set_success(false);
+		replyPkt.set_message("Already in party");
+
+		auto SendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+		session->Send(SendBuffer);
+		return false;
+	}
+
+	PartyRef party = PartyManager::Instance().CreatePartyWithName(player, pkt.partyname());
+
+	Protocol::S_PartyCreateReply replyPkt;
+	replyPkt.set_success(party != nullptr);
+	replyPkt.set_message(party ? "Party created" : "Failed to create party");
+
+	auto SendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+	session->Send(SendBuffer);
+
+	return true;
+}
+
+bool Handle_C_PartyJoinRequest(PacketSessionRef& session, Protocol::C_PartyJoinRequest& pkt)
+{
+	GameSessionRef gameSession = static_pointer_cast<GameSession>(session);
+
+	if (gameSession->GetState() != GameSession::State::InRoom)
+		return false;
+
+	PlayerRef player = gameSession->_currentPlayer;
+	if (!player)
+		return false;
+
+	RoomRef room = player->GetRoom();
+	if (!room)
+		return false;
+
+	PartyRef party = PartyManager::Instance().FindParty(pkt.partyid());
+
+	if (!party)
+	{
+		// 파티가 존재하지 않음
+		Protocol::S_PartyJoinReply replyPkt;
+		replyPkt.set_success(false);
+		replyPkt.set_message("Party not found");
+		auto SendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+		session->Send(SendBuffer);
+		return false;
+	}
+
+	if (party->IsFull())
+	{
+		Protocol::S_PartyJoinReply replyPkt;
+		replyPkt.set_success(false);
+		replyPkt.set_message("Party is full");
+		auto SendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+		session->Send(SendBuffer);
+		return false;
+	}
+
+	bool added = PartyManager::Instance().AddJoinRequest(pkt.partyid(), player);
+
+	Protocol::S_PartyJoinReply replyPkt;
+	replyPkt.set_success(added);
+	replyPkt.set_message(added ? "Request sent to leader" : "Request already pending");
+	auto SendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+	session->Send(SendBuffer);
+
+	// 리더에게 알림 전송
+	if (added)
+	{
+		PlayerRef leader = party->GetLeader();
+
+		if (auto leaderSession = leader->ownerSession.lock())
+		{
+			Protocol::S_PartyJoinNotify notifyPkt;
+			notifyPkt.set_joinplayerid(player->playerId);
+			notifyPkt.set_partyid(pkt.partyid());
+			notifyPkt.set_leaderid(leader->playerId);
+
+			auto SendBuffer = ClientPacketHandler::MakeSendBuffer(notifyPkt);
+			leaderSession->Send(SendBuffer);
+		}
+	}
+
+	return true;
+}
+
+bool Handle_C_PartyJoinResponse(PacketSessionRef& session, Protocol::C_PartyJoinResponse& pkt)
+{
+	GameSessionRef gameSession = static_pointer_cast<GameSession>(session);
+
+	if (gameSession->GetState() != GameSession::State::InRoom)
+		return false;
+
+	PlayerRef player = gameSession->_currentPlayer;
+	if (!player)
+		return false;
+
+	RoomRef room = player->GetRoom();
+	if (!room)
+		return false;
+
+	PartyRef party = PartyManager::Instance().FindParty(pkt.partyid());
+
+	if (!party || party->GetLeader() != player)
+	{
+		return false; // 리더가 아니거나 파티가 없음
+	}
+
+	// 변경: requesterPid로 특정 요청자 찾기
+	PlayerRef requester = PartyManager::Instance().FindRequesterById(pkt.partyid(), pkt.requesterpid());
+	
+	// 요청자가 없으면 종료
+	if (!requester)
+		return true;
+
+	if (pkt.accept())
+	{
+		// 수락: 파티에 가입시킴
+		bool success = PartyManager::Instance().JoinParty(pkt.partyid(), requester);
+
+		// Option 요청자에게 결과 전송
+		if (success)
+		{
+			PartyManager::Instance().RemoveJoinRequest(pkt.partyid(), requester);
+		}
+	}
+	else
+	{
+		// 거절: 요청 제거
+		PartyManager::Instance().RemoveJoinRequest(pkt.partyid(), requester);
+	}
+
+	return true;
+}
+
+bool Handle_C_PartyList(PacketSessionRef& session, Protocol::C_PartyList& pkt)
+{
+	Vector<Protocol::PartyInfo> parties = PartyManager::Instance().GetAllPublicParties();
+
+	Protocol::S_PartyList replyPkt;
+	for (auto& partyInfo : parties)
+	{
+		*replyPkt.add_partyinfos() = partyInfo;
+	}
+
+	auto SendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+	session->Send(SendBuffer);
+	return true;
+}
+
+bool Handle_C_PartyJoinRequestList(PacketSessionRef& session, Protocol::C_PartyJoinRequestList& pkt)
+{
+	GameSessionRef gameSession = static_pointer_cast<GameSession>(session);
+
+	if (gameSession->GetState() != GameSession::State::InRoom)
+		return false;
+
+	PlayerRef player = gameSession->_currentPlayer;
+	if (!player)
+		return false;
+
+	PartyRef party = PartyManager::Instance().FindParty(pkt.partyid());
+
+	if (!party || party->GetLeader() != player)
+	{
+		return false; // 리더가 아니면 조회 불가
+	}
+
+	// 요청자 리스트 가져오기
+	Vector<PlayerRef> requesters = PartyManager::Instance().GetJoinRequesters(pkt.partyid());
+
+	Protocol::S_PartyJoinRequestList replyPkt;
+	replyPkt.set_partyid(pkt.partyid());
+
+	for (const auto& requester : requesters)
+	{
+		if (!requester) continue;
+
+		auto* info = replyPkt.add_requesters();
+		info->set_playerid(requester->playerId);
+		info->set_playername(requester->username);
+		info->set_level(requester->Level());
+	}
+
+	auto SendBuffer = ClientPacketHandler::MakeSendBuffer(replyPkt);
+	session->Send(SendBuffer);
+
+	return true;
+}

--- a/GameServer/ClientPacketHandler.h
+++ b/GameServer/ClientPacketHandler.h
@@ -63,6 +63,16 @@ enum : uint16
 	PKT_C_PartyInviteResponse = 53,
 	PKT_C_PartyLeave = 54,
 	PKT_S_BroadcastPartyUpdate = 55,
+	PKT_C_PartyCreateRequest = 56,
+	PKT_S_PartyCreateReply = 57,
+	PKT_C_PartyJoinRequest = 58,
+	PKT_S_PartyJoinReply = 59,
+	PKT_S_PartyJoinNotify = 60,
+	PKT_C_PartyJoinResponse = 61,
+	PKT_C_PartyList = 62,
+	PKT_S_PartyList = 63,
+	PKT_C_PartyJoinRequestList = 64,
+	PKT_S_PartyJoinRequestList = 65,
 
 };
 
@@ -88,6 +98,11 @@ bool Handle_C_GiveItemRequest(PacketSessionRef& session, Protocol::C_GiveItemReq
 bool Handle_C_PartyInviteRequest(PacketSessionRef& session, Protocol::C_PartyInviteRequest& pkt);
 bool Handle_C_PartyInviteResponse(PacketSessionRef& session, Protocol::C_PartyInviteResponse& pkt);
 bool Handle_C_PartyLeave(PacketSessionRef& session, Protocol::C_PartyLeave& pkt);
+bool Handle_C_PartyCreateRequest(PacketSessionRef& session, Protocol::C_PartyCreateRequest& pkt);
+bool Handle_C_PartyJoinRequest(PacketSessionRef& session, Protocol::C_PartyJoinRequest& pkt);
+bool Handle_C_PartyJoinResponse(PacketSessionRef& session, Protocol::C_PartyJoinResponse& pkt);
+bool Handle_C_PartyList(PacketSessionRef& session, Protocol::C_PartyList& pkt);
+bool Handle_C_PartyJoinRequestList(PacketSessionRef& session, Protocol::C_PartyJoinRequestList& pkt);
 
 class ClientPacketHandler
 {
@@ -118,6 +133,11 @@ public:
 		GPacketHandler[PKT_C_PartyInviteRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyInviteRequest>(Handle_C_PartyInviteRequest, session, buffer, len); };
 		GPacketHandler[PKT_C_PartyInviteResponse] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyInviteResponse>(Handle_C_PartyInviteResponse, session, buffer, len); };
 		GPacketHandler[PKT_C_PartyLeave] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyLeave>(Handle_C_PartyLeave, session, buffer, len); };
+		GPacketHandler[PKT_C_PartyCreateRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyCreateRequest>(Handle_C_PartyCreateRequest, session, buffer, len); };
+		GPacketHandler[PKT_C_PartyJoinRequest] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyJoinRequest>(Handle_C_PartyJoinRequest, session, buffer, len); };
+		GPacketHandler[PKT_C_PartyJoinResponse] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyJoinResponse>(Handle_C_PartyJoinResponse, session, buffer, len); };
+		GPacketHandler[PKT_C_PartyList] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyList>(Handle_C_PartyList, session, buffer, len); };
+		GPacketHandler[PKT_C_PartyJoinRequestList] = [](PacketSessionRef& session, BYTE* buffer, int32 len) {return HandlePacket<Protocol::C_PartyJoinRequestList>(Handle_C_PartyJoinRequestList, session, buffer, len); };
 		
 	}
 	static bool HandlePacket(PacketSessionRef& session, BYTE* buffer, int32 len)
@@ -162,6 +182,11 @@ public:
 	static SendBufferRef MakeSendBuffer(Protocol::S_PartyInviteNotify& pkt) { return MakeSendBuffer(pkt, PKT_S_PartyInviteNotify); };
 	static SendBufferRef MakeSendBuffer(Protocol::S_PartyInviteReply& pkt) { return MakeSendBuffer(pkt, PKT_S_PartyInviteReply); };
 	static SendBufferRef MakeSendBuffer(Protocol::S_BroadcastPartyUpdate& pkt) { return MakeSendBuffer(pkt, PKT_S_BroadcastPartyUpdate); };
+	static SendBufferRef MakeSendBuffer(Protocol::S_PartyCreateReply& pkt) { return MakeSendBuffer(pkt, PKT_S_PartyCreateReply); };
+	static SendBufferRef MakeSendBuffer(Protocol::S_PartyJoinReply& pkt) { return MakeSendBuffer(pkt, PKT_S_PartyJoinReply); };
+	static SendBufferRef MakeSendBuffer(Protocol::S_PartyJoinNotify& pkt) { return MakeSendBuffer(pkt, PKT_S_PartyJoinNotify); };
+	static SendBufferRef MakeSendBuffer(Protocol::S_PartyList& pkt) { return MakeSendBuffer(pkt, PKT_S_PartyList); };
+	static SendBufferRef MakeSendBuffer(Protocol::S_PartyJoinRequestList& pkt) { return MakeSendBuffer(pkt, PKT_S_PartyJoinRequestList); };
 
 private:
 	template<typename PacketType, typename ProcessFunc>

--- a/GameServer/Party.cpp
+++ b/GameServer/Party.cpp
@@ -3,11 +3,16 @@
 #include "Player.h"
 #include "GameSession.h"
 
-Party::Party(int32 partyId, PlayerRef leader)
-    : _partyId(partyId), _leader(leader)
+Party::Party(int32 partyId, const string& partyName, PlayerRef leader)
+    : _partyId(partyId), _partyName(partyName), _leader(leader)
 {
     _members.reserve(MAX_MEMBERS);
     _members.push_back(leader);
+}
+
+void Party::SetPartyName(const string& name)
+{
+    _partyName = name;
 }
 
 bool Party::AddMember(PlayerRef player)
@@ -105,14 +110,14 @@ Vector<PlayerRef> Party::GetOnlineMembers()
     return onlineMembers;
 }
 
-const Vector<Protocol::PartyMemberInfoStatus> Party::GetMemberInfoStatus() const
+const Vector<Protocol::PartyMemberStatusInfo> Party::GetMemberStatusInfo() const
 {
-    Vector<Protocol::PartyMemberInfoStatus> memberInfos;
+    Vector<Protocol::PartyMemberStatusInfo> memberInfos;
     memberInfos.reserve(MAX_MEMBERS);
     
     for (const auto& member : _members)
     {
-        Protocol::PartyMemberInfoStatus memberInfo;
+        Protocol::PartyMemberStatusInfo memberInfo;
         memberInfo.set_playerid(member->playerId);
         memberInfo.set_hp(member->Hp());
         memberInfo.set_maxhp(member->MaxHp());
@@ -122,4 +127,33 @@ const Vector<Protocol::PartyMemberInfoStatus> Party::GetMemberInfoStatus() const
     }
 
     return memberInfos;
+}
+
+string Party::GetPartyName() const
+{
+    return _partyName;
+}
+
+int32 Party::GetCurrentMemberCount() const
+{
+    return _members.size();
+}
+
+Protocol::PartyInfo Party::GetPartyInfo() const
+{
+    Protocol::PartyInfo info;
+    info.set_partyid(_partyId);
+    info.set_partyname(_partyName);
+    
+    auto memberInfos = GetMemberStatusInfo();
+    for (auto& member : memberInfos)
+    {
+        *info.add_members() = member;
+    }
+
+    info.set_curmembercount(GetCurrentMemberCount());
+    info.set_maxmembercount(MAX_MEMBERS);
+    info.set_partyleaderid(GetLeader()->playerId);
+
+    return info;
 }

--- a/GameServer/Party.h
+++ b/GameServer/Party.h
@@ -7,7 +7,10 @@ public:
 public:
 	static constexpr int32 MAX_MEMBERS = 4;
 
-	explicit Party(int32 partyId, PlayerRef leader);
+	explicit Party(int32 partyId, const string& partyName, PlayerRef leader);
+
+	// 파티 관리
+	void SetPartyName(const string& name);
 
 	// 멤버 관리
 	bool AddMember(PlayerRef player);
@@ -20,10 +23,14 @@ public:
 	PlayerRef GetLeader() const;
 	const Vector<PlayerRef>& GetMembers() const;
 	Vector<PlayerRef> GetOnlineMembers();
-	const Vector<Protocol::PartyMemberInfoStatus> GetMemberInfoStatus() const;
+	const Vector<Protocol::PartyMemberStatusInfo> GetMemberStatusInfo() const;
+	string GetPartyName() const;
+	int32 GetCurrentMemberCount() const;
+	Protocol::PartyInfo GetPartyInfo() const;
 private:
 	int32 _partyId;
 	PlayerRef _leader;
+	string _partyName;
 	Vector<PlayerRef> _members;
 };
 

--- a/GameServer/PartyManager.cpp
+++ b/GameServer/PartyManager.cpp
@@ -13,7 +13,26 @@ PartyRef PartyManager::CreateParty(PlayerRef leader)
 
     int32 partyId = _nextPartyId.fetch_add(1);
 
-    PartyRef partyRef = MakeShared<Party>(partyId, leader);
+    PartyRef partyRef = MakeShared<Party>(partyId, "", leader);
+
+    _parties[partyId] = partyRef;
+    _playerToParty[leader] = partyId;
+
+    leader->SetPartyId(partyId);
+
+    PartyService::Instance().SendPartyStatusUpdate(partyId, Protocol::EPartyUpdateType::PARTY_UPDATE_MEMBER_JOIN);
+    return partyRef;
+}
+
+PartyRef PartyManager::CreatePartyWithName(PlayerRef leader, const string& partyName)
+{
+    WRITE_LOCK;
+
+    if (leader->IsInParty()) return FindPlayerParty(leader);
+
+    int32 partyId = _nextPartyId.fetch_add(1);
+
+    PartyRef partyRef = MakeShared<Party>(partyId, partyName, leader);
 
     _parties[partyId] = partyRef;
     _playerToParty[leader] = partyId;
@@ -135,4 +154,122 @@ int32 PartyManager::GetPlayerPartyId(PlayerRef player)
 {
     READ_LOCK;
     return player->GetPartyId();
+}
+
+Vector<Protocol::PartyInfo> PartyManager::GetAllPublicParties()
+{
+    READ_LOCK;
+
+    Vector<Protocol::PartyInfo> partyInfos;
+    partyInfos.reserve(_parties.size());
+
+    for (const auto& [partyId, party] : _parties)
+    {
+        if (!party) continue;
+
+        partyInfos.push_back(party->GetPartyInfo());
+
+        // 파티명이 있는 공개 파티만 조회 (파티명 없으면 초대전용 파티)
+        /*if (!party->GetPartyName().empty())
+        {
+            partyInfos.push_back(party->GetPartyInfo());
+        }*/
+    }
+
+    return partyInfos;
+}
+
+bool PartyManager::AddJoinRequest(int32 partyId, PlayerRef requester)
+{
+    WRITE_LOCK;
+
+    if (!requester) return false;
+
+    auto& requestQueue = _partyJoinRequests[partyId];
+
+    // 이미 요청이 있는지 확인
+    auto it = std::find(requestQueue.begin(), requestQueue.end(), requester);
+    if (it != requestQueue.end())
+    {
+        return false; // 중복 요청
+    }
+
+    requestQueue.push_back(requester);
+    return true;
+}
+
+bool PartyManager::HasPendingRequest(int32 partyId, PlayerRef requester)
+{
+    READ_LOCK;
+
+    auto it = _partyJoinRequests.find(partyId);
+    if (it == _partyJoinRequests.end()) return false;
+
+    const auto& requestQueue = it->second;
+    return std::find(requestQueue.begin(), requestQueue.end(), requester) != requestQueue.end();
+}
+
+bool PartyManager::RemoveJoinRequest(int32 partyId, PlayerRef requester)
+{
+    WRITE_LOCK;
+
+    auto it = _partyJoinRequests.find(partyId);
+    if (it == _partyJoinRequests.end() || it->second.empty())
+    {
+        return false;
+    }
+
+    // 특정 requester 찾아서 제거
+    auto& requestQueue = it->second;
+    auto reqIt = std::find(requestQueue.begin(), requestQueue.end(), requester);
+
+    if (reqIt == requestQueue.end())
+    {
+        return false; // 해당 requester 없음
+    }
+
+    requestQueue.erase(reqIt);
+
+    // 큐가 비었으면 맵에서도 제거
+    if (requestQueue.empty())
+    {
+        _partyJoinRequests.erase(it);
+    }
+
+    return true;
+}
+
+PlayerRef PartyManager::FindRequesterById(int32 partyId, int32 requesterPid)
+{
+    READ_LOCK;
+
+    auto it = _partyJoinRequests.find(partyId);
+    if (it == _partyJoinRequests.end())
+    {
+        return nullptr;
+    }
+
+    const auto& requesters = it->second;
+    for (const auto& requester : requesters)
+    {
+        if (requester->playerId == requesterPid)
+        {
+            return requester;
+        }
+    }
+
+    return nullptr;
+}
+
+Vector<PlayerRef> PartyManager::GetJoinRequesters(int32 partyId)
+{
+    READ_LOCK;
+
+    auto it = _partyJoinRequests.find(partyId);
+    if (it == _partyJoinRequests.end())
+    {
+        return Vector<PlayerRef>(); // 빈 벡터 반환
+    }
+
+    return it->second; // 전체 요청자 리스트 반환
 }

--- a/GameServer/PartyManager.h
+++ b/GameServer/PartyManager.h
@@ -14,6 +14,7 @@ public:
 
 	// 파티 관리
 	PartyRef CreateParty(PlayerRef leader);
+	PartyRef CreatePartyWithName(PlayerRef leader, const string& partyName);
 	bool DisbandParty(int32 partyId);
 	bool JoinParty(int32 partyId, PlayerRef player);
 	bool LeaveParty(PlayerRef player);
@@ -23,12 +24,22 @@ public:
 	PartyRef FindParty(int32 partyId);
 	PartyRef FindPlayerParty(PlayerRef player);
 	int32 GetPlayerPartyId(PlayerRef player);
+	Vector<Protocol::PartyInfo> GetAllPublicParties(); // 전체 파티 목록 조회
 
 	template <typename T, typename... Ts>
 	bool IsSameParty(const T& first, const Ts&... rest)
 	{
 		return ((first == rest) && ...);
 	}
+
+	// 파티 가입 요청 관리
+	bool AddJoinRequest(int32 partyId, PlayerRef requester);
+	bool HasPendingRequest(int32 partyId, PlayerRef requester);
+	bool RemoveJoinRequest(int32 partyId, PlayerRef requester);
+
+	Vector<PlayerRef> GetJoinRequesters(int32 partyId); // 전체 요청자 리스트
+	PlayerRef FindRequesterById(int32 partyId, int32 requesterPid); // 특정 요청자
+
 
 private:
 	PartyManager() = default;
@@ -39,6 +50,8 @@ private:
 	atomic<int32> _nextPartyId {1};
 	unordered_map<int32, PartyRef> _parties;
 	unordered_map<PlayerRef, int32> _playerToParty;
+	unordered_map<int32, Vector<PlayerRef>> _partyJoinRequests; // 파티별 가입 요청 대기엽
+
 	USE_LOCK;
 	bool _initialized = false;
 

--- a/Protocol/Protocol.proto
+++ b/Protocol/Protocol.proto
@@ -61,6 +61,16 @@ enum MsgId
 	C_PARTY_INVITE_RESPONSE = 53;
 	C_PARTY_LEAVE = 54;
 	S_BROADCAST_PARTY_UPDATE = 55;
+	C_PARTY_CREATE_REQUEST = 56;
+	S_PARTY_CREATE_REPLY = 57;
+	C_PARTY_JOIN_REQUEST = 58;
+	S_PARTY_JOIN_REPLY = 59;
+	S_PARTY_JOIN_NOTIFY = 60;
+	C_PARTY_JOIN_RESPONSE = 61;
+	C_PARTY_LIST = 62;
+	S_PARTY_LIST = 63;
+	C_PARTY_JOIN_REQUEST_LIST = 64;
+	S_PARTY_JOIN_REQUEST_LIST = 65;
 }
 
 // 클라 -> 게임 서버 jwt 로그인 인증 (0)
@@ -419,7 +429,74 @@ message C_PartyLeave
 message S_BroadcastPartyUpdate
 {
 	EPartyUpdateType updateType = 1;
-	repeated PartyMemberInfoStatus members = 2;
+	repeated PartyMemberStatusInfo members = 2;
+}
+
+// (56) 클라 -> 서버 : 파티 생성 요청
+message C_PartyCreateRequest
+{
+	string partyName = 1;
+}
+
+// (57) 서버 -> 클라 : 파티 생성 요청 결과 (성공 여부)
+message S_PartyCreateReply
+{
+	bool success = 1;
+	string message = 2;
+}
+
+// (58) 클라 -> 서버 : 파티 가입 요청
+message C_PartyJoinRequest
+{
+	int32 partyId = 1;
+}
+
+// (59) 서버 -> 클라 : 파티 가입 요청 결과 (성공 여부)
+message S_PartyJoinReply
+{
+	bool success = 1;
+	string message = 2;
+}
+
+// (60) 서버 -> 클라 : 다른 사람이 파티 가입 요청 -> 리더에게 전달
+message S_PartyJoinNotify 
+{
+	int32 joinPlayerId = 1;
+	int32 PartyId = 2;
+	int32 leaderId = 3;
+}
+
+// (61) 클라 -> 서버 : 파티 가입 요청 수락 or 거절 (리더)
+message C_PartyJoinResponse
+{
+	int32 partyId = 1; 
+	int32 requesterPid = 2; 
+	bool accept = 3; // 가입 여부
+}
+
+// (62) 클라 -> 서버 : 전체 파티 리스트 요청
+message C_PartyList
+{
+	
+}
+
+// (63) 서버 -> 클라 : 전체 파티 리스트 
+message S_PartyList
+{
+	repeated PartyInfo partyInfos = 1;
+}
+
+// (64) 클라 -> 서버 : 파티 가입 요청 리스트 조회
+message C_PartyJoinRequestList
+{
+    int32 partyId = 1;
+}
+
+// (65) 서버 -> 클라 : 파티 가입 요청 리스트 응답
+message S_PartyJoinRequestList
+{
+    int32 partyId = 1;
+    repeated PartyJoinRequesterInfo requesters = 2;
 }
 
 enum ELoginResult
@@ -590,11 +667,29 @@ message PlayerChatInfo
 	EChatType chatType = 5; 
 }
 
-message PartyMemberInfoStatus
+message PartyMemberStatusInfo
 {
 	int32 playerId = 1;
-	int32 hp = 2;
-	int32 maxHp = 3;
-	int32 level = 4;
-	bool isLeader = 5;
+	string playerName = 2;
+	int32 hp = 3;
+	int32 maxHp = 4;
+	int32 level = 5;
+	bool isLeader = 6;
+}
+
+message PartyInfo
+{
+	int32 partyId = 1;
+	string partyName = 2;
+	repeated PartyMemberStatusInfo members = 3;
+	int32 curMemberCount = 4;
+	int32 maxMemberCount = 5;
+	int32 partyLeaderId = 6;
+}
+
+message PartyJoinRequesterInfo
+{
+    int32 playerId = 1;
+    string playerName = 2;
+    int32 level = 3;
 }

--- a/TestClientUnity/Assets/@Scripts/Packet/ServerPacketManager.cs
+++ b/TestClientUnity/Assets/@Scripts/Packet/ServerPacketManager.cs
@@ -64,6 +64,16 @@ namespace Packet
 	    PKT_C_PartyInviteResponse = 53,
 	    PKT_C_PartyLeave = 54,
 	    PKT_S_BroadcastPartyUpdate = 55,
+	    PKT_C_PartyCreateRequest = 56,
+	    PKT_S_PartyCreateReply = 57,
+	    PKT_C_PartyJoinRequest = 58,
+	    PKT_S_PartyJoinReply = 59,
+	    PKT_S_PartyJoinNotify = 60,
+	    PKT_C_PartyJoinResponse = 61,
+	    PKT_C_PartyList = 62,
+	    PKT_S_PartyList = 63,
+	    PKT_C_PartyJoinRequestList = 64,
+	    PKT_S_PartyJoinRequestList = 65,
     }
     public class ServerPacketManager
     {
@@ -108,6 +118,11 @@ namespace Packet
         public static ArraySegment<byte> MakeSendBuffer(C_PartyInviteRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyInviteRequest);
         public static ArraySegment<byte> MakeSendBuffer(C_PartyInviteResponse pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyInviteResponse);
         public static ArraySegment<byte> MakeSendBuffer(C_PartyLeave pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyLeave);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyCreateRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyCreateRequest);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyJoinRequest pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyJoinRequest);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyJoinResponse pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyJoinResponse);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyList pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyList);
+        public static ArraySegment<byte> MakeSendBuffer(C_PartyJoinRequestList pkt) => MakeSendBuffer(pkt, (ushort)PacketID.PKT_C_PartyJoinRequestList);
 
         void Register()
         {
@@ -152,6 +167,11 @@ namespace Packet
             RegisterHandler((ushort)PacketID.PKT_S_PartyInviteNotify, ServerPacketHandler.HANDLE_S_PartyInviteNotify, S_PartyInviteNotify.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_PartyInviteReply, ServerPacketHandler.HANDLE_S_PartyInviteReply, S_PartyInviteReply.Parser);
             RegisterHandler((ushort)PacketID.PKT_S_BroadcastPartyUpdate, ServerPacketHandler.HANDLE_S_BroadcastPartyUpdate, S_BroadcastPartyUpdate.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyCreateReply, ServerPacketHandler.HANDLE_S_PartyCreateReply, S_PartyCreateReply.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyJoinReply, ServerPacketHandler.HANDLE_S_PartyJoinReply, S_PartyJoinReply.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyJoinNotify, ServerPacketHandler.HANDLE_S_PartyJoinNotify, S_PartyJoinNotify.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyList, ServerPacketHandler.HANDLE_S_PartyList, S_PartyList.Parser);
+            RegisterHandler((ushort)PacketID.PKT_S_PartyJoinRequestList, ServerPacketHandler.HANDLE_S_PartyJoinRequestList, S_PartyJoinRequestList.Parser);
             
                   
         }


### PR DESCRIPTION
초대 기반 파티 시스템과 공개 파티 시스템을 완전히 구현하고, 리스트 기반 가입 요청 관리 기능을 추가했습니다.

## 주요 기능

### 1. 초대 기반 파티 시스템 (Protocol 50-55)
- 파티 초대 및 수락/거절
- 파티 탈퇴 (리더 탈퇴 시 파티 해산)
- 파티원 강퇴 (리더 권한)
- 실시간 파티 상태 브로드캐스트

### 2. 공개 파티 시스템 (Protocol 56-65)
- 파티명 지정 공개 파티 생성
- 전체 파티 목록 조회
- 파티 가입 요청 및 리더 알림
- **리스트 기반 가입 요청 관리** (FIFO → PlayerId 선택 방식)
  - 리더가 대기 요청 목록 조회
  - 특정 요청자 선택하여 수락/거절

### 3. 채팅 시스템
- 룸별 채팅 (현재 룸의 플레이어들에게만)
- 전체 채팅 (모든 룸의 플레이어들에게)
- 배치 전송으로 네트워크 최적화

### 4. 문서화
- 34개 패킷 문서 작성 (Doc/Packet/)
- 파티 시스템 PRD 문서 (Doc/PRD/party_system.md)
- 실제 구현 코드 분석 기반

## 기술적 특징

- **멀티스레드 안전**: PartyManager READ_LOCK/WRITE_LOCK 동기화
- **JobQueue 패턴**: Room의 JobQueue를 통한 안전한 파티 작업 처리
- **자동 브로드캐스트**: 파티 상태 변경 시 전체 파티원 동기화
- **중복 요청 방지**: AddJoinRequest에서 중복 체크
- **경험치 분배**: 파티 사냥 시 처치자 110%, 나머지 파티원 각 10%

## 테스트

DummyClient 테스트 인터페이스 완전 구현:
- 파티 생성/초대/수락/거절/탈퇴/강퇴
- 공개 파티 목록 조회 및 가입 요청
- 가입 요청 리스트 조회 및 선택적 수락/거절
- 룸별/전체 채팅